### PR TITLE
Feature: Store TX' subject internally

### DIFF
--- a/src/routes/safe/store/actions/fetchTransactions.js
+++ b/src/routes/safe/store/actions/fetchTransactions.js
@@ -6,6 +6,7 @@ import { makeOwner } from '~/routes/safe/store/model/owner'
 import { makeTransaction, type Transaction, type TransactionProps } from '~/routes/safe/store/model/transaction'
 import { load, TX_KEY } from '~/utils/localStorage'
 import { type Confirmation, type ConfirmationProps, makeConfirmation } from '~/routes/safe/store/model/confirmation'
+import { loadSafeSubjects } from '~/utils/localStorage/transactions'
 import addTransactions from './addTransactions'
 
 export const loadSafeTransactions = () => {
@@ -14,10 +15,13 @@ export const loadSafeTransactions = () => {
   return Map().withMutations((map: Map<string, List<Confirmation>>) =>
     Object.keys(safes).map((safe: string) => {
       const safeTxs = safes[safe]
+      const safeSubjects = loadSafeSubjects(safe)
       const safeTxsRecord = safeTxs.map((tx: TransactionProps) => {
         const { confirmations } = tx
+        const name = safeSubjects.get(String(tx.nonce)) || 'Unknown'
         const txRecord = makeTransaction({
           ...tx,
+          name,
           confirmations: List(confirmations.map((conf: ConfirmationProps) =>
             makeConfirmation({ ...conf, owner: makeOwner(conf.owner) }))),
         })

--- a/src/test/safe.service.transactions.test.js
+++ b/src/test/safe.service.transactions.test.js
@@ -29,7 +29,7 @@ describe('Transactions Suite', () => {
     if (!secondOwner) { throw new Error() }
   })
 
-  it('adds first confirmation to stored safe', async () => {
+  it('adds first transaction to stored safe', async () => {
     // GIVEN
     const txName = 'Buy butteries for project'
     const nonce: number = 10
@@ -49,7 +49,7 @@ describe('Transactions Suite', () => {
     testTransactionFrom(safeTransactions, 0, txName, nonce, value, 2, destination, EMPTY_DATA, 'foo', 'confirmationHash', owners.get(0), owners.get(1))
   })
 
-  it('adds second confirmation to stored safe with one confirmation', async () => {
+  it('adds second transaction to stored safe with one transaction', async () => {
     // GIVEN
     const firstTxName = 'Buy butteries for project'
     const firstNonce: number = Date.now()
@@ -77,7 +77,7 @@ describe('Transactions Suite', () => {
     testTransactionFrom(safeTxs, 1, secondTxName, secondNonce, value, 2, destination, EMPTY_DATA, 'foo', 'confirmationHash', owners.get(0), owners.get(1))
   })
 
-  it('adds second confirmation to stored safe having two safes with one confirmation each', async () => {
+  it('adds second transaction to stored safe having two safes with one transaction each', async () => {
     const txName = 'Buy batteris for Alplha project'
     const nonce = 10
     const safeAddress = safe.address
@@ -113,7 +113,7 @@ describe('Transactions Suite', () => {
     const txConfirmations: List<Confirmation> = buildConfirmationsFrom(owners, creator, 'secondConfirmationHash')
     storeTransaction(
       txFirstName, txFirstNonce, destination, value, creator,
-      txConfirmations, '', safe.get('address'), safe.get('threshold'), EMPTY_DATA,
+      txConfirmations, '', safeAddress, safe.get('threshold'), EMPTY_DATA,
     )
 
     transactions = loadSafeTransactions()

--- a/src/utils/localStorage/transactions.js
+++ b/src/utils/localStorage/transactions.js
@@ -6,14 +6,21 @@ const getSubjectKeyFrom = (safeAddress: string) => `TXS-SUBJECTS-${safeAddress}`
 
 export const storeSubject = (safeAddress: string, nonce: number, subject: string) => {
   const key = getSubjectKeyFrom(safeAddress)
-  const subjects = load(key) || Map()
+  const subjects = Map(load(key)) || Map()
 
   try {
-    const updatedSubjects = subjects.setIn([safeAddress, String(nonce)], subject)
+    const updatedSubjects = subjects.set(nonce, subject)
     const serializedState = JSON.stringify(updatedSubjects)
     localStorage.setItem(key, serializedState)
   } catch (err) {
     // eslint-disable-next-line
     console.log('Error storing transaction subject in localstorage')
   }
+}
+
+export const loadSafeSubjects = (safeAddress: string): Map<string, string> => {
+  const key = getSubjectKeyFrom(safeAddress)
+  const data: any = load(key)
+
+  return data ? Map(data) : Map()
 }

--- a/src/utils/localStorage/transactions.js
+++ b/src/utils/localStorage/transactions.js
@@ -1,0 +1,19 @@
+// @flow
+import { Map } from 'immutable'
+import { load } from '~/utils/localStorage'
+
+const getSubjectKeyFrom = (safeAddress: string) => `TXS-SUBJECTS-${safeAddress}`
+
+export const storeSubject = (safeAddress: string, nonce: number, subject: string) => {
+  const key = getSubjectKeyFrom(safeAddress)
+  const subjects = load(key) || Map()
+
+  try {
+    const updatedSubjects = subjects.setIn([safeAddress, String(nonce)], subject)
+    const serializedState = JSON.stringify(updatedSubjects)
+    localStorage.setItem(key, serializedState)
+  } catch (err) {
+    // eslint-disable-next-line
+    console.log('Error storing transaction subject in localstorage')
+  }
+}

--- a/src/wallets/createTransactions.js
+++ b/src/wallets/createTransactions.js
@@ -59,7 +59,7 @@ export const storeTransaction = (
   // store subject in local storage (for testing it the actual name should be '')
 
   const transaction: Transaction = makeTransaction({
-    name, nonce, value, confirmations, destination, threshold: safeThreshold, tx, data,
+    name: '', nonce, value, confirmations, destination, threshold: safeThreshold, tx, data,
   })
 
   const safeTransactions = load(TX_KEY) || {}

--- a/src/wallets/createTransactions.js
+++ b/src/wallets/createTransactions.js
@@ -9,6 +9,7 @@ import { getWeb3 } from '~/wallets/getWeb3'
 import { type Safe } from '~/routes/safe/store/model/safe'
 import { sameAddress } from '~/wallets/ethAddresses'
 import { checkReceiptStatus, calculateGasOf, calculateGasPrice, EMPTY_DATA } from '~/wallets/ethTransactions'
+import { storeSubject } from '~/utils/localStorage/transactions'
 
 export const TX_NAME_PARAM = 'txName'
 export const TX_DESTINATION_PARAM = 'txDestination'
@@ -53,6 +54,9 @@ export const storeTransaction = (
   if (notMinedWhenOneOwnerSafe) {
     throw new Error('The tx should be mined before storing it in safes with one owner')
   }
+  // fetch actual transactions from endpoint and check nonce is higher than the last one
+  // send tx to service
+  // store subject in local storage (for testing it the actual name should be '')
 
   const transaction: Transaction = makeTransaction({
     name, nonce, value, confirmations, destination, threshold: safeThreshold, tx, data,
@@ -66,8 +70,9 @@ export const storeTransaction = (
     throw new Error(`Transaction with same nonce: ${nonce} already created for safe: ${safeAddress}`)
   }
 
-  safeTransactions[safeAddress] = txsRecord.push(transaction)
+  storeSubject(safeAddress, nonce, name)
 
+  safeTransactions[safeAddress] = txsRecord.push(transaction)
   localStorage.setItem(TX_KEY, JSON.stringify(safeTransactions))
 }
 


### PR DESCRIPTION
**Description**
This PR is the first step in the feature of integrating the TX History Service, it stores in the browser's localStorage the tx subject and when the app fetched transactions and build the app's redux store, it uses the stored subjects.

**Note for developers**
In this PR you won't notice any change this is just internal modifications, you can just create a couple of transactions and check if the subject is shown correctly.