### PR TITLE
Bugfixes: Load Safe, Firefox input labels

### DIFF
--- a/src/components/Stepper/OpenPaper/index.jsx
+++ b/src/components/Stepper/OpenPaper/index.jsx
@@ -41,7 +41,7 @@ const OpenPaper = ({
       <Block style={containerStyle} className={`${classes.container} ${padding ? classes.padding : ''}`}>
         {children}
       </Block>
-      { controls }
+      {controls}
     </Paper>
   )
 }

--- a/src/routes/load/components/DetailsForm/index.jsx
+++ b/src/routes/load/components/DetailsForm/index.jsx
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import contract from 'truffle-contract'
 import { withStyles } from '@material-ui/core/styles'
 import Field from '~/components/forms/Field'
 import {
@@ -63,7 +62,13 @@ export const safeFieldsValidation = async (values: Object) => {
 
   // check mastercopy
   const proxyAddressFromStorage = await web3.eth.getStorageAt(safeAddress, 0)
-  const checksummedProxyAddress = web3.utils.toChecksumAddress(proxyAddressFromStorage)
+  // https://www.reddit.com/r/ethereum/comments/6l3da1/how_long_are_ethereum_addresses/
+  // ganache returns plain address
+  // rinkeby returns 0x0000000000000+{40 address charachers}
+  // address comes last so we just get last 40 charachers (1byte = 2hex chars)
+  const checksummedProxyAddress = web3.utils.toChecksumAddress(
+    `0x${proxyAddressFromStorage.substr(proxyAddressFromStorage.length - 40)}`,
+  )
   const safeMaster = await getSafeMasterContract()
   const masterCopy = safeMaster.address
 

--- a/src/theme/mui.js
+++ b/src/theme/mui.js
@@ -116,6 +116,7 @@ export default createMuiTheme({
         order: 0,
         marginTop: '0px',
         backgroundColor: '#EAE9EF',
+        zIndex: 1, // for firefox
       },
     },
     MuiInput: {


### PR DESCRIPTION
- Get a substring of last 40 characters when getting proxy from storage (comment in the code explains it better)
- Add zIndex to MuiHelperText aka input label in our case fix it not showing in firefox
- Small prettier change