### PR TITLE
BUG: Ether balance is not updated automatically

### DIFF
--- a/src/routes/safe/container/actions.js
+++ b/src/routes/safe/container/actions.js
@@ -1,6 +1,7 @@
 // @flow
 import fetchSafe from '~/routes/safe/store/actions/fetchSafe'
 import fetchTokenBalances from '~/routes/safe/store/actions/fetchTokenBalances'
+import fetchEtherBalance from '~/routes/safe/store/actions/fetchEtherBalance'
 import createTransaction from '~/routes/safe/store/actions/createTransaction'
 import processTransaction from '~/routes/safe/store/actions/processTransaction'
 import fetchTransactions from '~/routes/safe/store/actions/fetchTransactions'
@@ -15,6 +16,7 @@ export type Actions = {
   updateSafe: typeof updateSafe,
   fetchTokens: typeof fetchTokens,
   processTransaction: typeof processTransaction,
+  fetchEtherBalance: typeof fetchEtherBalance,
 }
 
 export default {
@@ -25,4 +27,5 @@ export default {
   fetchTokens,
   fetchTransactions,
   updateSafe,
+  fetchEtherBalance,
 }

--- a/src/routes/safe/container/index.jsx
+++ b/src/routes/safe/container/index.jsx
@@ -23,6 +23,7 @@ class SafeView extends React.Component<Props> {
 
     fetchSafe(safeUrl)
     fetchTokenBalances(safeUrl, activeTokens)
+
     // fetch tokens there to get symbols for tokens in TXs list
     fetchTokens()
 
@@ -46,10 +47,11 @@ class SafeView extends React.Component<Props> {
 
   checkForUpdates() {
     const {
-      safeUrl, activeTokens, fetchTokenBalances,
+      safeUrl, activeTokens, fetchTokenBalances, fetchEtherBalance,
     } = this.props
 
     fetchTokenBalances(safeUrl, activeTokens)
+    fetchEtherBalance(safeUrl)
   }
 
   render() {

--- a/src/routes/safe/store/actions/fetchEtherBalance.js
+++ b/src/routes/safe/store/actions/fetchEtherBalance.js
@@ -11,7 +11,7 @@ const fetchEtherBalance = (safeAddress: string) => async (dispatch: ReduxDispatc
     dispatch(updateSafe({ address: safeAddress, ethBalance }))
   } catch (err) {
     // eslint-disable-next-line
-    console.error('Error while loading active tokens from storage:', err)
+    console.error('Error when fetching Ether balance:', err)
   }
 }
 

--- a/src/routes/safe/store/actions/fetchEtherBalance.js
+++ b/src/routes/safe/store/actions/fetchEtherBalance.js
@@ -1,0 +1,18 @@
+// @flow
+import type { Dispatch as ReduxDispatch } from 'redux'
+import { type GlobalState } from '~/store/index'
+import updateSafe from '~/routes/safe/store/actions/updateSafe'
+import { getBalanceInEtherOf } from '~/logic/wallets/getWeb3'
+
+const fetchEtherBalance = (safeAddress: string) => async (dispatch: ReduxDispatch<GlobalState>) => {
+  try {
+    const ethBalance = await getBalanceInEtherOf(safeAddress)
+
+    dispatch(updateSafe({ address: safeAddress, ethBalance }))
+  } catch (err) {
+    // eslint-disable-next-line
+    console.error('Error while loading active tokens from storage:', err)
+  }
+}
+
+export default fetchEtherBalance

--- a/src/routes/safe/store/actions/fetchTokenBalances.js
+++ b/src/routes/safe/store/actions/fetchTokenBalances.js
@@ -45,7 +45,7 @@ const fetchTokenBalances = (safeAddress: string, tokens: List<Token>) => async (
     dispatch(updateSafe({ address: safeAddress, balances: List(withBalances) }))
   } catch (err) {
     // eslint-disable-next-line
-    console.error('Error while loading active tokens from storage:', err)
+    console.error('Error when fetching token balances:', err)
   }
 }
 


### PR DESCRIPTION
This PR:
- Create an action `fetchEtherBalance` and add it to `checkForUpdates` in Safe Page Container. Previously we fetched ether balance in fetchSafe action, but then we stopped using it inside an interval because it can mess up owners/threshold updates