### PR TITLE
Test: Active tokens saved to localstorage

### DIFF
--- a/src/logic/tokens/utils/tokensStorage.js
+++ b/src/logic/tokens/utils/tokensStorage.js
@@ -31,17 +31,6 @@ export const getCustomTokens = async (): Promise<List<TokenProps>> => {
   return data ? List(data) : List()
 }
 
-export const setToken = async (safeAddress: string, token: Token) => {
-  const data: List<TokenProps> = await getCustomTokens()
-
-  try {
-    await saveToStorage(CUSTOM_TOKENS_KEY, data.push(token))
-  } catch (err) {
-    // eslint-disable-next-line
-    console.log('Error adding token in localstorage')
-  }
-}
-
 export const removeTokenFromStorage = async (safeAddress: string, token: Token) => {
   const data: List<TokenProps> = await getCustomTokens()
 

--- a/src/test/tokens.dom.enabling.test.js
+++ b/src/test/tokens.dom.enabling.test.js
@@ -11,6 +11,7 @@ import { clickOnManageTokens, toggleToken, closeManageTokensModal } from './util
 import { BALANCE_ROW_TEST_ID } from '~/routes/safe/components/Balances'
 import { makeToken } from '~/logic/tokens/store/model/token'
 import '@testing-library/jest-dom/extend-expect'
+import { getActiveTokens } from '~/logic/tokens/utils/tokensStorage'
 
 describe('DOM > Feature > Enable and disable default tokens', () => {
   let web3
@@ -43,7 +44,7 @@ describe('DOM > Feature > Enable and disable default tokens', () => {
     ])
   })
 
-  it('allows to enable and disable tokens', async () => {
+  it('allows to enable and disable tokens, stores active ones in the local storage', async () => {
     // GIVEN
     const store = aNewStore()
     const safeAddress = await aMinedSafe(store)
@@ -79,5 +80,7 @@ describe('DOM > Feature > Enable and disable default tokens', () => {
     balanceRows = TokensDom.getAllByTestId(BALANCE_ROW_TEST_ID)
     expect(balanceRows.length).toBe(1)
     expect(balanceRows[0]).toHaveTextContent('ETH')
+
+    expect()
   })
 })

--- a/src/test/tokens.dom.enabling.test.js
+++ b/src/test/tokens.dom.enabling.test.js
@@ -70,6 +70,13 @@ describe('DOM > Feature > Enable and disable default tokens', () => {
     expect(balanceRows[1]).toHaveTextContent('FTE')
     expect(balanceRows[2]).toHaveTextContent('STE')
 
+    await sleep(1000)
+
+    const tokensFromStorage = await getActiveTokens()
+
+    expect(Object.keys(tokensFromStorage)).toContain(firstErc20Token.address)
+    expect(Object.keys(tokensFromStorage)).toContain(secondErc20Token.address)
+
     // disable tokens
     clickOnManageTokens(TokensDom)
     toggleToken(TokensDom, 'FTE')
@@ -80,7 +87,5 @@ describe('DOM > Feature > Enable and disable default tokens', () => {
     balanceRows = TokensDom.getAllByTestId(BALANCE_ROW_TEST_ID)
     expect(balanceRows.length).toBe(1)
     expect(balanceRows[0]).toHaveTextContent('ETH')
-
-    expect()
   })
 })


### PR DESCRIPTION
Add test for a bug we recently experienced (Active tokens were not saved to local storage). Also remove unused storage helper function