### PR TITLE
BUG: Hotfix #218 Non-18 decimals tokens transfer

### DIFF
--- a/contracts/DevDependencies.sol
+++ b/contracts/DevDependencies.sol
@@ -2,5 +2,6 @@ pragma solidity ^0.5.2;
 
 import "../src/test/contracts/TokenOMG.sol";
 import "../src/test/contracts/TokenRDN.sol";
+import "../src/test/contracts/Token6Decimals.sol";
 
 contract DevDependenciesGetter {}

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewTx/index.jsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewTx/index.jsx
@@ -18,7 +18,7 @@ import { copyToClipboard } from '~/utils/clipboard'
 import Hairline from '~/components/layout/Hairline'
 import SafeInfo from '~/routes/safe/components/Balances/SendModal/SafeInfo'
 import { setImageToPlaceholder } from '~/routes/safe/components/Balances/utils'
-import { getStandardTokenContract } from '~/logic/tokens/store/actions/fetchTokens'
+import { getStandardTokenContract, getHumanFriendlyToken } from '~/logic/tokens/store/actions/fetchTokens'
 import { EMPTY_DATA } from '~/logic/wallets/ethTransactions'
 import { getWeb3 } from '~/logic/wallets/getWeb3'
 import { TX_NOTIFICATION_TYPES } from '~/logic/safe/transactions'
@@ -68,9 +68,11 @@ const ReviewTx = ({
 
     if (!isSendingETH) {
       const StandardToken = await getStandardTokenContract()
+      const HumanFriendlyToken = await getHumanFriendlyToken()
       const tokenInstance = await StandardToken.at(tx.token.address)
-      const decimals = await tokenInstance.decimals()
-      txAmount = new BigNumber(tx.amount).div(10 ** decimals).toString()
+      const hfTokenInstance = await HumanFriendlyToken.at(tx.token.address)
+      const decimals = await hfTokenInstance.decimals()
+      txAmount = new BigNumber(tx.amount).times(10 ** decimals.toNumber()).toString()
 
       txData = tokenInstance.contract.methods.transfer(tx.recipientAddress, txAmount).encodeABI()
       // txAmount should be 0 if we send tokens

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewTx/index.jsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewTx/index.jsx
@@ -18,7 +18,7 @@ import { copyToClipboard } from '~/utils/clipboard'
 import Hairline from '~/components/layout/Hairline'
 import SafeInfo from '~/routes/safe/components/Balances/SendModal/SafeInfo'
 import { setImageToPlaceholder } from '~/routes/safe/components/Balances/utils'
-import { getStandardTokenContract, getHumanFriendlyToken } from '~/logic/tokens/store/actions/fetchTokens'
+import { getHumanFriendlyToken } from '~/logic/tokens/store/actions/fetchTokens'
 import { EMPTY_DATA } from '~/logic/wallets/ethTransactions'
 import { getWeb3 } from '~/logic/wallets/getWeb3'
 import { TX_NOTIFICATION_TYPES } from '~/logic/safe/transactions'
@@ -67,11 +67,9 @@ const ReviewTx = ({
     let txAmount = web3.utils.toWei(tx.amount, 'ether')
 
     if (!isSendingETH) {
-      const StandardToken = await getStandardTokenContract()
       const HumanFriendlyToken = await getHumanFriendlyToken()
-      const tokenInstance = await StandardToken.at(tx.token.address)
-      const hfTokenInstance = await HumanFriendlyToken.at(tx.token.address)
-      const decimals = await hfTokenInstance.decimals()
+      const tokenInstance = await HumanFriendlyToken.at(tx.token.address)
+      const decimals = await tokenInstance.decimals()
       txAmount = new BigNumber(tx.amount).times(10 ** decimals.toNumber()).toString()
 
       txData = tokenInstance.contract.methods.transfer(tx.recipientAddress, txAmount).encodeABI()

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewTx/index.jsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewTx/index.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import { BigNumber } from 'bignumber.js'
 import OpenInNew from '@material-ui/icons/OpenInNew'
 import { withStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
@@ -68,6 +69,8 @@ const ReviewTx = ({
     if (!isSendingETH) {
       const StandardToken = await getStandardTokenContract()
       const tokenInstance = await StandardToken.at(tx.token.address)
+      const decimals = await tokenInstance.decimals()
+      txAmount = new BigNumber(tx.amount).div(10 ** decimals).toString()
 
       txData = tokenInstance.contract.methods.transfer(tx.recipientAddress, txAmount).encodeABI()
       // txAmount should be 0 if we send tokens

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
@@ -46,7 +46,7 @@ type CustomDescProps = {
   value: string,
   recipient: string,
   data: String,
-  classes: Obeject,
+  classes: Object,
 }
 
 const TransferDescription = ({ value = '', symbol, recipient }: TransferDescProps) => (

--- a/src/test/contracts/Token6Decimals.sol
+++ b/src/test/contracts/Token6Decimals.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.2;
+
+import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
+
+contract Token6Decimals is GnosisStandardToken {
+  string public constant symbol = "6DEC";
+  string public constant name = "6 Decimals";
+  uint8 public constant decimals = 6;
+
+  constructor(
+    uint amount
+  )
+    public 
+  {
+    balances[msg.sender] = amount;
+  }
+}

--- a/src/test/utils/tokenMovements.js
+++ b/src/test/utils/tokenMovements.js
@@ -5,6 +5,7 @@ import { ensureOnce } from '~/utils/singleton'
 import { toNative } from '~/logic/wallets/tokens'
 import TokenOMG from '../../../build/contracts/TokenOMG'
 import TokenRDN from '../../../build/contracts/TokenRDN'
+import Token6Decimals from '../../../build/contracts/Token6Decimals.json'
 
 export const sendEtherTo = async (address: string, eth: string, fromAccountIndex: number = 0) => {
   const web3 = getWeb3()
@@ -41,8 +42,20 @@ const createTokenRDNContract = async (web3: any, creator: string) => {
   return token.new(amount, { from: creator })
 }
 
+const create6DecimalsTokenContract = async (web3: any, creator: string) => {
+  const token = contract(Token6Decimals)
+  const { toBN } = web3.utils
+  const amount = toBN(50000)
+    .mul(toBN(10).pow(toBN(6)))
+    .toString()
+  token.setProvider(web3.currentProvider)
+
+  return token.new(amount, { from: creator })
+}
+
 export const getFirstTokenContract = ensureOnce(createTokenOMGContract)
 export const getSecondTokenContract = ensureOnce(createTokenRDNContract)
+export const get6DecimalsTokenContract = ensureOnce(create6DecimalsTokenContract)
 
 export const sendTokenTo = async (safe: string, value: string, tokenContract?: any) => {
   const web3 = getWeb3()

--- a/src/test/utils/transactions/moveFunds.helper.js
+++ b/src/test/utils/transactions/moveFunds.helper.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import { fireEvent, waitForElement } from '@testing-library/react'
+import { fireEvent, waitForElement, act } from '@testing-library/react'
 import { sleep } from '~/utils/timer'
 
 export const fillAndSubmitSendFundsForm = async (
@@ -9,8 +9,9 @@ export const fillAndSubmitSendFundsForm = async (
   value: string,
   recipient: string,
 ) => {
-  // load add multisig form component
-  fireEvent.click(sendButton)
+  await act(async () => {
+    fireEvent.click(sendButton)
+  })
   // give time to re-render it
   await sleep(400)
 
@@ -18,13 +19,16 @@ export const fillAndSubmitSendFundsForm = async (
   const recipientInput = SafeDom.getByPlaceholderText('Recipient*')
   const amountInput = SafeDom.getByPlaceholderText('Amount*')
   const reviewBtn = SafeDom.getByTestId('review-tx-btn')
-  fireEvent.change(recipientInput, { target: { value: recipient } })
-  fireEvent.change(amountInput, { target: { value } })
-  await sleep(200)
-  fireEvent.click(reviewBtn)
+  await act(async () => {
+    fireEvent.change(recipientInput, { target: { value: recipient } })
+    fireEvent.change(amountInput, { target: { value } })
+    fireEvent.click(reviewBtn)
+  })
 
   // Submit the tx (Review Tx screen)
   const submitBtn = await waitForElement(() => SafeDom.getByTestId('submit-tx-btn'))
-  fireEvent.click(submitBtn)
+  await act(async () => {
+    fireEvent.click(submitBtn)
+  })
   await sleep(1000)
 }


### PR DESCRIPTION
- Hotfix #218 
- Add a test case for sending token with non-18 decimals (6)

Testing:
- Get USDC coin (6 decimals) from compound: https://app.compound.finance/asset/cUSDC
- Send it to the safe and then send it back