### PR TITLE
Hotfix: Use alternative abi for getting symbol for DAI token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build_storybook/
 .DS_Store
 build/
 yarn-error.log
+.env.*

--- a/src/logic/tokens/utils/alternativeAbi.js
+++ b/src/logic/tokens/utils/alternativeAbi.js
@@ -1,0 +1,47 @@
+// @flow
+// https://github.com/ethers-io/ethers.js/issues/527
+
+export const ALTERNATIVE_TOKEN_ABI = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+]

--- a/src/routes/safe/components/Transactions/TxsTable/columns.js
+++ b/src/routes/safe/components/Transactions/TxsTable/columns.js
@@ -1,5 +1,6 @@
 // @flow
 import { format, getTime, parseISO } from 'date-fns'
+import { BigNumber } from 'bignumber.js'
 import { List } from 'immutable'
 import { type Transaction } from '~/routes/safe/store/models/transaction'
 import { type SortRow, buildOrderFieldFrom } from '~/components/Table/sorting'
@@ -32,7 +33,8 @@ export const getTxAmount = (tx: Transaction) => {
   let txAmount = 'n/a'
 
   if (tx.isTokenTransfer && tx.decodedParams) {
-    txAmount = `${fromWei(toBN(tx.decodedParams.value), 'ether')} ${tx.symbol}`
+    const tokenDecimals = tx.decimals.toNumber ? tx.decimals.toNumber() : tx.decimals
+    txAmount = `${new BigNumber(tx.decodedParams.value).div(10 ** tokenDecimals).toString()} ${tx.symbol}`
   } else if (Number(tx.value) > 0) {
     txAmount = `${fromWei(toBN(tx.value), 'ether')} ${tx.symbol}`
   }


### PR DESCRIPTION
- Use alternative abi for getting symbol for DAI token
- Also fix token transfer tx showing as custom transactions

https://github.com/ethers-io/ethers.js/issues/527
https://ethereum.stackexchange.com/questions/53038/contract-returns-a-hex-value-when-a-string-is-expected

This is https://github.com/gnosis/safe-react/pull/230 but without send funds improvements