### PR TITLE
Bug #234: Click to copy buttons are not shown in safari

### DIFF
--- a/src/components/CopyBtn/index.jsx
+++ b/src/components/CopyBtn/index.jsx
@@ -31,10 +31,6 @@ type CopyBtnProps = {
 }
 
 const CopyBtn = ({ content, increaseZindex = false }: CopyBtnProps) => {
-  if (!navigator.clipboard) {
-    return null
-  }
-
   const [clicked, setClicked] = useState<boolean>(false)
   const classes = useStyles()
   const customClasses = increaseZindex ? { popper: classes.inreasedPopperZindex } : {}

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,13 +1,17 @@
 // @flow
 
-export const copyToClipboard = (text: string) => {
-  if (!navigator.clipboard) {
-    return
-  }
+export const copyToClipboard = (text: string): void => {
+  const range = document.createRange()
+  range.selectNodeContents(document.body)
+  document.getSelection().addRange(range)
 
-  try {
-    navigator.clipboard.writeText(text)
-  } catch (err) {
-    console.error(err.message)
+  function listener(e: ClipboardEvent) {
+    e.clipboardData.setData('text/plain', text)
+    e.preventDefault()
   }
+  document.addEventListener('copy', listener)
+  document.execCommand('copy')
+  document.removeEventListener('copy', listener)
+
+  document.getSelection().removeAllRanges()
 }


### PR DESCRIPTION
This PR:
- Fixes #234 

So previously I added a check (just in case) to hide copy button if the `navigator.clipboard` was undefined. Turned out to be worth it 😄. Found the polyfill and replaced `copyToClipboard` function with it: https://gist.github.com/lgarron/d1dee380f4ed9d825ca7