### PR TITLE
exclude unneeded stuff from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,38 +20,14 @@ matrix:
   - env:
     - REACT_APP_NETWORK='rinkeby'
 before_install:
-  # Install custom docker-compose version
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -Ls https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-  # Shut down postgres because it blocks our db container's port map to :5432
-  # it comes enabled by default in docker-compose
-  - sudo service postgresql stop
-  # Wait for it to stop
-  - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
   # Needed to deploy pull request and releases
   - sudo apt-get -y install python-pip python-dev
   - pip install awscli --upgrade --user
   # Install truffle
   - yarn global add truffle
-before_script:
-  # Used in the tests of the project
-  - export NODE_ENV=testing
-  - git clone https://github.com/gnosis/safe-transaction-history.git
-  - cd safe-transaction-history
-  - git checkout develop
-  - docker-compose build
-  - docker-compose up -d
-  # Give some time to docker to enable all services
-  - sleep 15
-  - cd ..
 script:
   - yarn build
 after_success:
-  - cd safe-transaction-history
-  - docker-compose stop
-  - cd ..
   - |
 
     if [ ${TRAVIS_BRANCH} = "master" ]; then
@@ -60,7 +36,6 @@ after_success:
       export NODE_ENV=development;
     fi
   - if [[ -n "$TRAVIS_TAG" ]]; then export REACT_APP_ENV='production'; fi
-  - yarn build-storybook
   - yarn build
   # Pull Request - Deploy it to a review environment
   # Travis doesn't do deploy step with pull requests builds

--- a/config/travis/deploy_pull_request.sh
+++ b/config/travis/deploy_pull_request.sh
@@ -13,25 +13,19 @@ function deploy_pull_request {
 
   # TRAVIS_PULL_REQUEST contains pull request number
   REVIEW_FEATURE_FOLDER="$REPO_NAME_ALPHANUMERIC/$PULL_REQUEST_NAME"
-  # Specific for this project only
-  REVIEW_FEATURE_STORYBOOK_FOLDER="${REPO_NAME_ALPHANUMERIC}storybook/$PULL_REQUEST_NAME"
 
   # Deploy safe-team project
   aws s3 sync build_webpack s3://${REVIEW_BUCKET_NAME}/${REVIEW_FEATURE_FOLDER} --delete
-  # Deploy safe-team storybook project
-  aws s3 sync build_storybook s3://${REVIEW_BUCKET_NAME}/${REVIEW_FEATURE_STORYBOOK_FOLDER} --delete
 }
 
 function publish_pull_request_urls_in_github {
   REVIEW_FEATURE_URL="https://$PULL_REQUEST_NAME--$REPO_NAME_ALPHANUMERIC.$REVIEW_ENVIRONMENT_DOMAIN"
-  # Specific for this project only
-  REVIEW_FEATURE_STORYBOOK_URL="https://$PULL_REQUEST_NAME--${REPO_NAME_ALPHANUMERIC}storybook.$REVIEW_ENVIRONMENT_DOMAIN"
 
   # Using the Issues api instead of the PR api
   # Done so because every PR is an issue, and the issues api allows to post general comments,
   # while the PR api requires that comments are made to specific files and specific commits
   GITHUB_PR_COMMENTS=https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments
-  curl -H "Authorization: token ${GITHUB_API_TOKEN}" --request POST ${GITHUB_PR_COMMENTS} --data '{"body":"Travis automatic deployment:\r\n '${REVIEW_FEATURE_URL}' \r\n \r\n Storybook book automatic deployment: \r\n '${REVIEW_FEATURE_STORYBOOK_URL}'"}'
+  curl -H "Authorization: token ${GITHUB_API_TOKEN}" --request POST ${GITHUB_PR_COMMENTS} --data '{"body":"Travis automatic deployment:\r\n '${REVIEW_FEATURE_URL}' \r\n"}'
 }
 
 # Only:


### PR DESCRIPTION
This PR:
- Exclude building docker image of transaction-history-service, building and deploying storybook because we don't use it anymore to save some time on deployment