### PR TITLE
Bug 280: Missing whitespaces in load safe flow

### DIFF
--- a/src/routes/load/components/DetailsForm/index.jsx
+++ b/src/routes/load/components/DetailsForm/index.jsx
@@ -127,13 +127,13 @@ const Details = ({ classes, errors, form }: Props) => (
     <Block margin="sm">
       <Paragraph noMargin size="md" color="primary" className={classes.links}>
         By continuing you consent with the
-
+        {' '}
         <a rel="noopener noreferrer" href="https://safe.gnosis.io/terms" target="_blank">
           terms of use
         </a>
-
+        {' '}
         and
-
+        {' '}
         <a rel="noopener noreferrer" href="https://safe.gnosis.io/privacy" target="_blank">
           privacy policy
         </a>


### PR DESCRIPTION
This PR:
- Adds missing whitespaces in load safe flow