### PR TITLE
Bug 188: Long owner names cause UI glitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "qrcode.react": "1.0.0",
     "react": "16.12.0",
     "react-dom": "16.12.0",
-    "react-final-form": "6.3.2",
+    "react-final-form": "6.3.3",
     "react-final-form-listeners": "^1.0.2",
     "react-hot-loader": "4.12.18",
     "react-qr-reader": "^2.2.1",

--- a/src/components/Table/TableHead.jsx
+++ b/src/components/Table/TableHead.jsx
@@ -24,7 +24,7 @@ export const cellWidth = (width: number | typeof undefined) => {
   }
 
   return {
-    width: `${width}px`,
+    maxWidth: `${width}px`,
   }
 }
 

--- a/src/theme/mui.js
+++ b/src/theme/mui.js
@@ -285,6 +285,9 @@ export default createMuiTheme({
         fontWeight: 'normal',
         paddingTop: xs,
         paddingBottom: xs,
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
       },
     },
     MuiBackdrop: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14901,10 +14901,10 @@ react-final-form-listeners@^1.0.2:
   dependencies:
     "@babel/runtime" "^7.1.5"
 
-react-final-form@6.3.2:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.3.2.tgz#2c331540c8f5cbf6fbe75ecd98849a03b34dba6e"
-  integrity sha512-3eXCd9ScouKbf7GJubhUP0s8+aYCsltjjWZtvOKV+E0AeRjXmzQZfUAsKM+395+v1dLIyenB3x22ZQms2tWFRQ==
+react-final-form@6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.3.3.tgz#8856a92278de2733f83e88c75d9ef347294a66a0"
+  integrity sha512-hFLwLpLasywky46SovNEGlym7+N+3RKge1/cg+/fVec/YY0l4g0ihgjRof6PbkiYe4qGjKbwbrvlgfZ9/Uf8vw==
   dependencies:
     "@babel/runtime" "^7.4.5"
     ts-essentials "^3.0.2"


### PR DESCRIPTION
This PR:
- Fixes #188 

I set max-width for the owner's name table cell to 150px, which works for all width above 1366 (inclusive). But unfortunately it resulted in 18 symbols, not 30 as expected in ticket description