### PR TITLE
Bug 196: Modals incorrectly displayed on smaller screen resolutions

### DIFF
--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -20,6 +20,7 @@ const styles = () => ({
     alignItems: 'center',
     justifyContent: 'center',
     display: 'flex',
+    overflowY: 'scroll',
   },
   paper: {
     position: 'absolute',


### PR DESCRIPTION
This PR:
- Fixes #196 by allowing user to scroll modal view if it overflows the viewport