### PR TITLE
Feature #258: Use medium font size for 'select an asset' label

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.jsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.jsx
@@ -44,7 +44,7 @@ const SelectedToken = ({ tokenAddress, tokens, classes }: SelectedTokenProps) =>
           />
         </>
       ) : (
-        <Paragraph color="disabled" size="lg" weight="light" style={{ opacity: 0.5 }}>
+        <Paragraph color="disabled" size="md" weight="light" style={{ opacity: 0.5 }}>
           Select an asset*
         </Paragraph>
       )}


### PR DESCRIPTION
This PR:
- Implements #258 