### PR TITLE
Feature #340: Threshold undefined

### DIFF
--- a/src/routes/safe/container/index.jsx
+++ b/src/routes/safe/container/index.jsx
@@ -37,10 +37,11 @@ class SafeView extends React.Component<Props, State> {
       fetchSafe, activeTokens, safeUrl, fetchTokenBalances, fetchTokens, fetchTransactions,
     } = this.props
 
-    fetchSafe(safeUrl)
+    fetchSafe(safeUrl).then(() => {
+      // The safe needs to be loaded before fetching the transactions
+      fetchTransactions(safeUrl)
+    })
     fetchTokenBalances(safeUrl, activeTokens)
-    fetchTransactions(safeUrl)
-
     // fetch tokens there to get symbols for tokens in TXs list
     fetchTokens()
 

--- a/src/routes/safe/container/selector.js
+++ b/src/routes/safe/container/selector.js
@@ -119,7 +119,7 @@ const extendedTransactionsSelector: Selector<GlobalState, RouterProps, List<Tran
     const extendedTransactions = transactions.map((tx: Transaction) => {
       let extendedTx = tx
 
-      // If transactions is not executed, but there's a transaction with the same nonce submitted later
+      // If transactions are not executed, but there's a transaction with the same nonce submitted later
       // it means that the transaction was cancelled (Replaced) and shouldn't get executed
       let replacementTransaction
       if (!tx.isExecuted) {


### PR DESCRIPTION
Closes #340 

- Description
- There was an race condition between `fetchSafe` and `fetchTransactions` in which the transactions tried to load before the safe and then the `undefined safe`  error came, I just make the `fetchTransactions` promise to wait until `fetchSafe` ends.