### PR TITLE
Bug #348: Safelist entries get removed

### DIFF
--- a/src/logic/tokens/store/actions/activateTokensByBalance.js
+++ b/src/logic/tokens/store/actions/activateTokensByBalance.js
@@ -25,17 +25,24 @@ const activateTokensByBalance = (safeAddress: string) => async (
     // balances: tokens' balance returned by the backend
     const { addresses, balances } = result.data.reduce((acc, { tokenAddress, balance }) => ({
       addresses: [...acc.addresses, tokenAddress],
-      balances: [...acc.balances, balance],
-    }), { addresses: [], balances: [] })
+      balances: [[tokenAddress, balance]],
+    }), {
+      addresses: [],
+      balances: [],
+    })
 
     // update balance list for the safe
-    dispatch(updateSafe({ address: safeAddress, balances: Set(balances) }))
+    dispatch(updateSafe({
+      address: safeAddress,
+      balances: Set(balances),
+    }))
 
     // active tokens by balance, excluding those already blacklisted and the `null` address
     const activeByBalance = addresses.filter((address) => address !== null && !blacklistedTokens.includes(address))
 
     // need to persist those already active tokens, despite its balances
-    const activeTokens = alreadyActiveTokens.toSet().union(activeByBalance)
+    const activeTokens = alreadyActiveTokens.toSet()
+      .union(activeByBalance)
 
     // update list of active tokens
     dispatch(updateActiveTokens(safeAddress, activeTokens))

--- a/src/utils/storage/index.js
+++ b/src/utils/storage/index.js
@@ -8,7 +8,7 @@ import { getNetwork } from '~/config'
 const stores = [IndexedDbStore, LocalStorageStore]
 export const storage = new ImmortalStorage(stores)
 
-const PREFIX = `v1_${getNetwork()}`
+const PREFIX = `v2_${getNetwork()}`
 
 export const loadFromStorage = async (key: string): Promise<*> => {
   try {


### PR DESCRIPTION
Closes #348 

# Description
- The tokenBalances list updated to localStorage by the function `activateTokensByBalance` where in wrong format [balance] instead of [tokenAddress, balance]. When the app loads the info from the localStorage, an exception was thrown trying to load the balances and the safe was just removed from the available lists.