### PR TITLE
Bug #352: Owner shown multiple times

### DIFF
--- a/src/routes/safe/store/actions/fetchSafe.js
+++ b/src/routes/safe/store/actions/fetchSafe.js
@@ -12,6 +12,7 @@ import { loadFromStorage } from '~/utils/storage'
 import removeSafeOwner from '~/routes/safe/store/actions/removeSafeOwner'
 import addSafeOwner from '~/routes/safe/store/actions/addSafeOwner'
 import updateSafeThreshold from '~/routes/safe/store/actions/updateSafeThreshold'
+import { sameAddress } from '~/logic/wallets/ethAddresses'
 
 const buildOwnersFrom = (
   safeOwners: string[],
@@ -62,18 +63,14 @@ export const checkAndUpdateSafe = (safeAddress: string) => async (dispatch: Redu
 
   // If the remote owners does not contain a local address, we remove that local owner
   localOwners.forEach((localAddress) => {
-    const remoteLowerCased = remoteOwners.map((owner) => owner.toLowerCase && owner.toLowerCase())
-
-    if (localAddress.toLowerCase && !remoteLowerCased.includes(localAddress.toLowerCase())) {
+    if (remoteOwners.findIndex((remoteAddress) => sameAddress(remoteAddress, localAddress)) !== -1) {
       dispatch(removeSafeOwner({ safeAddress, ownerAddress: localAddress }))
     }
   })
 
   // If the remote has an owner that we don't have locally, we add it
   remoteOwners.forEach((remoteAddress) => {
-    const localLowerCased = localOwners.map((owner) => owner.toLowerCase && owner.toLowerCase())
-
-    if (remoteAddress.toLowercase && !localLowerCased.includes(remoteAddress.toLowerCase())) {
+    if (localOwners.findIndex((localAddress) => sameAddress(remoteAddress, localAddress)) !== -1) {
       dispatch(addSafeOwner({ safeAddress, ownerAddress: remoteAddress, ownerName: 'UNKNOWN' }))
     }
   })

--- a/src/routes/safe/store/actions/fetchSafe.js
+++ b/src/routes/safe/store/actions/fetchSafe.js
@@ -59,16 +59,21 @@ export const checkAndUpdateSafe = (safeAddress: string) => async (dispatch: Redu
   localSafe.threshold = threshold.toNumber()
 
   dispatch(updateSafeThreshold({ safeAddress, threshold: threshold.toNumber() }))
+
   // If the remote owners does not contain a local address, we remove that local owner
   localOwners.forEach((localAddress) => {
-    if (!remoteOwners.includes(localAddress)) {
+    const remoteLowerCased = remoteOwners.map((owner) => owner.toLowerCase && owner.toLowerCase())
+
+    if (localAddress.toLowerCase && !remoteLowerCased.includes(localAddress.toLowerCase())) {
       dispatch(removeSafeOwner({ safeAddress, ownerAddress: localAddress }))
     }
   })
 
   // If the remote has an owner that we don't have locally, we add it
   remoteOwners.forEach((remoteAddress) => {
-    if (!localOwners.includes(remoteAddress)) {
+    const localLowerCased = localOwners.map((owner) => owner.toLowerCase && owner.toLowerCase())
+
+    if (remoteAddress.toLowercase && !localLowerCased.includes(remoteAddress.toLowerCase())) {
       dispatch(addSafeOwner({ safeAddress, ownerAddress: remoteAddress, ownerName: 'UNKNOWN' }))
     }
   })


### PR DESCRIPTION
This PR closes #352, by:

- ensuring we're not comparing checksummed vs lowercased addresses for the `owners` addresses

As stated in https://github.com/gnosis/safe-react/issues/351#issuecomment-566455101, it's related to #351 and the solution is similar.
