### PR TITLE
(Fix) Transaction List not loading and handle DCD token

### DIFF
--- a/src/routes/safe/store/actions/fetchTransactions.js
+++ b/src/routes/safe/store/actions/fetchTransactions.js
@@ -207,7 +207,7 @@ export const buildIncomingTransactionFrom = async (tx: IncomingTxServiceModel) =
   const fee = await web3.eth.getTransaction(tx.transactionHash)
     .then(({ gas, gasPrice }) => bn(gas).div(gasPrice).toFixed())
 
-  if (tx.tokenAddress && tx.tokenAddress !== '0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A') {
+  if (tx.tokenAddress) {
     try {
       const tokenContract = await getHumanFriendlyToken()
       const tokenInstance = await tokenContract.at(tx.tokenAddress)

--- a/src/routes/safe/store/actions/fetchTransactions.js
+++ b/src/routes/safe/store/actions/fetchTransactions.js
@@ -204,12 +204,10 @@ export const buildIncomingTransactionFrom = async (tx: IncomingTxServiceModel) =
   let symbol = 'ETH'
   let decimals = 18
 
-  const whenExecutionDate = web3.eth.getBlock(tx.blockNumber)
-    .then(({ timestamp }) => new Date(timestamp * 1000).toISOString())
-  const whenFee = web3.eth.getTransaction(tx.transactionHash).then((t) => bn(t.gas).div(t.gasPrice).toFixed())
-  const [executionDate, fee] = await Promise.all([whenExecutionDate, whenFee])
+  const fee = await web3.eth.getTransaction(tx.transactionHash)
+    .then(({ gas, gasPrice }) => bn(gas).div(gasPrice).toFixed())
 
-  if (tx.tokenAddress) {
+  if (tx.tokenAddress && tx.tokenAddress !== '0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A') {
     try {
       const tokenContract = await getHumanFriendlyToken()
       const tokenInstance = await tokenContract.at(tx.tokenAddress)
@@ -217,10 +215,20 @@ export const buildIncomingTransactionFrom = async (tx: IncomingTxServiceModel) =
       symbol = tokenSymbol
       decimals = tokenDecimals
     } catch (err) {
-      const { methods } = new web3.eth.Contract(ALTERNATIVE_TOKEN_ABI, tx.tokenAddress)
-      const [tokenSymbol, tokenDecimals] = await Promise.all([methods.symbol, methods.decimals].map((m) => m().call()))
-      symbol = web3.utils.toAscii(tokenSymbol)
-      decimals = tokenDecimals
+      try {
+        const { methods } = new web3.eth.Contract(ALTERNATIVE_TOKEN_ABI, tx.tokenAddress)
+        const [tokenSymbol, tokenDecimals] = await Promise.all([methods.symbol, methods.decimals].map((m) => m()
+          .call()))
+        symbol = web3.utils.hexToString(tokenSymbol)
+        decimals = tokenDecimals
+      } catch (e) {
+        // this is a particular treatment for the DCD token, as it seems to lack of symbol and decimal methods
+        if (tx.tokenAddress && tx.tokenAddress.toLowerCase() === '0xe0b7927c4af23765cb51314a0e0521a9645f0e2a') {
+          symbol = 'DCD'
+          decimals = 9
+        }
+        // if it's not DCD, then we fall to the default values
+      }
     }
   }
 
@@ -231,7 +239,6 @@ export const buildIncomingTransactionFrom = async (tx: IncomingTxServiceModel) =
     symbol,
     decimals,
     fee,
-    executionDate,
     executionTxHash: transactionHash,
     safeTxHash: transactionHash,
   })


### PR DESCRIPTION
Things that are done in this PR:
- treat DCD particularly and hardcode `symbol` and `decimal` values
- for those ALTERNATIVE_TOKEN_ABI contracts, we were converting the `symbol` to ASCII, and we had to convert from hex to string instead
- the `incoming-transactions` endpoint is returning the `executionDate`, so no request for that value to the blockchain is required