### PR TITLE
(feature)  Adding origin for Apps Transactions

### DIFF
--- a/src/logic/contracts/__mocks__/safeContracts.js
+++ b/src/logic/contracts/__mocks__/safeContracts.js
@@ -1,0 +1,2 @@
+// @flow
+export const getGnosisSafeInstanceAt = () => Promise.resolve({ nonce: () => Promise.resolve({ toString: () => '45' }) })

--- a/src/logic/contracts/__mocks__/safeContracts.js
+++ b/src/logic/contracts/__mocks__/safeContracts.js
@@ -1,2 +1,0 @@
-// @flow
-export const getGnosisSafeInstanceAt = () => Promise.resolve({ nonce: () => Promise.resolve({ toString: () => '45' }) })

--- a/src/logic/safe/transactions/send.js
+++ b/src/logic/safe/transactions/send.js
@@ -8,20 +8,33 @@ export const DELEGATE_CALL = 1
 export const TX_TYPE_EXECUTION = 'execution'
 export const TX_TYPE_CONFIRMATION = 'confirmation'
 
-export const getApprovalTransaction = async (
+type Transaction = {
   safeInstance: any,
   to: string,
   valueInWei: number | string,
   data: string,
   operation: Operation,
-  nonce: number,
   safeTxGas: number,
   baseGas: number,
   gasPrice: number,
   gasToken: string,
   refundReceiver: string,
-  sender: string,
-) => {
+}
+
+export const getApprovalTransaction = async ({
+  safeInstance,
+  to,
+  valueInWei,
+  data,
+  operation,
+  nonce,
+  safeTxGas,
+  baseGas,
+  gasPrice,
+  gasToken,
+  refundReceiver,
+  sender,
+}: Transaction & { nonce: number | string, sender: string }) => {
   const txHash = await safeInstance.getTransactionHash(
     to,
     valueInWei,
@@ -49,21 +62,19 @@ export const getApprovalTransaction = async (
   }
 }
 
-export const getExecutionTransaction = async (
-  safeInstance: any,
-  to: string,
-  valueInWei: number | string,
-  data: string,
-  operation: Operation,
-  nonce: string | number,
-  safeTxGas: string | number,
-  baseGas: string | number,
-  gasPrice: string | number,
-  gasToken: string,
-  refundReceiver: string,
-  sender: string,
-  sigs: string,
-) => {
+export const getExecutionTransaction = async ({
+  safeInstance,
+  to,
+  valueInWei,
+  data,
+  operation,
+  safeTxGas,
+  baseGas,
+  gasPrice,
+  gasToken,
+  refundReceiver,
+  sigs,
+}: Transaction & { sigs: string }) => {
   try {
     const web3 = getWeb3()
     const contract = new web3.eth.Contract(GnosisSafeSol.abi, safeInstance.address)

--- a/src/logic/safe/transactions/txHistory.js
+++ b/src/logic/safe/transactions/txHistory.js
@@ -21,6 +21,7 @@ const calculateBodyFrom = async (
   transactionHash: string,
   sender: string,
   confirmationType: TxServiceType,
+  origin: string | null,
 ) => {
   const contractTransactionHash = await safeInstance.getTransactionHash(
     to,
@@ -50,6 +51,7 @@ const calculateBodyFrom = async (
     transactionHash,
     sender: getWeb3().utils.toChecksumAddress(sender),
     confirmationType,
+    origin,
   }
 }
 
@@ -75,6 +77,7 @@ export const saveTxToHistory = async (
   txHash: string,
   sender: string,
   type: TxServiceType,
+  origin: string | null = null,
 ) => {
   const url = buildTxServiceUrl(safeInstance.address)
   const body = await calculateBodyFrom(
@@ -92,6 +95,7 @@ export const saveTxToHistory = async (
     txHash,
     sender,
     type,
+    origin,
   )
   const response = await axios.post(url, body)
 

--- a/src/logic/safe/transactions/txHistory.js
+++ b/src/logic/safe/transactions/txHistory.js
@@ -62,7 +62,23 @@ export const buildTxServiceUrl = (safeAddress: string) => {
   return `${host}${base}`
 }
 
-export const saveTxToHistory = async (
+export const saveTxToHistory = async ({
+  safeInstance,
+  to,
+  valueInWei,
+  data,
+  operation,
+  nonce,
+  safeTxGas,
+  baseGas,
+  gasPrice,
+  gasToken,
+  refundReceiver,
+  txHash,
+  sender,
+  type,
+  origin,
+}: {
   safeInstance: any,
   to: string,
   valueInWei: number | string,
@@ -77,8 +93,8 @@ export const saveTxToHistory = async (
   txHash: string,
   sender: string,
   type: TxServiceType,
-  origin: string | null = null,
-) => {
+  origin: string | null,
+}) => {
   const url = buildTxServiceUrl(safeInstance.address)
   const body = await calculateBodyFrom(
     safeInstance,
@@ -95,7 +111,7 @@ export const saveTxToHistory = async (
     txHash,
     sender,
     type,
-    origin,
+    origin || null,
   )
   const response = await axios.post(url, body)
 

--- a/src/routes/safe/components/Apps/index.jsx
+++ b/src/routes/safe/components/Apps/index.jsx
@@ -54,7 +54,7 @@ function Apps({ web3, safeAddress, safeName, ethBalance, network, createTransact
         const onConfirm = async () => {
           closeModal()
 
-          const txHash = await sendTransactions(web3, createTransaction, safeAddress, data.data)
+          const txHash = await sendTransactions(web3, createTransaction, safeAddress, data.data, getSelectedApp().name)
 
           if (txHash) {
             sendMessageToIframe(operations.ON_TX_UPDATE, {

--- a/src/routes/safe/components/Apps/sendTransactions.js
+++ b/src/routes/safe/components/Apps/sendTransactions.js
@@ -14,7 +14,7 @@ const multiSendAbi = [
   },
 ]
 
-const sendTransactions = (web3: any, createTransaction: any, safeAddress: String, txs: Array<any>) => {
+const sendTransactions = (web3: any, createTransaction: any, safeAddress: String, txs: Array<any>, origin: string) => {
   const multiSend = new web3.eth.Contract(multiSendAbi, multiSendAddress)
 
   const encodeMultiSendCalldata = multiSend.methods
@@ -43,6 +43,7 @@ const sendTransactions = (web3: any, createTransaction: any, safeAddress: String
     closeSnackbar: () => {},
     operation: DELEGATE_CALL,
     navigateToTransactionsTab: false,
+    origin,
   })
 }
 export default sendTransactions

--- a/src/routes/safe/store/actions/__tests__/utils.test.js
+++ b/src/routes/safe/store/actions/__tests__/utils.test.js
@@ -1,4 +1,3 @@
-jest.mock('~/logic/contracts/safeContracts')
 import { getNewTxNonce, shouldExecuteTransaction } from '~/routes/safe/store/actions/utils'
 
 describe('Store actions utils > getNewTxNonce', () => {
@@ -8,10 +7,14 @@ describe('Store actions utils > getNewTxNonce', () => {
     const lastTx = {
       nonce: 44
     }
-    const safeAddress = '0x7d6F142F15f152417FCf8E2573AD75C0ed1BE542'
+    const safeInstance = {
+      nonce: () => Promise.resolve({
+        toString: () => Promise.resolve('45')
+      })
+    }
 
     // When
-    const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
+    const nonce = await getNewTxNonce(txNonce, lastTx, safeInstance)
 
     // Then
     expect(nonce).toBe('45')
@@ -23,10 +26,14 @@ describe('Store actions utils > getNewTxNonce', () => {
     const lastTx = {
       nonce: 44
     }
-    const safeAddress = '0x7d6F142F15f152417FCf8E2573AD75C0ed1BE542'
+    const safeInstance = {
+      nonce: () => Promise.resolve({
+        toString: () => Promise.resolve('45')
+      })
+    }
 
     // When
-    const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
+    const nonce = await getNewTxNonce(txNonce, lastTx, safeInstance)
 
     // Then
     expect(nonce).toBe('45')
@@ -36,10 +43,14 @@ describe('Store actions utils > getNewTxNonce', () => {
     // Given
     const txNonce = ''
     const lastTx = null
-    const safeAddress = '0x7d6F142F15f152417FCf8E2573AD75C0ed1BE542'
+    const safeInstance = {
+      nonce: () => Promise.resolve({
+        toString: () => Promise.resolve('45')
+      })
+    }
 
     // When
-    const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
+    const nonce = await getNewTxNonce(txNonce, lastTx, safeInstance)
 
     // Then
     expect(nonce).toBe('45')

--- a/src/routes/safe/store/actions/__tests__/utils.test.js
+++ b/src/routes/safe/store/actions/__tests__/utils.test.js
@@ -1,0 +1,106 @@
+jest.mock('~/logic/contracts/safeContracts')
+import { getNewTxNonce, shouldExecuteTransaction } from '~/routes/safe/store/actions/utils'
+
+describe('Store actions utils > getNewTxNonce', () => {
+  it(`should return txNonce if it's a valid value`, async () => {
+    // Given
+    const txNonce = '45'
+    const lastTx = {
+      nonce: 44
+    }
+    const safeAddress = '0x7d6F142F15f152417FCf8E2573AD75C0ed1BE542'
+
+    // When
+    const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
+
+    // Then
+    expect(nonce).toBe('45')
+  })
+
+  it(`should return lastTx.nonce + 1 if txNonce is not valid`, async () => {
+    // Given
+    const txNonce = ''
+    const lastTx = {
+      nonce: 44
+    }
+    const safeAddress = '0x7d6F142F15f152417FCf8E2573AD75C0ed1BE542'
+
+    // When
+    const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
+
+    // Then
+    expect(nonce).toBe('45')
+  })
+
+  it(`should retrieve contract's instance nonce value, if txNonce and lastTx are not valid`, async () => {
+    // Given
+    const txNonce = ''
+    const lastTx = null
+    const safeAddress = '0x7d6F142F15f152417FCf8E2573AD75C0ed1BE542'
+
+    // When
+    const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
+
+    // Then
+    expect(nonce).toBe('45')
+  })
+})
+
+describe('Store actions utils > shouldExecuteTransaction', () => {
+  it(`should return false if there's a previous tx pending to be executed`, async () => {
+    // Given
+    const safeInstance = {
+      getThreshold: () => Promise.resolve({
+        toNumber: () => 1
+      })
+    }
+    const nonce = '1'
+    const lastTx = {
+      isExecuted: false
+    }
+
+    // When
+    const isExecution = await shouldExecuteTransaction(safeInstance, nonce, lastTx)
+
+    // Then
+    expect(isExecution).toBeFalsy()
+  })
+
+  it(`should return false if threshold is greater than 1`, async () => {
+    // Given
+    const safeInstance = {
+      getThreshold: () => Promise.resolve({
+        toNumber: () => 2
+      })
+    }
+    const nonce = '1'
+    const lastTx = {
+      isExecuted: true
+    }
+
+    // When
+    const isExecution = await shouldExecuteTransaction(safeInstance, nonce, lastTx)
+
+    // Then
+    expect(isExecution).toBeFalsy()
+  })
+
+  it(`should return true is threshold is 1 and previous tx is executed`, async () => {
+    // Given
+    const safeInstance = {
+      getThreshold: () => Promise.resolve({
+        toNumber: () => 1
+      })
+    }
+    const nonce = '1'
+    const lastTx = {
+      isExecuted: true
+    }
+
+    // When
+    const isExecution = await shouldExecuteTransaction(safeInstance, nonce, lastTx)
+
+    // Then
+    expect(isExecution).toBeTruthy()
+  })
+})

--- a/src/routes/safe/store/actions/createTransaction.js
+++ b/src/routes/safe/store/actions/createTransaction.js
@@ -59,6 +59,7 @@ type CreateTransactionArgs = {
   shouldExecute?: boolean,
   txNonce?: number,
   operation?: 0 | 1,
+  origin?: string | null,
 }
 
 const createTransaction = ({
@@ -73,6 +74,7 @@ const createTransaction = ({
   txNonce,
   operation = CALL,
   navigateToTransactionsTab = true,
+  origin = null,
 }: CreateTransactionArgs) => async (dispatch: ReduxDispatch<GlobalState>, getState: GetState<GlobalState>) => {
   const state: GlobalState = getState()
 
@@ -99,38 +101,54 @@ const createTransaction = ({
 
   let txHash
   let tx
+  const txArgs = {
+    safeInstance,
+    to,
+    valueInWei,
+    txData,
+    operation,
+    nonce,
+    safeTxGas: 0,
+    baseGas: 0,
+    gasPrice: 0,
+    gasToken: ZERO_ADDRESS,
+    refundReceiver: ZERO_ADDRESS,
+    from,
+    sigs,
+  }
+
   try {
     if (isExecution) {
       tx = await getExecutionTransaction(
-        safeInstance,
-        to,
-        valueInWei,
-        txData,
-        operation,
-        nonce,
-        0,
-        0,
-        0,
-        ZERO_ADDRESS,
-        ZERO_ADDRESS,
-        from,
-        sigs,
+        txArgs.safeInstance,
+        txArgs.to,
+        txArgs.valueInWei,
+        txArgs.txData,
+        txArgs.operation,
+        txArgs.nonce,
+        txArgs.safeTxGas,
+        txArgs.baseGas,
+        txArgs.gasPrice,
+        txArgs.gasToken,
+        txArgs.refundReceiver,
+        txArgs.from,
+        txArgs.sigs,
       )
     } else {
       tx = await getApprovalTransaction(
-        safeInstance,
-        to,
-        valueInWei,
-        txData,
-        operation,
-        nonce,
-        0,
-        0,
-        0,
-        ZERO_ADDRESS,
-        ZERO_ADDRESS,
-        from,
-        sigs,
+        txArgs.safeInstance,
+        txArgs.to,
+        txArgs.valueInWei,
+        txArgs.txData,
+        txArgs.operation,
+        txArgs.nonce,
+        txArgs.safeTxGas,
+        txArgs.baseGas,
+        txArgs.gasPrice,
+        txArgs.gasToken,
+        txArgs.refundReceiver,
+        txArgs.from,
+        txArgs.sigs,
       )
     }
 
@@ -156,20 +174,21 @@ const createTransaction = ({
 
         try {
           await saveTxToHistory(
-            safeInstance,
-            to,
-            valueInWei,
-            txData,
-            operation,
-            nonce,
-            0,
-            0,
-            0,
-            ZERO_ADDRESS,
-            ZERO_ADDRESS,
+            txArgs.safeInstance,
+            txArgs.to,
+            txArgs.valueInWei,
+            txArgs.txData,
+            txArgs.operation,
+            txArgs.nonce,
+            txArgs.safeTxGas,
+            txArgs.baseGas,
+            txArgs.gasPrice,
+            txArgs.gasToken,
+            txArgs.refundReceiver,
             txHash,
             from,
             isExecution ? TX_TYPE_EXECUTION : TX_TYPE_CONFIRMATION,
+            origin,
           )
           dispatch(fetchTransactions(safeAddress))
         } catch (err) {

--- a/src/routes/safe/store/actions/createTransaction.js
+++ b/src/routes/safe/store/actions/createTransaction.js
@@ -19,7 +19,7 @@ import { type NotificationsQueue, getNotificationsFromTxType, showSnackbar } fro
 import { getErrorMessage } from '~/test/utils/ethereumErrors'
 import { ZERO_ADDRESS } from '~/logic/wallets/ethAddresses'
 import { SAFELIST_ADDRESS } from '~/routes/routes'
-import { getLastTx, getNewTxNonce, shouldAutomaticallyExecuteTransaction } from '~/routes/safe/store/actions/utils'
+import { getLastTx, getNewTxNonce, shouldExecuteTransaction } from '~/routes/safe/store/actions/utils'
 
 type CreateTransactionArgs = {
   safeAddress: string,
@@ -58,7 +58,7 @@ const createTransaction = ({
   const safeInstance = await getGnosisSafeInstanceAt(safeAddress)
   const lastTx = await getLastTx(safeAddress)
   const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
-  const shouldAutomaticallyExecuteTx = await shouldAutomaticallyExecuteTransaction(safeInstance, nonce, lastTx)
+  const isExecution = await shouldExecuteTransaction(safeInstance, nonce, lastTx)
 
   // https://gnosis-safe.readthedocs.io/en/latest/contracts/signatures.html#pre-validated-signatures
   const sigs = `0x000000000000000000000000${from.replace(
@@ -89,7 +89,7 @@ const createTransaction = ({
   }
 
   try {
-    tx = shouldAutomaticallyExecuteTx ? await getExecutionTransaction(txArgs) : await getApprovalTransaction(txArgs)
+    tx = isExecution ? await getExecutionTransaction(txArgs) : await getApprovalTransaction(txArgs)
 
     const sendParams = { from, value: 0 }
 
@@ -115,7 +115,7 @@ const createTransaction = ({
           await saveTxToHistory({
             ...txArgs,
             txHash,
-            type: shouldAutomaticallyExecuteTx ? TX_TYPE_EXECUTION : TX_TYPE_CONFIRMATION,
+            type: isExecution ? TX_TYPE_EXECUTION : TX_TYPE_CONFIRMATION,
             origin,
           })
           dispatch(fetchTransactions(safeAddress))
@@ -129,7 +129,7 @@ const createTransaction = ({
       .then(receipt => {
         closeSnackbar(pendingExecutionKey)
         showSnackbar(
-          shouldAutomaticallyExecuteTx
+          isExecution
             ? notificationsQueue.afterExecution.noMoreConfirmationsNeeded
             : notificationsQueue.afterExecution.moreConfirmationsNeeded,
           enqueueSnackbar,

--- a/src/routes/safe/store/actions/createTransaction.js
+++ b/src/routes/safe/store/actions/createTransaction.js
@@ -57,7 +57,7 @@ const createTransaction = ({
   const from = userAccountSelector(state)
   const safeInstance = await getGnosisSafeInstanceAt(safeAddress)
   const lastTx = await getLastTx(safeAddress)
-  const nonce = await getNewTxNonce(txNonce, lastTx, safeAddress)
+  const nonce = await getNewTxNonce(txNonce, lastTx, safeInstance)
   const isExecution = await shouldExecuteTransaction(safeInstance, nonce, lastTx)
 
   // https://gnosis-safe.readthedocs.io/en/latest/contracts/signatures.html#pre-validated-signatures

--- a/src/routes/safe/store/actions/createTransaction.js
+++ b/src/routes/safe/store/actions/createTransaction.js
@@ -59,6 +59,7 @@ type CreateTransactionArgs = {
   shouldExecute?: boolean,
   txNonce?: number,
   operation?: 0 | 1,
+  navigateToTransactionsTab?: boolean,
   origin?: string | null,
 }
 

--- a/src/routes/safe/store/actions/createTransaction.js
+++ b/src/routes/safe/store/actions/createTransaction.js
@@ -105,7 +105,7 @@ const createTransaction = ({
     safeInstance,
     to,
     valueInWei,
-    txData,
+    data: txData,
     operation,
     nonce,
     safeTxGas: 0,
@@ -113,44 +113,12 @@ const createTransaction = ({
     gasPrice: 0,
     gasToken: ZERO_ADDRESS,
     refundReceiver: ZERO_ADDRESS,
-    from,
+    sender: from,
     sigs,
   }
 
   try {
-    if (isExecution) {
-      tx = await getExecutionTransaction(
-        txArgs.safeInstance,
-        txArgs.to,
-        txArgs.valueInWei,
-        txArgs.txData,
-        txArgs.operation,
-        txArgs.nonce,
-        txArgs.safeTxGas,
-        txArgs.baseGas,
-        txArgs.gasPrice,
-        txArgs.gasToken,
-        txArgs.refundReceiver,
-        txArgs.from,
-        txArgs.sigs,
-      )
-    } else {
-      tx = await getApprovalTransaction(
-        txArgs.safeInstance,
-        txArgs.to,
-        txArgs.valueInWei,
-        txArgs.txData,
-        txArgs.operation,
-        txArgs.nonce,
-        txArgs.safeTxGas,
-        txArgs.baseGas,
-        txArgs.gasPrice,
-        txArgs.gasToken,
-        txArgs.refundReceiver,
-        txArgs.from,
-        txArgs.sigs,
-      )
-    }
+    tx = isExecution ? await getExecutionTransaction(txArgs) : await getApprovalTransaction(txArgs)
 
     const sendParams = { from, value: 0 }
 
@@ -173,23 +141,12 @@ const createTransaction = ({
         pendingExecutionKey = showSnackbar(notificationsQueue.pendingExecution, enqueueSnackbar, closeSnackbar)
 
         try {
-          await saveTxToHistory(
-            txArgs.safeInstance,
-            txArgs.to,
-            txArgs.valueInWei,
-            txArgs.txData,
-            txArgs.operation,
-            txArgs.nonce,
-            txArgs.safeTxGas,
-            txArgs.baseGas,
-            txArgs.gasPrice,
-            txArgs.gasToken,
-            txArgs.refundReceiver,
+          await saveTxToHistory({
+            ...txArgs,
             txHash,
-            from,
-            isExecution ? TX_TYPE_EXECUTION : TX_TYPE_CONFIRMATION,
+            type: isExecution ? TX_TYPE_EXECUTION : TX_TYPE_CONFIRMATION,
             origin,
-          )
+          })
           dispatch(fetchTransactions(safeAddress))
         } catch (err) {
           console.error(err)

--- a/src/routes/safe/store/actions/processTransaction.js
+++ b/src/routes/safe/store/actions/processTransaction.js
@@ -44,7 +44,7 @@ const processTransaction = ({
   const from = userAccountSelector(state)
   const safeInstance = await getGnosisSafeInstanceAt(safeAddress)
   const lastTx = await getLastTx(safeAddress)
-  const nonce = await getNewTxNonce(null, lastTx, safeAddress)
+  const nonce = await getNewTxNonce(null, lastTx, safeInstance)
   const isExecution = approveAndExecute || (await shouldExecuteTransaction(safeInstance, nonce, lastTx))
 
   let sigs = generateSignaturesFromTxConfirmations(tx.confirmations, approveAndExecute && userAddress)

--- a/src/routes/safe/store/actions/processTransaction.js
+++ b/src/routes/safe/store/actions/processTransaction.js
@@ -96,7 +96,6 @@ const processTransaction = ({
           await saveTxToHistory({
             ...txArgs,
             txHash,
-            from,
             type: shouldExecute ? TX_TYPE_EXECUTION : TX_TYPE_CONFIRMATION,
           })
           dispatch(fetchTransactions(safeAddress))

--- a/src/routes/safe/store/actions/utils.js
+++ b/src/routes/safe/store/actions/utils.js
@@ -29,23 +29,19 @@ export const getNewTxNonce = async (txNonce, lastTx, safeAddress) => {
   return txNonce
 }
 
-export const doesTxNeedApproval = async (safeInstance, nonce, lastTx) => {
+export const shouldAutomaticallyExecuteTransaction = async (safeInstance, nonce, lastTx) => {
   const threshold = await safeInstance.getThreshold()
 
-  // if treshold is grater than one, it always needs approval
-  if (threshold.toNumber() > 1) {
-    return true
+  // Tx will automatically be executed if and only if the threshold is 1
+  if (threshold.toNumber() === 1) {
+    const isFirstTransaction = Number.parseInt(nonce) === 0
+    // if the previous tx is not executed, it's delayed using the approval mechanisms,
+    // once the previous tx is executed, the current tx will be available to be executed
+    // by the user using the exec button.
+    const canExecuteCurrentTransaction = lastTx && lastTx.isExecuted
+
+    return isFirstTransaction || canExecuteCurrentTransaction
   }
 
-  // if treshold is 1, and is the first TX, it does not need approval
-  if (!Number.parseInt(nonce) === 0) {
-    return false
-  }
-
-  // if threshold is 1, but the previous tx is not executed, it's delayed
-  // using the approval mechanisims, once the previous tx is executed, the
-  // current tx will be abailable to be executed by the user using the exec button.
-  if (lastTx && !lastTx.isExecuted) {
-    return false
-  }
+  return false
 }

--- a/src/routes/safe/store/actions/utils.js
+++ b/src/routes/safe/store/actions/utils.js
@@ -2,7 +2,6 @@
 import axios from 'axios'
 
 import { buildTxServiceUrl } from '~/logic/safe/transactions/txHistory'
-import { getGnosisSafeInstanceAt } from '~/logic/contracts/safeContracts'
 
 export const getLastTx = async (safeAddress: string): Promise<TransactionProps> => {
   try {
@@ -16,15 +15,12 @@ export const getLastTx = async (safeAddress: string): Promise<TransactionProps> 
   }
 }
 
-export const getSafeNonce = async (safeAddress: string): Promise<string> => {
-  // use current's safe nonce as fallback
-  const safeInstance = await getGnosisSafeInstanceAt(safeAddress)
-  return (await safeInstance.nonce()).toString()
-}
-
-export const getNewTxNonce = async (txNonce, lastTx, safeAddress) => {
+export const getNewTxNonce = async (txNonce, lastTx, safeInstance) => {
   if (!Number.isInteger(Number.parseInt(txNonce, 10))) {
-    return lastTx === null ? await getSafeNonce(safeAddress) : `${lastTx.nonce + 1}`
+    return lastTx === null
+      ? // use current's safe nonce as fallback
+        (await safeInstance.nonce()).toString()
+      : `${lastTx.nonce + 1}`
   }
   return txNonce
 }

--- a/src/routes/safe/store/actions/utils.js
+++ b/src/routes/safe/store/actions/utils.js
@@ -24,12 +24,12 @@ export const getSafeNonce = async (safeAddress: string): Promise<string> => {
 
 export const getNewTxNonce = async (txNonce, lastTx, safeAddress) => {
   if (!Number.isInteger(Number.parseInt(txNonce, 10))) {
-    return lastTx === null ? getSafeNonce(safeAddress) : `${lastTx.nonce + 1}`
+    return lastTx === null ? await getSafeNonce(safeAddress) : `${lastTx.nonce + 1}`
   }
   return txNonce
 }
 
-export const shouldAutomaticallyExecuteTransaction = async (safeInstance, nonce, lastTx) => {
+export const shouldExecuteTransaction = async (safeInstance, nonce, lastTx) => {
   const threshold = await safeInstance.getThreshold()
 
   // Tx will automatically be executed if and only if the threshold is 1

--- a/src/routes/safe/store/actions/utils.js
+++ b/src/routes/safe/store/actions/utils.js
@@ -1,0 +1,51 @@
+// @flow
+import axios from 'axios'
+
+import { buildTxServiceUrl } from '~/logic/safe/transactions/txHistory'
+import { getGnosisSafeInstanceAt } from '~/logic/contracts/safeContracts'
+
+export const getLastTx = async (safeAddress: string): Promise<TransactionProps> => {
+  try {
+    const url = buildTxServiceUrl(safeAddress)
+    const response = await axios.get(url, { params: { limit: 1 } })
+
+    return response.data.results[0]
+  } catch (e) {
+    console.error('failed to retrieve last Tx from server', e)
+    return null
+  }
+}
+
+export const getSafeNonce = async (safeAddress: string): Promise<string> => {
+  // use current's safe nonce as fallback
+  const safeInstance = await getGnosisSafeInstanceAt(safeAddress)
+  return (await safeInstance.nonce()).toString()
+}
+
+export const getNewTxNonce = async (txNonce, lastTx, safeAddress) => {
+  if (!Number.isInteger(Number.parseInt(txNonce, 10))) {
+    return lastTx === null ? getSafeNonce(safeAddress) : `${lastTx.nonce + 1}`
+  }
+  return txNonce
+}
+
+export const doesTxNeedApproval = async (safeInstance, nonce, lastTx) => {
+  const threshold = await safeInstance.getThreshold()
+
+  // if treshold is grater than one, it always needs approval
+  if (threshold.toNumber() > 1) {
+    return true
+  }
+
+  // if treshold is 1, and is the first TX, it does not need approval
+  if (!Number.parseInt(nonce) === 0) {
+    return false
+  }
+
+  // if threshold is 1, but the previous tx is not executed, it's delayed
+  // using the approval mechanisims, once the previous tx is executed, the
+  // current tx will be abailable to be executed by the user using the exec button.
+  if (lastTx && !lastTx.isExecuted) {
+    return false
+  }
+}


### PR DESCRIPTION
* Send the origin field when saves the TX
* Refactor of `getApprovalTransaction` and getExecutionTransaction
* Fixes issue #563