### PR TITLE
(fix) sidebar contents' scrolling

### DIFF
--- a/src/components/Sidebar/SafeList/index.jsx
+++ b/src/components/Sidebar/SafeList/index.jsx
@@ -38,10 +38,10 @@ const useStyles = makeStyles({
     marginRight: '10px',
   },
   list: {
-    overflow: 'hidden',
-    overflowY: 'hidden',
-    padding: 0,
     height: '100%',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    padding: 0,
   },
   listItemRoot: {
     paddingTop: 0,


### PR DESCRIPTION
Closes #454

It should work as intended now.

![Screen Shot 2020-02-27 at 17 19 02](https://user-images.githubusercontent.com/4015436/75483480-b034e380-5985-11ea-8652-6c3b6fdbf7a5.png)

![Feb-27-2020 17-15-26](https://user-images.githubusercontent.com/4015436/75483488-b4f99780-5985-11ea-8508-fa15b875a644.gif)
![Feb-27-2020 17-17-39](https://user-images.githubusercontent.com/4015436/75483491-b7f48800-5985-11ea-896a-4360d3854128.gif)
