### PR TITLE
Bug: Accounts/Network are not updated in production build

### DIFF
--- a/src/logic/wallets/store/middlewares/providerWatcher.js
+++ b/src/logic/wallets/store/middlewares/providerWatcher.js
@@ -1,11 +1,11 @@
 // @flow
 import type { AnyAction, Store } from 'redux'
 
-import { ADD_PROVIDER, REMOVE_PROVIDER } from '../actions'
-
 import closeSnackbar from '~/logic/notifications/store/actions/closeSnackbar'
 import { WALLET_PROVIDER, getProviderInfo, getWeb3 } from '~/logic/wallets/getWeb3'
 import { fetchProvider } from '~/logic/wallets/store/actions'
+import { ADD_PROVIDER } from '~/logic/wallets/store/actions/addProvider'
+import { REMOVE_PROVIDER } from '~/logic/wallets/store/actions/removeProvider'
 import { type GlobalState } from '~/store/'
 import { loadFromStorage, removeFromStorage, saveToStorage } from '~/utils/storage'
 


### PR DESCRIPTION
So the reason for this problem was that:
```js
const watchedActions = [ADD_PROVIDER, REMOVE_PROVIDER]
```

in the production build became `[undefined, undefined]` and thus `  if (watchedActions.includes(action.type)) {` didn't work in providerWatcher

I don't know the exact reason for this, whether it's a circular dependency, we messed up the imports or some webpack bundling bug but by using an absolute path it works