### PR TITLE
processTransaction: add gasLimit in development

### DIFF
--- a/src/routes/safe/store/actions/processTransaction.js
+++ b/src/routes/safe/store/actions/processTransaction.js
@@ -82,6 +82,12 @@ const processTransaction = ({
     transaction = isExecution ? await getExecutionTransaction(txArgs) : await getApprovalTransaction(txArgs)
 
     const sendParams = { from, value: 0 }
+
+    // TODO find a better solution for this in dev and production.
+    if (process.env.REACT_APP_ENV !== 'production') {
+      sendParams.gasLimit = 1000000
+    }
+
     // if not set owner management tests will fail on ganache
     if (process.env.NODE_ENV === 'test') {
       sendParams.gas = '7000000'


### PR DESCRIPTION
Adding the same fix as in `createTransaction`. When sending more than 1 tx to multisend, the second one fails because a wrong gas estimation.