### PR TITLE
(Fix) Wrong value for ERC-20 tokens transfers

### DIFF
--- a/src/logic/tokens/utils/tokenHelpers.js
+++ b/src/logic/tokens/utils/tokenHelpers.js
@@ -6,6 +6,9 @@ import { type Token, makeToken } from '~/logic/tokens/store/model/token'
 import { getWeb3 } from '~/logic/wallets/getWeb3'
 
 export const ETH_ADDRESS = '0x000'
+export const SAFE_TRANSFER_FROM_WITHOUT_DATA_HASH = '0x42842e0e'
+export const DECIMALS_METHOD_HASH = '313ce567'
+
 export const isEther = (symbol: string) => symbol === 'ETH'
 
 export const getEthAsToken = (balance: string) => {

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.jsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.jsx
@@ -32,6 +32,7 @@ import {
 } from '~/logic/tokens/store/actions/fetchTokens'
 import { type Token } from '~/logic/tokens/store/model/token'
 import { formatAmount } from '~/logic/tokens/utils/formatAmount'
+import { SAFE_TRANSFER_FROM_WITHOUT_DATA_HASH } from '~/logic/tokens/utils/tokenHelpers'
 import { getWeb3 } from '~/logic/wallets/getWeb3'
 import SafeInfo from '~/routes/safe/components/Balances/SendModal/SafeInfo'
 import { setImageToPlaceholder } from '~/routes/safe/components/Balances/utils'
@@ -41,8 +42,6 @@ import { sm } from '~/theme/variables'
 import { textShortener } from '~/utils/strings'
 
 const useStyles = makeStyles(styles)
-
-const SAFE_TRANSFER_FROM_WITHOUT_DATA_HASH = '0x42842e0e'
 
 type Props = {
   onClose: () => void,

--- a/src/routes/safe/store/actions/fetchTransactions.js
+++ b/src/routes/safe/store/actions/fetchTransactions.js
@@ -13,7 +13,13 @@ import { type TxServiceType, buildTxServiceUrl } from '~/logic/safe/transactions
 import { getLocalSafe } from '~/logic/safe/utils'
 import { getHumanFriendlyToken } from '~/logic/tokens/store/actions/fetchTokens'
 import { ALTERNATIVE_TOKEN_ABI } from '~/logic/tokens/utils/alternativeAbi'
-import { isMultisendTransaction, isTokenTransfer, isUpgradeTransaction } from '~/logic/tokens/utils/tokenHelpers'
+import {
+  DECIMALS_METHOD_HASH,
+  SAFE_TRANSFER_FROM_WITHOUT_DATA_HASH,
+  isMultisendTransaction,
+  isTokenTransfer,
+  isUpgradeTransaction,
+} from '~/logic/tokens/utils/tokenHelpers'
 import { ZERO_ADDRESS, sameAddress } from '~/logic/wallets/ethAddresses'
 import { EMPTY_DATA } from '~/logic/wallets/ethTransactions'
 import { getWeb3 } from '~/logic/wallets/getWeb3'
@@ -93,7 +99,8 @@ export const buildTransactionFrom = async (safeAddress: string, tx: TxServiceMod
   const cancellationTx = sameAddress(tx.to, safeAddress) && Number(tx.value) === 0 && !tx.data
   const code = tx.to ? await web3.eth.getCode(tx.to) : ''
   const isERC721Token =
-    code.includes('42842e0e') || (isTokenTransfer(tx.data, Number(tx.value)) && code.includes('06fdde03'))
+    code.includes(SAFE_TRANSFER_FROM_WITHOUT_DATA_HASH) ||
+    (isTokenTransfer(tx.data, Number(tx.value)) && !code.includes(DECIMALS_METHOD_HASH))
   const isSendTokenTx = !isERC721Token && isTokenTransfer(tx.data, Number(tx.value))
   const isMultiSendTx = isMultisendTransaction(tx.data, Number(tx.value))
   const isUpgradeTx = isMultiSendTx && isUpgradeTransaction(tx.data)


### PR DESCRIPTION
The wrong attempt to differentiate an ETH from an ERC-721 token `transfer` was to look for a `name` method, in the ERC-721 token code.

That assumption missed completely the existence of ERC-20 tokens.

This fix looks for a `decimals` method. If it's not there, then it's considered an ERC-721 token.

We're assuming that an ERC-721 token won't have a `decimal` method, based on the standard and also in the list of the `ERC721Full` OpenZeppelin contract:

```bash
➜ eth abi:methods ./ERC721Full.json
095ea7b3	approve(address,uint256)
70a08231	balanceOf(address)
6c0360eb	baseURI()
081812fc	getApproved(uint256)
e985e9c5	isApprovedForAll(address,address)
06fdde03	name()
6352211e	ownerOf(uint256)
42842e0e	safeTransferFrom(address,address,uint256)
b88d4fde	safeTransferFrom(address,address,uint256,bytes)
a22cb465	setApprovalForAll(address,bool)
01ffc9a7	supportsInterface(bytes4)
95d89b41	symbol()
4f6ccce7	tokenByIndex(uint256)
2f745c59	tokenOfOwnerByIndex(address,uint256)
c87b56dd	tokenURI(uint256)
18160ddd	totalSupply()
23b872dd	transferFrom(address,address,uint256)
```


fixes #678