### PR TITLE
BUG: Transactions with the same nonce won't show "Cancelled" status if one of them was executed

### DIFF
--- a/src/logic/safe/transactions/awaitingTransactions.js
+++ b/src/logic/safe/transactions/awaitingTransactions.js
@@ -16,14 +16,15 @@ export const getAwaitingTransactions = (
     const nonCancelledTransactions = safeTransactions.filter((transaction: Transaction) => {
       // If transactions are not executed, but there's a transaction with the same nonce EXECUTED later
       // it means that the transaction was cancelled (Replaced) and shouldn't get executed
+      let isTransactionCancelled = false
       if (!transaction.isExecuted) {
         if (cancellationTransactionsByNonce.get(transaction.nonce)) {
           // eslint-disable-next-line no-param-reassign
-          transaction = transaction.set('cancelled', true)
+          isTransactionCancelled = true
         }
       }
       // The transaction is not executed and is not cancelled, so it's still waiting confirmations
-      if (!transaction.executionTxHash && !transaction.cancelled) {
+      if (!transaction.executionTxHash && !isTransactionCancelled) {
         // Then we check if the waiting confirmations are not from the current user, otherwise, filters this
         // transaction
         const transactionWaitingUser = transaction.confirmations.filter(

--- a/src/routes/safe/container/selector.js
+++ b/src/routes/safe/container/selector.js
@@ -129,8 +129,9 @@ const extendedTransactionsSelector: Selector<
 
       if (!tx.isExecuted) {
         if (
-          cancellationTransactionsByNonce.get(tx.nonce) &&
-          cancellationTransactionsByNonce.get(tx.nonce).get('isExecuted')
+          (cancellationTransactionsByNonce.get(tx.nonce) &&
+            cancellationTransactionsByNonce.get(tx.nonce).get('isExecuted')) ||
+          transactions.find((safeTx) => tx.nonce === safeTx.nonce && safeTx.isExecuted)
         ) {
           extendedTx = tx.set('cancelled', true)
         }


### PR DESCRIPTION
- Set `cancelled` on transaction to true if there's executed transaction with the same nonce which is not cancellation transaction
- Don't reassign `transaction` in `getAwaitingTransactions` because it won't do anything (Since we're inside .filter method), instead use a boolean variable 