### PR TITLE
(Fix) set `INCOMING` as the default `type` for incoming txs

### DIFF
--- a/src/routes/safe/store/models/incomingTransaction.js
+++ b/src/routes/safe/store/models/incomingTransaction.js
@@ -2,7 +2,7 @@
 import { Record } from 'immutable'
 import type { RecordFactory, RecordOf } from 'immutable'
 
-export const INCOMING_TX_TYPES = ['ERC721_TRANSFER', 'ERC20_TRANSFER', 'ETHER_TRANSFER']
+export const INCOMING_TX_TYPES = ['INCOMING', 'ERC721_TRANSFER', 'ERC20_TRANSFER', 'ETHER_TRANSFER']
 
 export type IncomingTransactionProps = {
   blockNumber: number,
@@ -53,7 +53,7 @@ export const makeIncomingTransaction: RecordFactory<IncomingTransactionProps> = 
   decimals: 18,
   fee: '',
   executionDate: '',
-  type: INCOMING_TX_TYPES,
+  type: 'INCOMING',
   status: 'success',
   nonce: null,
   confirmations: null,


### PR DESCRIPTION
This PR solves an issue with the upcoming `type` that will be sent from the backend for the `incoming transactions`.

It sets a default/generic `INCOMING` type, for those unspecified types.

@francovenica, In staging env everything must remain the same, there shouldn't be any differences.