### PR TITLE
(Fix) Change the order of the upgrade methods lookup

### DIFF
--- a/src/logic/tokens/utils/tokenHelpers.js
+++ b/src/logic/tokens/utils/tokenHelpers.js
@@ -62,10 +62,10 @@ export const isTokenTransfer = (data: string, value: number): boolean =>
 export const isMultisendTransaction = (data: string, value: number): boolean =>
   !!data && data.substring(0, 10) === '0x8d80ff0a' && value === 0
 
-// f08a0323 - setFallbackHandler (308, 8)
-// 7de7edef - changeMasterCopy (550, 8)
+// 7de7edef - changeMasterCopy (308, 8)
+// f08a0323 - setFallbackHandler (550, 8)
 export const isUpgradeTransaction = (data: string) =>
-  !!data && data.substr(308, 8) === 'f08a0323' && data.substr(550, 8) === '7de7edef'
+  !!data && data.substr(308, 8) === '7de7edef' && data.substr(550, 8) === 'f08a0323'
 
 export const isERC721Contract = async (contractAddress: string): boolean => {
   const ERC721Token = await getStandardTokenContract()

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/utils.js
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/utils.js
@@ -18,7 +18,7 @@ type DecodedTxData = {
 }
 
 const getSafeVersion = (data: string) => {
-  const contractAddress = data.substr(582, 40).toLowerCase()
+  const contractAddress = data.substr(340, 40).toLowerCase()
 
   return (
     {


### PR DESCRIPTION
This PR fixes the wrong identification of the upgrade transactions.

![image](https://user-images.githubusercontent.com/3315606/78565079-c3906580-77f3-11ea-97a8-e8690694549a.png)

The `isUpgradeTransaction` method was looking for methods in the wrong order (#599). This worked fine before the #610, which set the proper order for the upgrade methods.


**Note:** Added the last fix, the version wasn't properly extracted from the data object: https://github.com/gnosis/safe-react/pull/740/commits/1161b213fedb59654032503cae70049f8d7590a9