### PR TITLE
(Fix) Properly decode threshold value in tx details

### DIFF
--- a/src/logic/contracts/methodIds.js
+++ b/src/logic/contracts/methodIds.js
@@ -39,11 +39,18 @@ import { getWeb3 } from '~/logic/wallets/getWeb3'
 //   { name: "getTransactionHash", id: "0xd8d11f78" }
 // ]
 
+export const SAFE_METHODS_NAMES = {
+  ADD_OWNER_WITH_THRESHOLD: 'addOwnerWithThreshold',
+  CHANGE_THRESHOLD: 'changeThreshold',
+  REMOVE_OWNER: 'removeOwner',
+  SWAP_OWNER: 'swapOwner',
+}
+
 const METHOD_TO_ID = {
-  '0xe318b52b': 'swapOwner',
-  '0x0d582f13': 'addOwnerWithThreshold',
-  '0xf8dc5dd9': 'removeOwner',
-  '0x694e80c3': 'changeThreshold',
+  '0xe318b52b': SAFE_METHODS_NAMES.SWAP_OWNER,
+  '0x0d582f13': SAFE_METHODS_NAMES.ADD_OWNER_WITH_THRESHOLD,
+  '0xf8dc5dd9': SAFE_METHODS_NAMES.REMOVE_OWNER,
+  '0x694e80c3': SAFE_METHODS_NAMES.CHANGE_THRESHOLD,
 }
 
 export const decodeParamsFromSafeMethod = async (data: string) => {

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
@@ -10,6 +10,7 @@ import Bold from '~/components/layout/Bold'
 import LinkWithRef from '~/components/layout/Link'
 import Paragraph from '~/components/layout/Paragraph'
 import { getNameFromAddressBook } from '~/logic/addressBook/utils'
+import { SAFE_METHODS_NAMES } from '~/logic/contracts/methodIds'
 import { shortVersionOf } from '~/logic/wallets/ethAddresses'
 import OwnerAddressTableCell from '~/routes/safe/components/Settings/ManageOwners/OwnerAddressTableCell'
 import { getTxAmount } from '~/routes/safe/components/Transactions/TxsTable/columns'
@@ -120,7 +121,7 @@ const NewThreshold = ({ newThreshold }: { newThreshold: string }) => (
 )
 
 const SettingsDescription = ({ action, addedOwner, newThreshold, removedOwner }: DescriptionDescProps) => {
-  if (action === 'removeOwner' && removedOwner && newThreshold) {
+  if (action === SAFE_METHODS_NAMES.REMOVE_OWNER && removedOwner && newThreshold) {
     return (
       <>
         <RemovedOwner removedOwner={removedOwner} />
@@ -129,11 +130,11 @@ const SettingsDescription = ({ action, addedOwner, newThreshold, removedOwner }:
     )
   }
 
-  if (action === 'changeThreshold' && newThreshold) {
+  if (action === SAFE_METHODS_NAMES.CHANGE_THRESHOLD && newThreshold) {
     return <NewThreshold newThreshold={newThreshold} />
   }
 
-  if (action === 'addOwnerWithThreshold' && addedOwner && newThreshold) {
+  if (action === SAFE_METHODS_NAMES.ADD_OWNER_WITH_THRESHOLD && addedOwner && newThreshold) {
     return (
       <>
         <AddedOwner addedOwner={addedOwner} />
@@ -142,7 +143,7 @@ const SettingsDescription = ({ action, addedOwner, newThreshold, removedOwner }:
     )
   }
 
-  if (action === 'swapOwner' && removedOwner && addedOwner) {
+  if (action === SAFE_METHODS_NAMES.SWAP_OWNER && removedOwner && addedOwner) {
     return (
       <>
         <RemovedOwner removedOwner={removedOwner} />

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
@@ -129,7 +129,7 @@ const SettingsDescription = ({ action, addedOwner, newThreshold, removedOwner }:
     )
   }
 
-  if (action === 'changedThreshold' && newThreshold) {
+  if (action === 'changeThreshold' && newThreshold) {
     return <NewThreshold newThreshold={newThreshold} />
   }
 

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/utils.js
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/utils.js
@@ -1,4 +1,5 @@
 // @flow
+import { SAFE_METHODS_NAMES } from '~/logic/contracts/methodIds'
 import { getWeb3 } from '~/logic/wallets/getWeb3'
 import { type Transaction } from '~/routes/safe/store/models/transaction'
 
@@ -51,15 +52,15 @@ export const getTxData = (tx: Transaction): DecodedTxData => {
     if (tx.decodedParams) {
       txData.action = tx.decodedParams.methodName
 
-      if (txData.action === 'removeOwner') {
+      if (txData.action === SAFE_METHODS_NAMES.REMOVE_OWNER) {
         txData.removedOwner = tx.decodedParams.args[1]
         txData.newThreshold = tx.decodedParams.args[2]
-      } else if (txData.action === 'changeThreshold') {
+      } else if (txData.action === SAFE_METHODS_NAMES.CHANGE_THRESHOLD) {
         txData.newThreshold = tx.decodedParams.args[0]
-      } else if (txData.action === 'addOwnerWithThreshold') {
+      } else if (txData.action === SAFE_METHODS_NAMES.ADD_OWNER_WITH_THRESHOLD) {
         txData.addedOwner = tx.decodedParams.args[0]
         txData.newThreshold = tx.decodedParams.args[1]
-      } else if (txData.action === 'swapOwner') {
+      } else if (txData.action === SAFE_METHODS_NAMES.SWAP_OWNER) {
         txData.removedOwner = tx.decodedParams.args[1]
         txData.addedOwner = tx.decodedParams.args[2]
       }


### PR DESCRIPTION
This PR fixes #746, by fixing a typo for the ~`changedThreshold`~ `changeThreshold` action

| before fix | after fix |
|---|---|
|![image](https://user-images.githubusercontent.com/3315606/78837856-59cab400-79cb-11ea-9f6f-0439097c49ad.png)|![image](https://user-images.githubusercontent.com/3315606/78837868-5fc09500-79cb-11ea-887c-66e3257844f7.png)|

