### PR TITLE
Rename incoming-transactions url to incoming-transfers

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -56,7 +56,7 @@ export const getTxServiceUriFrom = (safeAddress: string) =>
   `safes/${safeAddress}/transactions/`
 
 export const getIncomingTxServiceUriTo = (safeAddress: string) =>
-  `safes/${safeAddress}/incoming-transactions/`
+  `safes/${safeAddress}/incoming-transfers/`
 
 export const getRelayUrl = () => getConfig()[RELAY_API_URL]
 


### PR DESCRIPTION
Service will still support the old endpoint alias, but as it's already deployed in every environment this can be merged

EDIT: Deployment is still ongoing as travis is stuck, but should be ready in a few minutes