### PR TITLE
(Feature) Tx Table amount notations

### DIFF
--- a/src/logic/tokens/store/reducer/tokens.js
+++ b/src/logic/tokens/store/reducer/tokens.js
@@ -9,7 +9,7 @@ import { type Token, makeToken } from '~/logic/tokens/store/model/token'
 
 export const TOKEN_REDUCER_ID = 'tokens'
 
-export type State = Map<string, Map<string, Token>>
+export type State = Map<string, Token>
 
 export default handleActions<State, *>(
   {

--- a/src/logic/tokens/utils/formatAmount.js
+++ b/src/logic/tokens/utils/formatAmount.js
@@ -18,7 +18,7 @@ export const formatAmount = (number: string | number) => {
   let numberFloat = parseFloat(number)
 
   if (numberFloat === 0) {
-    numberFloat = '0.000'
+    numberFloat = '0'
   } else if (numberFloat < 0.001) {
     numberFloat = '< 0.001'
   } else if (numberFloat < 1000) {

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/IncomingTxDescription/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/IncomingTxDescription/index.jsx
@@ -49,7 +49,7 @@ const IncomingTxDescription = ({ tx }: Props) => {
   const txFromName = getNameFromAddressBook(tx.from)
   return (
     <Block className={classes.txDataContainer}>
-      <TransferDescription from={tx.from} txFromName={txFromName} value={getIncomingTxAmount(tx)} />
+      <TransferDescription from={tx.from} txFromName={txFromName} value={getIncomingTxAmount(tx, false)} />
     </Block>
   )
 }

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.jsx
@@ -222,7 +222,7 @@ const TxDescription = ({ classes, tx }: Props) => {
     removedOwner,
     upgradeTx,
   } = getTxData(tx)
-  const amount = getTxAmount(tx)
+  const amount = getTxAmount(tx, false)
   return (
     <Block className={classes.txDataContainer}>
       {modifySettingsTx && action && (

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/index.jsx
@@ -66,10 +66,12 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
                 <Bold className={classes.txHash}>Hash:</Bold>
                 {tx.executionTxHash ? <EtherScanLink cut={8} type="tx" value={tx.executionTxHash} /> : 'n/a'}
               </Block>
-              <Paragraph noMargin>
-                <Bold>Nonce: </Bold>
-                <Span>{tx.nonce}</Span>
-              </Paragraph>
+              {INCOMING_TX_TYPES.includes(tx.type) ? null : (
+                <Paragraph noMargin>
+                  <Bold>Nonce: </Bold>
+                  <Span>{tx.nonce}</Span>
+                </Paragraph>
+              )}
               <Paragraph noMargin>
                 <Bold>Fee: </Bold>
                 {tx.fee ? tx.fee : 'n/a'}

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/index.jsx
@@ -41,8 +41,9 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
   const [openModal, setOpenModal] = useState<OpenModal>(null)
   const openApproveModal = () => setOpenModal('approveTx')
   const closeModal = () => setOpenModal(null)
-  const thresholdReached = !INCOMING_TX_TYPES[tx.type] && threshold <= tx.confirmations.size
-  const canExecute = !INCOMING_TX_TYPES[tx.type] && nonce === tx.nonce
+  const isIncomingTx = !!INCOMING_TX_TYPES[tx.type]
+  const thresholdReached = !isIncomingTx && threshold <= tx.confirmations.size
+  const canExecute = !isIncomingTx && nonce === tx.nonce
   const cancelThresholdReached = !!cancelTx && threshold <= cancelTx.confirmations.size
   const canExecuteCancel = nonce === tx.nonce
 
@@ -59,12 +60,12 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
       <Block className={classes.expandedTxBlock}>
         <Row>
           <Col layout="column" xs={6}>
-            <Block className={cn(classes.txDataContainer, INCOMING_TX_TYPES[tx.type] && classes.incomingTxBlock)}>
+            <Block className={cn(classes.txDataContainer, isIncomingTx && classes.incomingTxBlock)}>
               <Block align="left" className={classes.txData}>
                 <Bold className={classes.txHash}>Hash:</Bold>
                 {tx.executionTxHash ? <EtherScanLink cut={8} type="tx" value={tx.executionTxHash} /> : 'n/a'}
               </Block>
-              {INCOMING_TX_TYPES[tx.type] ? null : (
+              {!isIncomingTx && (
                 <Paragraph noMargin>
                   <Bold>Nonce: </Bold>
                   <Span>{tx.nonce}</Span>
@@ -74,7 +75,7 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
                 <Bold>Fee: </Bold>
                 {tx.fee ? tx.fee : 'n/a'}
               </Paragraph>
-              {INCOMING_TX_TYPES[tx.type] ? (
+              {isIncomingTx ? (
                 <>
                   <Paragraph noMargin>
                     <Bold>Created: </Bold>
@@ -113,9 +114,9 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
               )}
             </Block>
             <Hairline />
-            {INCOMING_TX_TYPES[tx.type] ? <IncomingTxDescription tx={tx} /> : <TxDescription tx={tx} />}
+            {isIncomingTx ? <IncomingTxDescription tx={tx} /> : <TxDescription tx={tx} />}
           </Col>
-          {!INCOMING_TX_TYPES[tx.type] && (
+          {!isIncomingTx && (
             <OwnersColumn
               cancelThresholdReached={cancelThresholdReached}
               cancelTx={cancelTx}

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/index.jsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/index.jsx
@@ -41,8 +41,8 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
   const [openModal, setOpenModal] = useState<OpenModal>(null)
   const openApproveModal = () => setOpenModal('approveTx')
   const closeModal = () => setOpenModal(null)
-  const thresholdReached = !INCOMING_TX_TYPES.includes(tx.type) && threshold <= tx.confirmations.size
-  const canExecute = !INCOMING_TX_TYPES.includes(tx.type) && nonce === tx.nonce
+  const thresholdReached = !INCOMING_TX_TYPES[tx.type] && threshold <= tx.confirmations.size
+  const canExecute = !INCOMING_TX_TYPES[tx.type] && nonce === tx.nonce
   const cancelThresholdReached = !!cancelTx && threshold <= cancelTx.confirmations.size
   const canExecuteCancel = nonce === tx.nonce
 
@@ -59,14 +59,12 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
       <Block className={classes.expandedTxBlock}>
         <Row>
           <Col layout="column" xs={6}>
-            <Block
-              className={cn(classes.txDataContainer, INCOMING_TX_TYPES.includes(tx.type) && classes.incomingTxBlock)}
-            >
+            <Block className={cn(classes.txDataContainer, INCOMING_TX_TYPES[tx.type] && classes.incomingTxBlock)}>
               <Block align="left" className={classes.txData}>
                 <Bold className={classes.txHash}>Hash:</Bold>
                 {tx.executionTxHash ? <EtherScanLink cut={8} type="tx" value={tx.executionTxHash} /> : 'n/a'}
               </Block>
-              {INCOMING_TX_TYPES.includes(tx.type) ? null : (
+              {INCOMING_TX_TYPES[tx.type] ? null : (
                 <Paragraph noMargin>
                   <Bold>Nonce: </Bold>
                   <Span>{tx.nonce}</Span>
@@ -76,7 +74,7 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
                 <Bold>Fee: </Bold>
                 {tx.fee ? tx.fee : 'n/a'}
               </Paragraph>
-              {INCOMING_TX_TYPES.includes(tx.type) ? (
+              {INCOMING_TX_TYPES[tx.type] ? (
                 <>
                   <Paragraph noMargin>
                     <Bold>Created: </Bold>
@@ -115,9 +113,9 @@ const ExpandedTx = ({ cancelTx, tx }: Props) => {
               )}
             </Block>
             <Hairline />
-            {INCOMING_TX_TYPES.includes(tx.type) ? <IncomingTxDescription tx={tx} /> : <TxDescription tx={tx} />}
+            {INCOMING_TX_TYPES[tx.type] ? <IncomingTxDescription tx={tx} /> : <TxDescription tx={tx} />}
           </Col>
-          {!INCOMING_TX_TYPES.includes(tx.type) && (
+          {!INCOMING_TX_TYPES[tx.type] && (
             <OwnersColumn
               cancelThresholdReached={cancelThresholdReached}
               cancelTx={cancelTx}

--- a/src/routes/safe/components/Transactions/TxsTable/columns.js
+++ b/src/routes/safe/components/Transactions/TxsTable/columns.js
@@ -41,24 +41,24 @@ type TxValues = {
 
 const NOT_AVAILABLE = 'n/a'
 
-const getAmountWithSymbol = ({ decimals = 0, symbol = NOT_AVAILABLE, value }: TxValues, precise = false) => {
+const getAmountWithSymbol = ({ decimals = 0, symbol = NOT_AVAILABLE, value }: TxValues, usePrecise = false) => {
   const nonFormattedValue = BigNumber(value).times(`1e-${decimals}`).toFixed()
-  const finalValue = precise ? formatAmount(nonFormattedValue).toString() : nonFormattedValue
+  const finalValue = usePrecise ? formatAmount(nonFormattedValue).toString() : nonFormattedValue
   const txAmount = finalValue === 'NaN' ? NOT_AVAILABLE : finalValue
 
   return `${txAmount} ${symbol}`
 }
 
-export const getIncomingTxAmount = (tx: IncomingTransaction, precise: boolean = true) => {
+export const getIncomingTxAmount = (tx: IncomingTransaction, usePrecise: boolean = true) => {
   // simple workaround to avoid displaying unexpected values for incoming NFT transfer
   if (INCOMING_TX_TYPES[tx.type] === INCOMING_TX_TYPES.ERC721_TRANSFER) {
     return `1 ${tx.symbol}`
   }
 
-  return getAmountWithSymbol(tx, precise)
+  return getAmountWithSymbol(tx, usePrecise)
 }
 
-export const getTxAmount = (tx: Transaction, precise: boolean = true) => {
+export const getTxAmount = (tx: Transaction, usePrecise: boolean = true) => {
   const { decimals = 18, decodedParams, isTokenTransfer, symbol } = tx
   const { value } = isTokenTransfer && decodedParams && decodedParams.value ? decodedParams : tx
 
@@ -66,7 +66,7 @@ export const getTxAmount = (tx: Transaction, precise: boolean = true) => {
     return NOT_AVAILABLE
   }
 
-  return getAmountWithSymbol({ decimals, symbol, value }, precise)
+  return getAmountWithSymbol({ decimals, symbol, value }, usePrecise)
 }
 
 export type TransactionRow = SortRow<TxData>

--- a/src/routes/safe/components/Transactions/TxsTable/columns.js
+++ b/src/routes/safe/components/Transactions/TxsTable/columns.js
@@ -50,6 +50,11 @@ const getAmountWithSymbol = ({ decimals = 0, symbol = NOT_AVAILABLE, value }: Tx
 }
 
 export const getIncomingTxAmount = (tx: IncomingTransaction, useFormatAmount: boolean = true) => {
+  // simple workaround to avoid displaying unexpected values for incoming NFT transfer
+  if (INCOMING_TX_TYPES[tx.type] === INCOMING_TX_TYPES.ERC721_TRANSFER) {
+    return `1 ${tx.symbol}`
+  }
+
   return getAmountWithSymbol(tx, useFormatAmount)
 }
 

--- a/src/routes/safe/components/Transactions/TxsTable/columns.js
+++ b/src/routes/safe/components/Transactions/TxsTable/columns.js
@@ -41,24 +41,24 @@ type TxValues = {
 
 const NOT_AVAILABLE = 'n/a'
 
-const getAmountWithSymbol = ({ decimals = 0, symbol = NOT_AVAILABLE, value }: TxValues, usePrecise = false) => {
+const getAmountWithSymbol = ({ decimals = 0, symbol = NOT_AVAILABLE, value }: TxValues, formatted = false) => {
   const nonFormattedValue = BigNumber(value).times(`1e-${decimals}`).toFixed()
-  const finalValue = usePrecise ? formatAmount(nonFormattedValue).toString() : nonFormattedValue
+  const finalValue = formatted ? formatAmount(nonFormattedValue).toString() : nonFormattedValue
   const txAmount = finalValue === 'NaN' ? NOT_AVAILABLE : finalValue
 
   return `${txAmount} ${symbol}`
 }
 
-export const getIncomingTxAmount = (tx: IncomingTransaction, usePrecise: boolean = true) => {
+export const getIncomingTxAmount = (tx: IncomingTransaction, formatted: boolean = true) => {
   // simple workaround to avoid displaying unexpected values for incoming NFT transfer
   if (INCOMING_TX_TYPES[tx.type] === INCOMING_TX_TYPES.ERC721_TRANSFER) {
     return `1 ${tx.symbol}`
   }
 
-  return getAmountWithSymbol(tx, usePrecise)
+  return getAmountWithSymbol(tx, formatted)
 }
 
-export const getTxAmount = (tx: Transaction, usePrecise: boolean = true) => {
+export const getTxAmount = (tx: Transaction, formatted: boolean = true) => {
   const { decimals = 18, decodedParams, isTokenTransfer, symbol } = tx
   const { value } = isTokenTransfer && decodedParams && decodedParams.value ? decodedParams : tx
 
@@ -66,7 +66,7 @@ export const getTxAmount = (tx: Transaction, usePrecise: boolean = true) => {
     return NOT_AVAILABLE
   }
 
-  return getAmountWithSymbol({ decimals, symbol, value }, usePrecise)
+  return getAmountWithSymbol({ decimals, symbol, value }, formatted)
 }
 
 export type TransactionRow = SortRow<TxData>

--- a/src/routes/safe/components/Transactions/TxsTable/columns.js
+++ b/src/routes/safe/components/Transactions/TxsTable/columns.js
@@ -59,8 +59,8 @@ export const getIncomingTxAmount = (tx: IncomingTransaction, useFormatAmount: bo
 }
 
 export const getTxAmount = (tx: Transaction, useFormatAmount: boolean = true) => {
-  const { decodedParams, isTokenTransfer, symbol } = tx
-  const { decimals = 18, value } = isTokenTransfer && decodedParams && decodedParams.value ? decodedParams : tx
+  const { decimals = 18, decodedParams, isTokenTransfer, symbol } = tx
+  const { value } = isTokenTransfer && decodedParams && decodedParams.value ? decodedParams : tx
 
   if (!isTokenTransfer && !(Number(value) > 0)) {
     return NOT_AVAILABLE

--- a/src/routes/safe/components/Transactions/TxsTable/columns.js
+++ b/src/routes/safe/components/Transactions/TxsTable/columns.js
@@ -111,7 +111,7 @@ export const getTxTableData = (
   const cancelTxsByNonce = cancelTxs.reduce((acc, tx) => acc.set(tx.nonce, tx), Map())
 
   return transactions.map((tx) => {
-    if (INCOMING_TX_TYPES.includes(tx.type)) {
+    if (INCOMING_TX_TYPES[tx.type]) {
       return getIncomingTxTableData(tx)
     }
 

--- a/src/routes/safe/components/Transactions/TxsTable/columns.js
+++ b/src/routes/safe/components/Transactions/TxsTable/columns.js
@@ -41,24 +41,24 @@ type TxValues = {
 
 const NOT_AVAILABLE = 'n/a'
 
-const getAmountWithSymbol = ({ decimals = 0, symbol = NOT_AVAILABLE, value }: TxValues, useFormatAmount = false) => {
+const getAmountWithSymbol = ({ decimals = 0, symbol = NOT_AVAILABLE, value }: TxValues, precise = false) => {
   const nonFormattedValue = BigNumber(value).times(`1e-${decimals}`).toFixed()
-  const finalValue = useFormatAmount ? formatAmount(nonFormattedValue).toString() : nonFormattedValue
+  const finalValue = precise ? formatAmount(nonFormattedValue).toString() : nonFormattedValue
   const txAmount = finalValue === 'NaN' ? NOT_AVAILABLE : finalValue
 
   return `${txAmount} ${symbol}`
 }
 
-export const getIncomingTxAmount = (tx: IncomingTransaction, useFormatAmount: boolean = true) => {
+export const getIncomingTxAmount = (tx: IncomingTransaction, precise: boolean = true) => {
   // simple workaround to avoid displaying unexpected values for incoming NFT transfer
   if (INCOMING_TX_TYPES[tx.type] === INCOMING_TX_TYPES.ERC721_TRANSFER) {
     return `1 ${tx.symbol}`
   }
 
-  return getAmountWithSymbol(tx, useFormatAmount)
+  return getAmountWithSymbol(tx, precise)
 }
 
-export const getTxAmount = (tx: Transaction, useFormatAmount: boolean = true) => {
+export const getTxAmount = (tx: Transaction, precise: boolean = true) => {
   const { decimals = 18, decodedParams, isTokenTransfer, symbol } = tx
   const { value } = isTokenTransfer && decodedParams && decodedParams.value ? decodedParams : tx
 
@@ -66,7 +66,7 @@ export const getTxAmount = (tx: Transaction, useFormatAmount: boolean = true) =>
     return NOT_AVAILABLE
   }
 
-  return getAmountWithSymbol({ decimals, symbol, value }, useFormatAmount)
+  return getAmountWithSymbol({ decimals, symbol, value }, precise)
 }
 
 export type TransactionRow = SortRow<TxData>

--- a/src/routes/safe/store/actions/fetchTransactions.js
+++ b/src/routes/safe/store/actions/fetchTransactions.js
@@ -230,7 +230,7 @@ const addMockSafeCreationTx = (safeAddress): Array<TxServiceModel> => [
 const batchRequestTxsData = (txs: any[]) => {
   const web3Batch = new web3.BatchRequest()
 
-  const whenTxsValues = txs.map((tx) => {
+  const txsTokenInfo = txs.map((tx) => {
     const methods = [{ method: 'getCode', type: 'eth', args: [tx.to] }, 'decimals', 'name', 'symbol']
     return generateBatchRequests({
       abi: ERC20Detailed.abi,
@@ -243,7 +243,7 @@ const batchRequestTxsData = (txs: any[]) => {
 
   web3Batch.execute()
 
-  return Promise.all(whenTxsValues)
+  return Promise.all(txsTokenInfo)
 }
 
 const batchRequestIncomingTxsData = (txs: IncomingTxServiceModel[]) => {

--- a/src/routes/safe/store/actions/fetchTransactions.js
+++ b/src/routes/safe/store/actions/fetchTransactions.js
@@ -118,7 +118,7 @@ export const buildTransactionFrom = async (
   let refundParams = null
   if (tx.gasPrice > 0) {
     const refundSymbol = txTokenSymbol || 'ETH'
-    const decimals = txTokenName || 18
+    const decimals = txTokenDecimals || 18
     const feeString = (tx.gasPrice * (tx.baseGas + tx.safeTxGas)).toString().padStart(decimals, 0)
     const whole = feeString.slice(0, feeString.length - decimals) || '0'
     const fraction = feeString.slice(feeString.length - decimals)

--- a/src/routes/safe/store/models/incomingTransaction.js
+++ b/src/routes/safe/store/models/incomingTransaction.js
@@ -2,7 +2,12 @@
 import { Record } from 'immutable'
 import type { RecordFactory, RecordOf } from 'immutable'
 
-export const INCOMING_TX_TYPES = ['INCOMING', 'ERC721_TRANSFER', 'ERC20_TRANSFER', 'ETHER_TRANSFER']
+export const INCOMING_TX_TYPES = {
+  INCOMING: 'INCOMING',
+  ERC721_TRANSFER: 'ERC721_TRANSFER',
+  ERC20_TRANSFER: 'ERC20_TRANSFER',
+  ETHER_TRANSFER: 'ETHER_TRANSFER',
+}
 
 export type IncomingTransactionProps = {
   blockNumber: number,


### PR DESCRIPTION
This PR works on the requirement stated on https://github.com/gnosis/safe-react/pull/799#issuecomment-619045019, by:

- Creating a common function to format values for incoming and outgoing txs (https://github.com/gnosis/safe-react/commit/e94a448de6e7ae551eecec92ec7b084dc8087b97, https://github.com/gnosis/safe-react/pull/812/commits/a9bde84fa0237ed6bc62253b766c3d19bb00a0d6)
- Displaying unformatted value in the tx detailed view (https://github.com/gnosis/safe-react/commit/9a18d1d9f8a823291cf972c0acf3447e98878537)
- Making a few improvements around the Incoming Txs:
  - No more `Nonce` label in the details (https://github.com/gnosis/safe-react/commit/d45199bef0494bc07197f0d72fd11e0f264a2955)
  - Properly formatting amount column in the overview (https://github.com/gnosis/safe-react/commit/de35e6b9169bedef0614e10f227e00a52c0befd5, https://github.com/gnosis/safe-react/commit/8d294c5ee960078abf6e0dec9ac08a942a34df43)
- Remove trailing zeros from exact zero values (https://github.com/gnosis/safe-react/pull/812/commits/d9e8f80c891180f0cf0bc6f7eb4c4359d7e76137)
- Fixing Outgoing txs `symbol` for known tokens (https://github.com/gnosis/safe-react/pull/812/commits/05c8ea1ba4bd695faa2879b5b8eea5f245f7dce0)
- Fixing `decimals` value used for `fee` calculation (this looks like so far not used, and there's  a new `fee` field in the object returned by the backend that we can use) (https://github.com/gnosis/safe-react/pull/812/commits/a5b9f8e56f3f3b59432bb0561771c51db4632d27)