### PR TITLE
Feature/desktop logs

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -129,13 +129,17 @@ function createWindow() {
     autoUpdater.init(mainWindow);
   });
 
-  mainWindow.webContents.on('crashed', () => {
-    log.info('App Crashed');
+  mainWindow.webContents.on('crashed', (event) => {
+    log.info(`App Crashed: ${event}`);
     mainWindow.reload();
   });
 
   mainWindow.on("closed", () => (mainWindow = null));
 }
+
+process.on('uncaughtException',function(error){
+  log.error(error);
+});
 
 app.userAgentFallback = process.platform ==='win32' ?
 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.100 Safari/537.36' :

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -2,11 +2,21 @@
 // It has the same sandbox as a Chrome extension.
 
 const TransportNodeHid = require("@ledgerhq/hw-transport-node-hid").default;
+const log = require('electron-log');
 window.TransportNodeHid = TransportNodeHid;
 
 window.isDesktop = true;
 
 window.addEventListener('DOMContentLoaded', () => {
+  console.error = (...args) => {
+    log.error(...args)
+  }
+  console.warn = (...args) => {
+    log.warn(...args)
+  }
+  console.log = (...args) => {
+    log.info(...args)
+  }
   const replaceText = (selector, text) => {
     const element = document.getElementById(selector)
     if (element) element.innerText = text


### PR DESCRIPTION
closes #857

By default, it writes logs to the following locations:
- on Linux: ~/.config/{app name}/logs/{process type}.log
- on macOS: ~/Library/Logs/{app name}/{process type}.log
- on Windows: %USERPROFILE%\AppData\Roaming\{app name}\logs\{process type}.log

process type: [main | renderer]