### PR TITLE
Bug: Stepper component non-transparent bg

### DIFF
--- a/src/theme/mui.ts
+++ b/src/theme/mui.ts
@@ -108,6 +108,7 @@ const theme = createMuiTheme({
     MuiStepper: {
       root: {
         padding: `${lg} 0 0 15px`,
+        background: 'transparent',
       },
     },
     MuiIconButton: {


### PR DESCRIPTION
In `safe-react-components` we do not have a custom mui theme so I included the fix there and not inside safe-react-components

**BEFORE:**
![image](https://user-images.githubusercontent.com/16622558/82656115-4189be00-9c34-11ea-9937-4efa048db4b6.png)


**AFTER:**
<img width="2316" alt="Screenshot 2020-05-22 at 13 57 06" src="https://user-images.githubusercontent.com/16622558/82656084-3040b180-9c34-11ea-8432-d11ccceebbb2.png">
