### PR TITLE
(Fix) Fix undefined for maxValue validator  in case there is no token selected

### DIFF
--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -59,7 +59,7 @@ export const minValue = (min: number | string) => (value: string) => {
 }
 
 export const maxValue = (max: number | string) => (value: string) => {
-  if (Number.isNaN(Number(value)) || parseFloat(value) <= parseFloat(max.toString())) {
+  if (!max || Number.isNaN(Number(value)) || parseFloat(value) <= parseFloat(max.toString())) {
     return undefined
   }
 

--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -58,12 +58,16 @@ export const minValue = (min: number | string) => (value: string) => {
   return `Should be at least ${min}`
 }
 
-export const maxValue = (max: number | string) => (value: string) => {
+export const maxValueCheck = (max: number | string, value: string): string | undefined => {
   if (!max || Number.isNaN(Number(value)) || parseFloat(value) <= parseFloat(max.toString())) {
     return undefined
   }
 
   return `Maximum value is ${max}`
+}
+
+export const maxValue = (max: number | string) => (value: string) => {
+  return maxValueCheck(max, value)
 }
 
 export const ok = () => undefined

--- a/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
@@ -88,6 +88,9 @@ const AddressBookInput = ({
         )
       })
       setADBKList(filteredADBK)
+      if (!isValidText) {
+        setSelectedEntry({ address: addressValue })
+      }
     }
     setIsValidForm(isValidText === undefined)
     setValidationText(isValidText)

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -17,7 +17,14 @@ import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
 import Field from 'src/components/forms/Field'
 import GnoForm from 'src/components/forms/GnoForm'
 import TextField from 'src/components/forms/TextField'
-import { composeValidators, greaterThan, maxValue, mustBeFloat, required } from 'src/components/forms/validator'
+import {
+  composeValidators,
+  greaterThan,
+  maxValue,
+  maxValueCheck,
+  mustBeFloat,
+  required,
+} from 'src/components/forms/validator'
 import Block from 'src/components/layout/Block'
 import Button from 'src/components/layout/Button'
 import ButtonLink from 'src/components/layout/ButtonLink'
@@ -56,6 +63,7 @@ const SendFunds = ({ initialValues, onClose, onNext, recipientAddress, selectedT
     address: recipientAddress || initialValues.recipientAddress,
     name: '',
   })
+
   const [pristine, setPristine] = useState(true)
   const [isValidAddress, setIsValidAddress] = useState(true)
 
@@ -86,7 +94,18 @@ const SendFunds = ({ initialValues, onClose, onNext, recipientAddress, selectedT
         </IconButton>
       </Row>
       <Hairline />
-      <GnoForm formMutators={formMutators} initialValues={initialValues} onSubmit={handleSubmit}>
+      <GnoForm
+        formMutators={formMutators}
+        initialValues={initialValues}
+        onSubmit={handleSubmit}
+        validation={(values) => {
+          const selectedTokenRecord = tokens.find((token) => token.address === values?.token)
+
+          return {
+            amount: maxValueCheck(selectedTokenRecord?.balance, values.amount),
+          }
+        }}
+      >
         {(...args) => {
           const formState = args[2]
           const mutators = args[3]
@@ -229,6 +248,10 @@ const SendFunds = ({ initialValues, onClose, onNext, recipientAddress, selectedT
                     />
                     <OnChange name="token">
                       {() => {
+                        setSelectedEntry({
+                          name: selectedEntry?.name,
+                          address: selectedEntry?.address,
+                        })
                         mutators.onTokenChange()
                       }}
                     </OnChange>

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -39,7 +39,7 @@ const formMutators = {
     utils.changeValue(state, 'amount', () => args[0])
   },
   onTokenChange: (args, state, utils) => {
-    utils.changeValue(state, 'amount', () => '')
+    utils.changeValue(state, 'amount', () => state.formState.values.amount)
   },
   setRecipient: (args, state, utils) => {
     utils.changeValue(state, 'recipientAddress', () => args[0])

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -220,7 +220,6 @@ const SendFunds = ({ initialValues, onClose, onNext, recipientAddress, selectedT
                       placeholder="Amount*"
                       text="Amount*"
                       type="text"
-                      disabled={!selectedTokenRecord}
                       validate={composeValidators(
                         required,
                         mustBeFloat,

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -220,11 +220,12 @@ const SendFunds = ({ initialValues, onClose, onNext, recipientAddress, selectedT
                       placeholder="Amount*"
                       text="Amount*"
                       type="text"
+                      disabled={!selectedTokenRecord}
                       validate={composeValidators(
                         required,
                         mustBeFloat,
                         greaterThan(0),
-                        maxValue(selectedTokenRecord && selectedTokenRecord.balance),
+                        maxValue(selectedTokenRecord?.balance),
                       )}
                     />
                     <OnChange name="token">


### PR DESCRIPTION
## Description
- Working on #1013 I found that was possible to add a value on the send funds modal without selecting an asset
![image](https://user-images.githubusercontent.com/21086218/85028077-07d3a680-b151-11ea-9d0c-e5ed13a7cb5f.png)

This prs fixs that by disabling the review button:
![image](https://user-images.githubusercontent.com/21086218/85028177-20dc5780-b151-11ea-96ac-26a9e6882640.png)
