### PR TITLE
Bug: 2.3.1 Outgoing transactions not showing

### DIFF
--- a/src/config/development-mainnet.ts
+++ b/src/config/development-mainnet.ts
@@ -1,11 +1,11 @@
 // 
-import devConfig from './development'
+import prodConfig from './production'
 import { TX_SERVICE_HOST, RELAY_API_URL } from 'src/config/names'
 
-const devMainnetConfig = {
-  ...devConfig,
-  [TX_SERVICE_HOST]: 'https://safe-transaction.mainnet.staging.gnosisdev.com/api/v1/',
-  [RELAY_API_URL]: 'https://safe-relay.mainnet.staging.gnosisdev.com/api/v1/',
+const prodMainnetConfig = {
+  ...prodConfig,
+  [TX_SERVICE_HOST]: 'https://safe-transaction.mainnet.gnosis.io/api/v1/',
+  [RELAY_API_URL]: 'https://safe-relay.gnosis.io/api/v1/',
 }
 
-export default devMainnetConfig
+export default prodMainnetConfig

--- a/src/config/development-mainnet.ts
+++ b/src/config/development-mainnet.ts
@@ -1,11 +1,11 @@
 // 
-import prodConfig from './production'
+import devConfig from './development'
 import { TX_SERVICE_HOST, RELAY_API_URL } from 'src/config/names'
 
-const prodMainnetConfig = {
-  ...prodConfig,
-  [TX_SERVICE_HOST]: 'https://safe-transaction.mainnet.gnosis.io/api/v1/',
-  [RELAY_API_URL]: 'https://safe-relay.gnosis.io/api/v1/',
+const devMainnetConfig = {
+  ...devConfig,
+  [TX_SERVICE_HOST]: 'https://safe-transaction.mainnet.staging.gnosisdev.com/api/v1/',
+  [RELAY_API_URL]: 'https://safe-relay.mainnet.staging.gnosisdev.com/api/v1/',
 }
 
-export default prodMainnetConfig
+export default devMainnetConfig

--- a/src/logic/tokens/utils/tokenHelpers.ts
+++ b/src/logic/tokens/utils/tokenHelpers.ts
@@ -1,4 +1,3 @@
-import memoize from 'lodash.memoize'
 import logo from 'src/assets/icons/icon_etherTokens.svg'
 import generateBatchRequests from 'src/logic/contracts/generateBatchRequests'
 import {
@@ -55,19 +54,17 @@ export const isSendERC721Transaction = (tx: any, txCode: string, knownTokens: an
   )
 }
 
-export const getERC721Symbol = memoize(
-  async (contractAddress: string): Promise<string> => {
-    let tokenSymbol = 'UNKNOWN'
-    try {
-      const ERC721token = await getERC721TokenContract()
-      const tokenInstance = await ERC721token.at(contractAddress)
-      tokenSymbol = tokenInstance.symbol()
-    } catch (err) {
-      console.error(`Failed to retrieve token symbol for ERC721 token ${contractAddress}`)
-    }
-    return tokenSymbol
-  },
-)
+export const getERC721Symbol = async (contractAddress: string): Promise<string> => {
+  let tokenSymbol = 'UNKNOWN'
+  try {
+    const ERC721token = await getERC721TokenContract()
+    const tokenInstance = await ERC721token.at(contractAddress)
+    tokenSymbol = tokenInstance.symbol()
+  } catch (err) {
+    console.error(`Failed to retrieve token symbol for ERC721 token ${contractAddress}`)
+  }
+  return tokenSymbol
+}
 
 export const getERC20DecimalsAndSymbol = async (
   tokenAddress: string,

--- a/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
+++ b/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
@@ -253,7 +253,17 @@ export const buildTx = async ({
   const refundParams = await getRefundParams(tx, getERC20DecimalsAndSymbol)
   const decodedParams = getDecodedParams(tx)
   const confirmations = getConfirmations(tx)
-  const { decimals = 18, symbol = 'ETH' } = isSendERC20Tx ? await getERC20DecimalsAndSymbol(tx.to) : {}
+
+  let tokenDecimals = 18
+  let tokenSymbol = 'ETH'
+  if (isSendERC20Tx) {
+    const { decimals, symbol } = await getERC20DecimalsAndSymbol(tx.to)
+    tokenDecimals = decimals
+    tokenSymbol = symbol
+  } else if (isSendERC721Tx) {
+    const { symbol } = await getERC721Symbol(tx.to)
+    tokenSymbol = symbol
+  }
 
   const txToStore = makeTransaction({
     baseGas: tx.baseGas,
@@ -263,7 +273,7 @@ export const buildTx = async ({
     creationTx: tx.creationTx,
     customTx: isCustomTx,
     data: tx.data ? tx.data : EMPTY_DATA,
-    decimals,
+    decimals: tokenDecimals,
     decodedParams,
     executionDate: tx.executionDate,
     executionTxHash: tx.transactionHash,
@@ -286,7 +296,7 @@ export const buildTx = async ({
     safeTxGas: tx.safeTxGas,
     safeTxHash: tx.safeTxHash,
     submissionDate: tx.submissionDate,
-    symbol: isSendERC721Tx ? await getERC721Symbol(tx.to) : symbol,
+    symbol: tokenSymbol,
     upgradeTx: isUpgradeTx,
     value: tx.value.toString(),
   })

--- a/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
+++ b/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
@@ -256,13 +256,16 @@ export const buildTx = async ({
 
   let tokenDecimals = 18
   let tokenSymbol = 'ETH'
-  if (isSendERC20Tx) {
-    const { decimals, symbol } = await getERC20DecimalsAndSymbol(tx.to)
-    tokenDecimals = decimals
-    tokenSymbol = symbol
-  } else if (isSendERC721Tx) {
-    const { symbol } = await getERC721Symbol(tx.to)
-    tokenSymbol = symbol
+  try {
+    if (isSendERC20Tx) {
+      const { decimals, symbol } = await getERC20DecimalsAndSymbol(tx.to)
+      tokenDecimals = decimals
+      tokenSymbol = symbol
+    } else if (isSendERC721Tx) {
+      tokenSymbol = await getERC721Symbol(tx.to)
+    }
+  } catch (err) {
+    console.log(`Failed to retrieve token data from ${tx.to}`)
   }
 
   const txToStore = makeTransaction({


### PR DESCRIPTION
So the problem was that the safe included a contract interaction with ENS contract which implements `safeTransferFrom` method, but no proper ERC721 standard. Thus we were trying to get symbol for it and it returned an error which was uncatched.

This PR:
- Hardcode ens contract address to `isSendERC721Transaction`
- Wrap all methods getting token info with try/catch so it doesn't fail with tokens not implementing standard properly

Will create a follow up issue on how we can prevent this in the future