### PR TITLE
Bugfix: Txs symbols decoding

### DIFF
--- a/src/logic/tokens/store/actions/fetchTokens.ts
+++ b/src/logic/tokens/store/actions/fetchTokens.ts
@@ -9,7 +9,7 @@ import saveTokens from './saveTokens'
 
 import generateBatchRequests from 'src/logic/contracts/generateBatchRequests'
 import { fetchTokenList } from 'src/logic/tokens/api'
-import { makeToken } from 'src/logic/tokens/store/model/token'
+import { makeToken, Token } from 'src/logic/tokens/store/model/token'
 import { tokensSelector } from 'src/logic/tokens/store/selectors'
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { store } from 'src/store'
@@ -57,7 +57,7 @@ const getTokenValues = (tokenAddress) =>
     methods: ['decimals', 'name', 'symbol'],
   })
 
-export const getTokenInfos = async (tokenAddress) => {
+export const getTokenInfos = async (tokenAddress: string): Promise<Token> => {
   if (!tokenAddress) {
     return null
   }

--- a/src/routes/safe/store/actions/transactions/fetchTransactions/loadOutgoingTransactions.ts
+++ b/src/routes/safe/store/actions/transactions/fetchTransactions/loadOutgoingTransactions.ts
@@ -66,7 +66,7 @@ export type OutgoingTxs = {
 
 export type BatchProcessTxsProps = OutgoingTxs & {
   currentUser?: string
-  knownTokens: Record<string, Token>
+  knownTokens: Map<string, Token>
   safe: SafeRecord
 }
 

--- a/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
+++ b/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
@@ -85,7 +85,7 @@ export const isCustomTransaction = async (
   tx: TxServiceModel,
   txCode: string,
   safeAddress: string,
-  knownTokens: Record<string, Token>,
+  knownTokens: Map<string, Token>,
 ): Promise<boolean> => {
   return (
     isOutgoingTransaction(tx, safeAddress) &&
@@ -340,7 +340,7 @@ export const mockTransaction = (tx: TxToMock, safeAddress: string, state): Promi
     ...tx,
   }
 
-  const knownTokens: Record<string, Token> = state[TOKEN_REDUCER_ID]
+  const knownTokens: Map<string, Token> = state[TOKEN_REDUCER_ID]
   const safe: SafeRecord = state[SAFE_REDUCER_ID].getIn([SAFE_REDUCER_ID, safeAddress])
   const cancellationTxs = state[CANCELLATION_TRANSACTIONS_REDUCER_ID].get(safeAddress) || Map()
   const outgoingTxs = state[TRANSACTIONS_REDUCER_ID].get(safeAddress) || List()


### PR DESCRIPTION
Related to #1068 

## Description
- There was a problem with different safes in which the symbols of the tokens where not displayed. 
- After some research we found that this [PR](https://github.com/gnosis/safe-react/pull/1067) was related, basically and else condition was missing when checking if storedTokenInfo was null and then we were just returning the default value, this adds that condition

Before:
![image](https://user-images.githubusercontent.com/21086218/86497920-e6caa280-bd59-11ea-8818-57775bdeacf0.png)

After:
![image](https://user-images.githubusercontent.com/21086218/86497935-f2b66480-bd59-11ea-9760-5a368a97dae1.png)

cc: @fernandomg @pablofullana 