### PR TITLE
Bug 2.5.1: Can't execute a transaction if one of the previous transactions was empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/routes/safe/store/actions/transactions/fetchTransactions/loadOutgoingTransactions.ts
+++ b/src/routes/safe/store/actions/transactions/fetchTransactions/loadOutgoingTransactions.ts
@@ -79,7 +79,10 @@ export type BatchProcessTxsProps = OutgoingTxs & {
 const extractCancelAndOutgoingTxs = (safeAddress: string, outgoingTxs: TxServiceModel[]): OutgoingTxs => {
   return outgoingTxs.reduce(
     (acc, transaction) => {
-      if (isCancelTransaction(transaction, safeAddress)) {
+      if (
+        isCancelTransaction(transaction, safeAddress) &&
+        outgoingTxs.find((tx) => tx.nonce === transaction.nonce && !isCancelTransaction(tx, safeAddress))
+      ) {
         if (!isNaN(Number(transaction.nonce))) {
           acc.cancellationTxs[transaction.nonce] = transaction
         }


### PR DESCRIPTION
Currently the interface treats every empty transaction as a cancellation, which is not true. Even if there's no transaction for the "cancellation" transaction to cancel, it wouldn't display it in the transactions table. This PR fixes it by checking if there's a pending transaction to actually cancel

TODO: 
- Fix the label (currently an empty transaction is shown as cancellation transaction). Let's address this in the new transactions UI