### PR TITLE
fix: show tx data for txs with decoded params

### DIFF
--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/utils.ts
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/utils.ts
@@ -54,6 +54,8 @@ export const getTxData = (tx) => {
       txData.customTx = true
     } else {
       txData.recipient = tx.recipient
+      txData.data = tx.data
+      txData.customTx = true
     }
   } else if (tx.customTx) {
     txData.recipient = tx.recipient


### PR DESCRIPTION
There is no tx data shown for transactions with `decodedParams` and thus such txs are impossible to verify before signing. 

For instance, this is how the `ERC20.approve` function call looks like in our Safe:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/163447/87393712-3eb5a480-c5b7-11ea-8395-45387138cf8c.png">

This PR suggests a quick fix to show raw hex data for such transactions. 

NB: I have [a code](https://github.com/leapdao/leap-safe/commit/e9bb55b7849755f260ee71bc53edb66f70b17db3) which displays decoded params as well, but I've noticed you have some work already going in this direction — let me know if it still worth a PR.