### PR TITLE
Allow HX values

### DIFF
--- a/src/routes/safe/components/Apps/confirmTransactions.tsx
+++ b/src/routes/safe/components/Apps/confirmTransactions.tsx
@@ -63,7 +63,7 @@ const isTxValid = (t: SafeAppTx): boolean => {
     return false
   }
 
-  if (typeof t.value === 'string' && !/^\d+$/.test(t.value)) {
+  if (typeof t.value === 'string' && !/^(0x)?[0-9a-f]+$/i.test(t.value)) {
     return false
   }
 


### PR DESCRIPTION
It was working for ETC20 tokens because the value was encoded in the data field.