### PR TITLE
Fix: Standardized modal alignment settings

### DIFF
--- a/src/routes/safe/components/AddressBook/CreateEditEntryModal/style.ts
+++ b/src/routes/safe/components/AddressBook/CreateEditEntryModal/style.ts
@@ -22,6 +22,5 @@ export const styles = () => ({
   },
   smallerModalWindow: {
     height: 'auto',
-    position: 'static',
   },
 })

--- a/src/routes/safe/components/AddressBook/DeleteEntryModal/style.ts
+++ b/src/routes/safe/components/AddressBook/DeleteEntryModal/style.ts
@@ -29,6 +29,5 @@ export const styles = () => ({
   },
   smallerModalWindow: {
     height: 'auto',
-    position: 'static',
   },
 })

--- a/src/routes/safe/components/Balances/SendModal/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/index.tsx
@@ -29,7 +29,6 @@ const useStyles = makeStyles({
   },
   scalableStaticModalWindow: {
     height: 'auto',
-    position: 'static',
   },
   loaderStyle: {
     height: '500px',

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/index.tsx
@@ -21,7 +21,6 @@ const styles = () => ({
   biggerModalWindow: {
     width: '775px',
     minHeight: '500px',
-    position: 'static',
     height: 'auto',
   },
 })

--- a/src/routes/safe/components/Settings/ManageOwners/EditOwnerModal/style.ts
+++ b/src/routes/safe/components/Settings/ManageOwners/EditOwnerModal/style.ts
@@ -33,6 +33,5 @@ export const styles = () => ({
   },
   smallerModalWindow: {
     height: 'auto',
-    position: 'static',
   },
 })

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/index.tsx
@@ -23,7 +23,6 @@ const styles = () => ({
   biggerModalWindow: {
     width: '775px',
     minHeight: '500px',
-    position: 'static',
     height: 'auto',
   },
 })

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/index.tsx
@@ -19,7 +19,6 @@ const styles = () => ({
   biggerModalWindow: {
     width: '775px',
     minHeight: '500px',
-    position: 'static',
     height: 'auto',
   },
 })


### PR DESCRIPTION
Closes #1147 
Now all modals have the same alignment settings (120px from top navbar).

![Screenshot from 2020-07-24 14-25-41](https://user-images.githubusercontent.com/622217/88418551-18afb180-cdba-11ea-878b-acce44f8d18e.png)
![Screenshot from 2020-07-24 14-26-05](https://user-images.githubusercontent.com/622217/88418549-177e8480-cdba-11ea-9664-7ddf945af57c.png)


Maybe we have to think to implement Generic Modal from [safe-react-component](https://components.gnosis-safe.io/?path=/docs/utils-modals-generic--modal).