### PR TITLE
(Fix) Prevent accessing `contentWindow` if `iframe` is `null`

### DIFF
--- a/src/routes/safe/components/Apps/index.tsx
+++ b/src/routes/safe/components/Apps/index.tsx
@@ -226,9 +226,9 @@ function Apps({ closeModal, closeSnackbar, enqueueSnackbar, openModal }) {
   const sendMessageToIframe = useCallback(
     (messageId, data) => {
       const app = getSelectedApp()
-      iframeEl.contentWindow.postMessage({ messageId, data }, app.url)
+      iframeEl?.contentWindow.postMessage({ messageId, data }, app.url)
     },
-    [getSelectedApp, iframeEl.contentWindow],
+    [getSelectedApp, iframeEl],
   )
 
   // handle messages from iframe


### PR DESCRIPTION
This PR solves the issue in `development` that prevents the app from starting up

![image](https://user-images.githubusercontent.com/3315606/88432603-e5c5e780-cdd2-11ea-8a39-e96a5f1fc237.png)
