### PR TITLE
BUG 1192: Set inclusive false for minValue validator in sendfunds form

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -240,7 +240,7 @@ const SendFunds = ({ initialValues, onClose, onNext, recipientAddress, selectedT
                       validate={composeValidators(
                         required,
                         mustBeFloat,
-                        minValue(0),
+                        minValue(0, false),
                         maxValue(selectedTokenRecord?.balance),
                       )}
                     />


### PR DESCRIPTION
This PR:
- Fixes https://github.com/gnosis/safe-react/issues/1192 by setting inclusive param to false for minValue validator in send funds form