### PR TITLE
Allow `tx.operation` to enable usage of layered multiSend

### DIFF
--- a/src/routes/safe/components/Apps/sendTransactions.ts
+++ b/src/routes/safe/components/Apps/sendTransactions.ts
@@ -22,7 +22,7 @@ const sendTransactions = (dispatch, safeAddress, txs, enqueueSnackbar, closeSnac
   const joinedTxs = txs
     .map((tx) =>
       [
-        web3.eth.abi.encodeParameter('uint8', 0).slice(-2),
+        web3.eth.abi.encodeParameter('uint8', tx.operation || 0).slice(-2),
         web3.eth.abi.encodeParameter('address', tx.to).slice(-40),
         web3.eth.abi.encodeParameter('uint256', tx.value).slice(-64),
         web3.eth.abi.encodeParameter('uint256', web3.utils.hexToBytes(tx.data).length).slice(-64),


### PR DESCRIPTION
# Description
When using a multiSend transaction with the [safe-apps-sdk](https://github.com/gnosis/safe-apps-sdk/) the transaction can't succeed because MultiSend transactions can only be executed as `DELEGATE_CALL`s this makes it impossible to send transactions working with multiSend. This is unfortunately a blocker for the CMM.

