### PR TITLE
(Hotfix) Update Balancer Pool IPFS URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -23,7 +23,7 @@ export const staticAppsList: Array<{ url: string; disabled: boolean }> = [
   //Balancer Exchange
   { url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmfPLXne1UrY399RQAcjD1dmBhQrPGZWgp311CDLLW3VTn`, disabled: false },
   //Balancer Pool
-  { url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmSiUgsYQE6y4ADZQtKuVCwszvUeeHnaRc7kmQMZRiF4ZH`, disabled: false },
+  { url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmaTucdZYLKTqaewwJduVMM8qfCDhyaEqjd8tBNae26K1J`, disabled: false },
   // Compound
   { url: `${gnosisAppsUrl}/compound`, disabled: false },
   // Idle


### PR DESCRIPTION
This hotfix closes #1262, by:

- updating the Balancer Pool URL
- also setting the Safe's version to `2.10.1`