### PR TITLE
(Feature) [Spending Limits] Transaction List details

### DIFF
--- a/src/routes/safe/components/Settings/SpendingLimit/txsDetails/NewSpendingLimitDetails.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/txsDetails/NewSpendingLimitDetails.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import Block from 'src/components/layout/Block'
+import Col from 'src/components/layout/Col'
+import { RESET_TIME_OPTIONS } from 'src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime'
+import useToken from 'src/routes/safe/components/Settings/SpendingLimit/hooks/useToken'
+import { AddressInfo, ResetTimeInfo, TokenInfo } from 'src/routes/safe/components/Settings/SpendingLimit/InfoDisplay'
+import { fromTokenUnit } from 'src/routes/safe/components/Settings/SpendingLimit/utils'
+import { useStyles } from 'src/routes/safe/components/Settings/SpendingLimit/style'
+
+interface TxDetailsProps {
+  amount: string
+  beneficiary: string
+  resetTimeMin: string
+  tokenAddress: string
+}
+
+const NewSpendingLimitDetails = ({
+  amount,
+  beneficiary,
+  resetTimeMin,
+  tokenAddress,
+}: TxDetailsProps): React.ReactElement => {
+  const classes = useStyles()
+  const resetTimeLabel = React.useMemo(
+    () => RESET_TIME_OPTIONS.find(({ value }) => +value === +resetTimeMin / 24 / 60)?.label ?? '',
+    [resetTimeMin],
+  )
+  const tokenInfo = useToken(tokenAddress)
+
+  return (
+    <Block className={classes.container}>
+      <Col margin="lg">
+        <AddressInfo title="Beneficiary" address={beneficiary} />
+      </Col>
+      <Col margin="lg">
+        {tokenInfo && <TokenInfo amount={fromTokenUnit(amount, tokenInfo.decimals)} title="Amount" token={tokenInfo} />}
+      </Col>
+      <Col margin="lg">
+        <ResetTimeInfo title="Reset Time" label={resetTimeLabel} />
+      </Col>
+    </Block>
+  )
+}
+
+export default NewSpendingLimitDetails

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/CustomDescription.tsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/CustomDescription.tsx
@@ -42,6 +42,7 @@ const InlineText = styled(Text)`
 `
 const TxDetailsContent = styled.div`
   padding: 8px 8px 8px 16px;
+  overflow-wrap: break-word;
 `
 
 const TxInfo = styled.div`

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.tsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.tsx
@@ -1,53 +1,51 @@
 import { makeStyles } from '@material-ui/core/styles'
 import React from 'react'
 
-import { styles } from './styles'
-import { getTxData } from './utils'
-import SettingsDescription from './SettingsDescription'
-import CustomDescription from './CustomDescription'
-import TransferDescription from './TransferDescription'
-
-import { getTxAmount } from 'src/routes/safe/components/Transactions/TxsTable/columns'
 import Block from 'src/components/layout/Block'
-import { Transaction } from 'src/logic/safe/store/models/types/transaction'
+import { Transaction, TransactionTypes } from 'src/logic/safe/store/models/types/transaction'
+import { getTxAmount } from 'src/routes/safe/components/Transactions/TxsTable/columns'
+
+import CustomDescription from './CustomDescription'
+import SettingsDescription from './SettingsDescription'
+import { styles } from './styles'
+import TransferDescription from './TransferDescription'
+import { getTxData } from './utils'
 
 export const TRANSACTIONS_DESC_SEND_TEST_ID = 'tx-description-send'
 
 const useStyles = makeStyles(styles)
 
+const SettingsDescriptionTx = ({ tx }: { tx: Transaction }): React.ReactElement => {
+  const { action, addedOwner, module, newThreshold, removedOwner } = getTxData(tx)
+  return <SettingsDescription {...{ action, addedOwner, module, newThreshold, removedOwner }} />
+}
+
+const CustomDescriptionTx = ({ tx }: { tx: Transaction }): React.ReactElement => {
+  const amount = getTxAmount(tx, false)
+  const { data, recipient } = getTxData(tx)
+  return <CustomDescription {...{ amount, data, recipient }} storedTx={tx} />
+}
+
+const UpgradeDescriptionTx = ({ tx }: { tx: Transaction }): React.ReactElement => {
+  const { data } = getTxData(tx)
+  return <div>{data}</div>
+}
+
+const TransferDescriptionTx = ({ tx }: { tx: Transaction }): React.ReactElement => {
+  const amount = getTxAmount(tx, false)
+  const { recipient } = getTxData(tx)
+  return <TransferDescription {...{ amount, recipient }} />
+}
+
 const TxDescription = ({ tx }: { tx: Transaction }): React.ReactElement => {
   const classes = useStyles()
-  const {
-    action,
-    addedOwner,
-    cancellationTx,
-    creationTx,
-    customTx,
-    data,
-    modifySettingsTx,
-    module,
-    newThreshold,
-    recipient,
-    removedOwner,
-    upgradeTx,
-  }: any = getTxData(tx)
-  const amount = getTxAmount(tx, false)
+
   return (
     <Block className={classes.txDataContainer}>
-      {modifySettingsTx && action && (
-        <SettingsDescription
-          action={action}
-          addedOwner={addedOwner}
-          newThreshold={newThreshold}
-          removedOwner={removedOwner}
-          module={module}
-        />
-      )}
-      {!upgradeTx && customTx && <CustomDescription amount={amount} data={data} recipient={recipient} storedTx={tx} />}
-      {upgradeTx && <div>{data}</div>}
-      {!cancellationTx && !modifySettingsTx && !customTx && !creationTx && !upgradeTx && (
-        <TransferDescription amount={amount} recipient={recipient} />
-      )}
+      {tx.type === TransactionTypes.SETTINGS && <SettingsDescriptionTx tx={tx} />}
+      {tx.type === TransactionTypes.CUSTOM && <CustomDescriptionTx tx={tx} />}
+      {tx.type === TransactionTypes.UPGRADE && <UpgradeDescriptionTx tx={tx} />}
+      {[TransactionTypes.TOKEN, TransactionTypes.COLLECTIBLE].includes(tx.type) && <TransferDescriptionTx tx={tx} />}
     </Block>
   )
 }

--- a/src/routes/safe/store/actions/transactions/utils/multiSendDecodedDetails.ts
+++ b/src/routes/safe/store/actions/transactions/utils/multiSendDecodedDetails.ts
@@ -19,7 +19,8 @@ import { Transaction } from 'src/logic/safe/store/models/types/transaction'
 export type MultiSendDetails = {
   operation: keyof typeof Operation
   to: string
-  data: DataDecoded | null
+  decodedData: DataDecoded | null
+  data: string | null
   value: number
 }
 
@@ -48,7 +49,8 @@ export const extractMultiSendDetails = (parameter: Parameter): MultiSendDetails[
         operation: decodedValue.operation,
         to: decodedValue.to,
         value: decodedValue.value,
-        data: decodedValue?.decodedData ?? null,
+        decodedData: decodedValue?.decodedData ?? null,
+        data: decodedValue?.data ?? null,
       }
     })
   }


### PR DESCRIPTION
This PR closes #691, by:

- identifying and displaying tx details for Spending Limit txs

<kbd><img src="https://user-images.githubusercontent.com/3315606/91106192-7436be80-e648-11ea-8223-a1a2ce48bd37.gif" width="550" /></kbd>


- also displays hex data for those txs that don't have decodedData and wraps its content to avoid overflow of text: 
<kbd><img src="https://user-images.githubusercontent.com/3315606/91106165-64b77580-e648-11ea-8686-1650e03a0dc8.png" width="480" /></kbd>


Still WIP (it depends on #1039)