### PR TITLE
Long values break Transaction decoding UI

### DIFF
--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/CustomDescription.tsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/CustomDescription.tsx
@@ -36,9 +36,7 @@ const TxDetailsMethodName = styled(Text)`
 `
 const TxDetailsMethodParam = styled.div`
   text-indent: 8px;
-`
-const InlineText = styled(Text)`
-  display: inline-flex;
+  display: flex;
 `
 const TxDetailsContent = styled.div`
   padding: 8px 8px 8px 16px;
@@ -56,9 +54,9 @@ const TxInfoDetails = ({ data }: { data: DataDecoded }): React.ReactElement => (
 
     {data.parameters.map((param, index) => (
       <TxDetailsMethodParam key={`${data.method}_param-${index}`}>
-        <InlineText size="lg" strong>
+        <Text size="lg" strong>
           {param.name}({param.type}):
-        </InlineText>
+        </Text>
         <Value method={data.method} type={param.type} value={param.value} />
       </TxDetailsMethodParam>
     ))}

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/Value.tsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/Value.tsx
@@ -14,12 +14,12 @@ import SafeEtherscanLink from 'src/components/EtherscanLink'
 
 const useStyles = makeStyles(styles)
 
-const InlineText = styled(Text)`
-  display: inline-flex;
-`
-
 const NestedWrapper = styled.div`
   text-indent: 24px;
+`
+
+const StyledText = styled(Text)`
+  white-space: normal;
 `
 
 interface RenderValueProps {
@@ -61,15 +61,15 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
     return (
       <NestedWrapper>
         {(value as string[]).map((value, index) => (
-          <Text key={`${method}-value-${index}`} size="lg">
+          <StyledText key={`${method}-value-${index}`} size="lg">
             {value}
-          </Text>
+          </StyledText>
         ))}
       </NestedWrapper>
     )
   }
 
-  return <InlineText size="lg">{value as string}</InlineText>
+  return <StyledText size="lg">{value as string}</StyledText>
 }
 
 const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {


### PR DESCRIPTION
I had to mock a long value. The result is like so:

![image](https://user-images.githubusercontent.com/4376509/91338500-6ea5b980-e7ab-11ea-99e4-e5d77a65b59f.png)

Once it's merged, we can re-test on staging. 
