### PR TITLE
Bug: incoming transactions do not load if it fails to fetch gas for a transaction

### DIFF
--- a/src/logic/contracts/generateBatchRequests.ts
+++ b/src/logic/contracts/generateBatchRequests.ts
@@ -10,8 +10,9 @@ import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
  * @param {array<{ args: [any], method: string, type: 'eth'|undefined } | string>} args.methods - methods to be called
  * @returns {Promise<[*]>}
  */
-const generateBatchRequests = ({ abi, address, batch = new web3.BatchRequest() , context, methods }: any): any => {
+const generateBatchRequests = ({ abi, address, batch, context, methods }: any): any => {
   const contractInstance: any = new web3.eth.Contract(abi, address)
+  const localBatch = new web3.BatchRequest()
 
   const values = methods.map((methodObject) => {
     let method, type, args = []
@@ -39,14 +40,14 @@ const generateBatchRequests = ({ abi, address, batch = new web3.BatchRequest() ,
           request = contractInstance.methods[method](...args).call.request(resolver)
         }
 
-        batch.add(request)
+        batch ? batch.add(request) : localBatch.add(request)
       } catch (e) {
         resolve(null)
       }
     })
   })
 
-  batch.execute()
+  !batch && localBatch.execute()
 
   const returnValues = context ? [context, ...values] : values
 

--- a/src/logic/safe/store/actions/transactions/fetchTransactions/loadIncomingTransactions.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/loadIncomingTransactions.ts
@@ -59,11 +59,11 @@ const batchIncomingTxsTokenDataRequest = (txs: IncomingTxServiceModel[]) => {
   batch.execute()
 
   return Promise.all(whenTxsValues).then((txsValues) =>
-    txsValues.map(([tx, symbol, decimals, gasInfo]) => [
+    txsValues.map(([tx, symbol, decimals, { gas, gasPrice }]) => [
       tx,
       symbol === null ? 'ETH' : symbol,
       decimals === null ? '18' : decimals,
-      gasInfo ? new bn(gasInfo.gas).div(gasInfo.gasPrice).toFixed() : 0,
+      new bn(gas).div(gasPrice).toFixed(),
     ]),
   )
 }

--- a/src/logic/safe/store/actions/transactions/fetchTransactions/loadIncomingTransactions.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/loadIncomingTransactions.ts
@@ -59,11 +59,11 @@ const batchIncomingTxsTokenDataRequest = (txs: IncomingTxServiceModel[]) => {
   batch.execute()
 
   return Promise.all(whenTxsValues).then((txsValues) =>
-    txsValues.map(([tx, symbol, decimals, { gas, gasPrice }]) => [
+    txsValues.map(([tx, symbol, decimals, gasInfo]) => [
       tx,
       symbol === null ? 'ETH' : symbol,
       decimals === null ? '18' : decimals,
-      new bn(gas).div(gasPrice).toFixed(),
+      gasInfo ? new bn(gasInfo.gas).div(gasInfo.gasPrice).toFixed() : 0,
     ]),
   )
 }


### PR DESCRIPTION
Dani recently spot this error on this rinkeby safe 0x32d6F7bf55b6692E0d16bFB26317b7D36b494f4a

![Screenshot from 2020-09-04 17 02 45](https://user-images.githubusercontent.com/16622558/92242700-3f8cf780-eed1-11ea-997c-e8b3f0cb3c02.png)

It failed to request gas used by a transaction and then a destructure statement was used on a null value. This PR checks if the returned values are valid