### PR TITLE
(Fix) Recipient address used as name as well

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
@@ -108,10 +108,20 @@ const AddressBookInput = ({
       })
       setADBKList(filteredADBK)
       if (!addressErrorMessage) {
-        setSelectedEntry({
-          name: normalizedAddress,
-          address: resolvedAddress,
-        })
+        // if address is valid, and is in the address book, then we use the stored values
+        if (filteredADBK.length === 1) {
+          const addressBookContact = filteredADBK[0]
+          setSelectedEntry({
+            name: addressBookContact.name ?? '',
+            address: addressBookContact.address ?? resolvedAddress,
+          })
+        } else {
+          // if address is valid, but does not exist in the address book, we just set the address
+          setSelectedEntry({
+            name: '',
+            address: resolvedAddress,
+          })
+        }
       }
     }
     setIsValidForm(addressErrorMessage === undefined)

--- a/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
@@ -103,7 +103,7 @@ const AddressBookInput = ({
         const { address, name } = adbkEntry
         return (
           name.toLowerCase().includes(normalizedAddress.toLowerCase()) ||
-          address.toLowerCase().includes(normalizedAddress.toLowerCase())
+          address.toLowerCase().includes(resolvedAddress.toLowerCase())
         )
       })
       setADBKList(filteredADBK)

--- a/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
@@ -108,20 +108,20 @@ const AddressBookInput = ({
       })
       setADBKList(filteredADBK)
       if (!addressErrorMessage) {
+        // base case if isENSDomain we set the domain as the name
+        // if address does not exist in address book we use blank name
+        let addressName = isENSDomain ? normalizedAddress : ''
+
         // if address is valid, and is in the address book, then we use the stored values
         if (filteredADBK.length === 1) {
           const addressBookContact = filteredADBK[0]
-          setSelectedEntry({
-            name: addressBookContact.name ?? '',
-            address: addressBookContact.address ?? resolvedAddress,
-          })
-        } else {
-          // if address is valid, but does not exist in the address book, we just set the address
-          setSelectedEntry({
-            name: '',
-            address: resolvedAddress,
-          })
+          addressName = addressBookContact.name ?? ''
         }
+
+        setSelectedEntry({
+          name: addressName,
+          address: resolvedAddress,
+        })
       }
     }
     setIsValidForm(addressErrorMessage === undefined)

--- a/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
@@ -115,7 +115,7 @@ const AddressBookInput = ({
         // if address is valid, and is in the address book, then we use the stored values
         if (filteredADBK.length === 1) {
           const addressBookContact = filteredADBK[0]
-          addressName = addressBookContact.name ?? ''
+          addressName = addressBookContact.name ?? addressName
         }
 
         setSelectedEntry({


### PR DESCRIPTION
This PR closes #1386, by preventing the use of the eth address as `name`. And by extracting the contract information from the Address Book if it exist.

Note: despite this fixes the issue. I think we should review the whole `AddressBookInput` component, as its growing big and hard to maintain.