### PR TITLE
Make getExplorerInfo return values per network

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -151,15 +151,15 @@ export type BlockScanInfo = () => {
 
 export const getExplorerInfo = (hash: string): BlockScanInfo => {
   const { name, url } = getNetworkExplorerInfo()
+  const networkInfo = getNetworkInfo()
 
-  const blockScanInfo = () => {
-    const type = hash.length > 42 ? 'tx' : 'address'
-
-    return  {
-      url: `${url}${type}/${hash}`,
-      alt:  name || '',
-    }
+  switch (networkInfo.id) {
+    default: {
+      const type = hash.length > 42 ? 'tx' : 'address'  
+      return () => ({
+        url: `${url}${type}/${hash}`,
+        alt:  name || '',
+      })
+    }      
   }
-
-  return blockScanInfo
 }


### PR DESCRIPTION
In a discussion related to how to deal with `getExplorerInfo` (it's a function that returns the explorer URL to inspect an address or transaction). Pablo and I suggested that we should have a separate file in order to define all the functions that should handle a particular case depending on the current network. 

The intention was that at the moment of creating a new network, a developer should go to `src/config` folder and replicate all the existing files with the new network. Giving it a second thought I think it is an overkill, at the moment `getExplorerInfo` it's the only function that needs a special treatment depending on the network.

Another alternative is to create another file `utils.ts (?)` where we can handle all these particular cases, but we will end having an index.ts and a utils.ts where won't be crystal what's the purpose of each one.

What I suggest to do is to make a little refactor in the current ` getExplorerInfo`.  That's what this PR does. 
