### PR TITLE
(Fix) "Approve transaction" modal closes

### DIFF
--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -24,6 +24,14 @@ const Balances = React.lazy(() => import('../components/Balances'))
 const TxsTable = React.lazy(() => import('src/routes/safe/components/Transactions/TxsTable'))
 const AddressBookTable = React.lazy(() => import('src/routes/safe/components/AddressBook'))
 
+const featuresEqualityFn = (left, right) => {
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return JSON.stringify(left) === JSON.stringify(right)
+  }
+
+  return left === right
+}
+
 const Container = (): React.ReactElement => {
   const [modal, setModal] = useState({
     isOpen: false,
@@ -35,7 +43,7 @@ const Container = (): React.ReactElement => {
 
   const safeAddress = useSelector(safeParamAddressFromStateSelector)
   const provider = useSelector(providerNameSelector)
-  const featuresEnabled = useSelector(safeFeaturesEnabledSelector)
+  const featuresEnabled = useSelector(safeFeaturesEnabledSelector, featuresEqualityFn)
   const matchSafeWithAddress = useRouteMatch<{ safeAddress: string }>({ path: `${SAFELIST_ADDRESS}/:safeAddress` })
   const safeAppsEnabled = Boolean(featuresEnabled?.includes(FEATURES.SAFE_APPS))
 

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -1,11 +1,12 @@
+import { GenericModal } from '@gnosis.pm/safe-react-components'
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
-import { GenericModal } from '@gnosis.pm/safe-react-components'
 
 import NoSafe from 'src/components/NoSafe'
 import { providerNameSelector } from 'src/logic/wallets/store/selectors'
 import { safeFeaturesEnabledSelector, safeParamAddressFromStateSelector } from 'src/logic/safe/store/selectors'
+import { AppReduxState } from 'src/store'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import { SAFELIST_ADDRESS } from 'src/routes/routes'
 import { FEATURES } from 'src/config/networks/network.d'
@@ -24,14 +25,6 @@ const Balances = React.lazy(() => import('../components/Balances'))
 const TxsTable = React.lazy(() => import('src/routes/safe/components/Transactions/TxsTable'))
 const AddressBookTable = React.lazy(() => import('src/routes/safe/components/AddressBook'))
 
-const featuresEqualityFn = (left, right) => {
-  if (Array.isArray(left) && Array.isArray(right)) {
-    return JSON.stringify(left) === JSON.stringify(right)
-  }
-
-  return left === right
-}
-
 const Container = (): React.ReactElement => {
   const [modal, setModal] = useState({
     isOpen: false,
@@ -43,7 +36,16 @@ const Container = (): React.ReactElement => {
 
   const safeAddress = useSelector(safeParamAddressFromStateSelector)
   const provider = useSelector(providerNameSelector)
-  const featuresEnabled = useSelector(safeFeaturesEnabledSelector, featuresEqualityFn)
+  const featuresEnabled = useSelector<AppReduxState, FEATURES[] | undefined>(
+    safeFeaturesEnabledSelector,
+    (left, right) => {
+      if (Array.isArray(left) && Array.isArray(right)) {
+        return JSON.stringify(left) === JSON.stringify(right)
+      }
+
+      return left === right
+    },
+  )
   const matchSafeWithAddress = useRouteMatch<{ safeAddress: string }>({ path: `${SAFELIST_ADDRESS}/:safeAddress` })
   const safeAppsEnabled = Boolean(featuresEnabled?.includes(FEATURES.SAFE_APPS))
 


### PR DESCRIPTION
This PR closes #1474, by:

- adding an equality function to the `useAction` hook for the featuresEnabled selector