### PR TITLE
Fix etherscan links

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -157,7 +157,7 @@ export const getExplorerInfo = (hash: string): BlockScanInfo => {
     default: {
       const type = hash.length > 42 ? 'tx' : 'address'  
       return () => ({
-        url: `${url}${type}/${hash}`,
+        url: `${url}/${type}/${hash}`,
         alt:  name || '',
       })
     }      


### PR DESCRIPTION
Etherscan links are not working properly. A / is missing on link creation funcion

Fixes #1495 