### PR TITLE
Fix development deployment to always use rinkeby network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ after_success:
   - yarn coveralls
 
 deploy:
-  # Development environment
+  # Development environment only on rinkeby
   - provider: s3
     bucket: $DEV_BUCKET_NAME
     access_key_id: $AWS_ACCESS_KEY_ID
@@ -83,6 +83,7 @@ deploy:
     region: $AWS_DEFAULT_REGION
     on:
       branch: development
+      condition: $REACT_APP_NETWORK = rinkeby
 
   # Staging environment
   - provider: s3
@@ -95,19 +96,6 @@ deploy:
     region: $AWS_DEFAULT_REGION
     on:
       branch: master
-  
-  # EWC testing on staging
-  - provider: s3
-    bucket: $STAGING_BUCKET_NAME
-    access_key_id: $AWS_ACCESS_KEY_ID
-    secret_access_key: $AWS_SECRET_ACCESS_KEY
-    skip_cleanup: true
-    local_dir: build
-    upload_dir: current/app
-    region: $AWS_DEFAULT_REGION
-    on:
-      branch: release/v2.14.0
-      condition: $REACT_APP_NETWORK = energy_web_chain
 
   # Prepare production deployment
   - provider: s3


### PR DESCRIPTION
When adding `Volta` to be deployed on PRs development environment could end up having Rinkeby or Volta version.

Ensure that only rinkeby version is deployed on development environment