### PR TITLE
(Fix) Remove the provider when the site is disconnected

### DIFF
--- a/src/components/ConnectButton/index.tsx
+++ b/src/components/ConnectButton/index.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import Button from 'src/components/layout/Button'
 import { getNetworkId } from 'src/config'
 import { getWeb3, setWeb3 } from 'src/logic/wallets/getWeb3'
-import { fetchProvider } from 'src/logic/wallets/store/actions'
+import { fetchProvider, removeProvider } from 'src/logic/wallets/store/actions'
 import transactionDataCheck from 'src/logic/wallets/transactionDataCheck'
 import { getSupportedWallets } from 'src/logic/wallets/utils/walletList'
 import { store } from 'src/store'
@@ -39,6 +39,7 @@ export const onboard = Onboard({
       if (!address && lastUsedAddress) {
         lastUsedAddress = ''
         providerName = undefined
+        store.dispatch(removeProvider())
       }
     },
   },


### PR DESCRIPTION
When a user disconnected the Safe from the wallet, the Safe didn't remove the provider leading to the error: `Provided address "" is invalid, the capitalization checksum test failed, or it's an indirect IBAN address which can't be converted.`

This PR solves that issue by disconnecting the provider when there's no address provided by the connected wallet.

![remove-provider](https://user-images.githubusercontent.com/3315606/98733392-36ac1c80-237f-11eb-80a0-5463b0cc3727.gif)
