### PR TITLE
(Fix) Native Coin transfer not shown

### DIFF
--- a/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
+++ b/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
@@ -63,12 +63,14 @@ export const EllipsisTransactionDetails = ({
       <div className={classes.container} role="menu" tabIndex={0}>
         <MoreHorizIcon onClick={handleClick} onKeyDown={handleClick} />
         <Menu anchorEl={anchorEl} id="simple-menu" keepMounted onClose={closeMenuHandler} open={Boolean(anchorEl)}>
-          {sendModalOpenHandler ? (
-            <>
-              <MenuItem onClick={sendModalOpenHandler}>Send Again</MenuItem>
-              <Divider />
-            </>
-          ) : null}
+          {sendModalOpenHandler
+            ? [
+                <MenuItem key="send-again-button" onClick={sendModalOpenHandler}>
+                  Send Again
+                </MenuItem>,
+                <Divider key="divider" />,
+              ]
+            : null}
           {knownAddress ? (
             <MenuItem onClick={addOrEditEntryHandler}>Edit Address book Entry</MenuItem>
           ) : (

--- a/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.tsx
+++ b/src/routes/safe/components/Transactions/TxsTable/ExpandedTx/TxDescription/index.tsx
@@ -45,7 +45,9 @@ const TxDescription = ({ tx }: { tx: Transaction }): React.ReactElement => {
       {tx.type === TransactionTypes.SETTINGS && <SettingsDescriptionTx tx={tx} />}
       {tx.type === TransactionTypes.CUSTOM && <CustomDescriptionTx tx={tx} />}
       {tx.type === TransactionTypes.UPGRADE && <UpgradeDescriptionTx tx={tx} />}
-      {[TransactionTypes.TOKEN, TransactionTypes.COLLECTIBLE].includes(tx.type) && <TransferDescriptionTx tx={tx} />}
+      {[TransactionTypes.TOKEN, TransactionTypes.COLLECTIBLE, TransactionTypes.OUTGOING].includes(tx.type) && (
+        <TransferDescriptionTx tx={tx} />
+      )}
     </Block>
   )
 }


### PR DESCRIPTION
This PR closes #1665, by displaying the "native coin" outgoing transactions.

Also, I ran into an error in the console when expanding the tx view:
![image](https://user-images.githubusercontent.com/3315606/100616019-3c9a7b00-32f7-11eb-85ad-f30859d4bed3.png)

I fixed that by replacing a react-fragment with an array, as it's suggested in the log.