### PR TITLE
Add types for redux actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "@types/react-dom": "^16.9.9",
     "@types/react-redux": "^7.1.11",
     "@types/react-router-dom": "^5.1.6",
+    "@types/redux-actions": "^2.6.1",
     "@types/styled-components": "^5.1.4",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",

--- a/src/logic/addressBook/store/actions/addAddressBookEntry.ts
+++ b/src/logic/addressBook/store/actions/addAddressBookEntry.ts
@@ -9,7 +9,7 @@ type addAddressBookEntryOptions = {
 
 export const addAddressBookEntry = createAction(
   ADD_ENTRY,
-  (entry: AddressBookEntry, options: addAddressBookEntryOptions) => {
+  (entry: AddressBookEntry, options?: addAddressBookEntryOptions) => {
     let notifyEntryUpdate = true
     if (options) {
       notifyEntryUpdate = options.notifyEntryUpdate

--- a/src/logic/addressBook/store/reducer/addressBook.ts
+++ b/src/logic/addressBook/store/reducer/addressBook.ts
@@ -1,11 +1,12 @@
-import { handleActions } from 'redux-actions'
+import { Action, handleActions } from 'redux-actions'
 
-import { AddressBookState, makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
+import { AddressBookEntry, AddressBookState, makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
 import { ADD_ENTRY } from 'src/logic/addressBook/store/actions/addAddressBookEntry'
 import { ADD_OR_UPDATE_ENTRY } from 'src/logic/addressBook/store/actions/addOrUpdateAddressBookEntry'
 import { LOAD_ADDRESS_BOOK } from 'src/logic/addressBook/store/actions/loadAddressBook'
 import { REMOVE_ENTRY } from 'src/logic/addressBook/store/actions/removeAddressBookEntry'
 import { UPDATE_ENTRY } from 'src/logic/addressBook/store/actions/updateAddressBookEntry'
+import { AppReduxState } from 'src/store'
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { getValidAddressBookName } from 'src/logic/addressBook/utils'
 
@@ -18,13 +19,19 @@ export const buildAddressBook = (storedAddressBook: AddressBookState): AddressBo
   })
 }
 
-export default handleActions(
+type AddressBookPayload = { addressBook: AddressBookState }
+type EntryPayload = { entry: AddressBookEntry }
+type RemoveEntryPayload = { entryAddress: string }
+
+type Payloads = AddressBookPayload | EntryPayload | RemoveEntryPayload
+
+export default handleActions<AppReduxState['addressBook'], Payloads>(
   {
-    [LOAD_ADDRESS_BOOK]: (state, action) => {
+    [LOAD_ADDRESS_BOOK]: (state, action: Action<AddressBookPayload>) => {
       const { addressBook } = action.payload
       return addressBook
     },
-    [ADD_ENTRY]: (state, action) => {
+    [ADD_ENTRY]: (state, action: Action<EntryPayload>) => {
       const { entry } = action.payload
 
       const entryFound = state.find((oldEntry) => oldEntry.address === entry.address)
@@ -34,7 +41,7 @@ export default handleActions(
       }
       return state
     },
-    [UPDATE_ENTRY]: (state, action) => {
+    [UPDATE_ENTRY]: (state, action: Action<EntryPayload>) => {
       const { entry } = action.payload
       const entryIndex = state.findIndex((oldEntry) => oldEntry.address === entry.address)
       if (entryIndex >= 0) {
@@ -42,13 +49,13 @@ export default handleActions(
       }
       return state
     },
-    [REMOVE_ENTRY]: (state, action) => {
+    [REMOVE_ENTRY]: (state, action: Action<RemoveEntryPayload>) => {
       const { entryAddress } = action.payload
       const entryIndex = state.findIndex((oldEntry) => oldEntry.address === entryAddress)
       state.splice(entryIndex, 1)
       return state
     },
-    [ADD_OR_UPDATE_ENTRY]: (state, action) => {
+    [ADD_OR_UPDATE_ENTRY]: (state, action: Action<EntryPayload>) => {
       const { entry } = action.payload
 
       // Only updates entries with valid names

--- a/src/logic/collectibles/store/reducer/collectibles.ts
+++ b/src/logic/collectibles/store/reducer/collectibles.ts
@@ -1,11 +1,15 @@
 import { handleActions } from 'redux-actions'
 
 import { ADD_NFT_ASSETS, ADD_NFT_TOKENS } from 'src/logic/collectibles/store/actions/addCollectibles'
+import { NFTAssets, NFTTokens } from 'src/logic/collectibles/sources/collectibles'
+import { AppReduxState } from 'src/store'
 
 export const NFT_ASSETS_REDUCER_ID = 'nftAssets'
 export const NFT_TOKENS_REDUCER_ID = 'nftTokens'
 
-export const nftAssetReducer = handleActions(
+type NFTAssetsPayload = { nftAssets: NFTAssets }
+
+export const nftAssetReducer = handleActions<AppReduxState['nftAssets'], NFTAssetsPayload>(
   {
     [ADD_NFT_ASSETS]: (state, action) => {
       const { nftAssets } = action.payload
@@ -16,7 +20,9 @@ export const nftAssetReducer = handleActions(
   {},
 )
 
-export const nftTokensReducer = handleActions(
+type NFTTokensPayload = { nftTokens: NFTTokens }
+
+export const nftTokensReducer = handleActions<AppReduxState['nftTokens'], NFTTokensPayload>(
   {
     [ADD_NFT_TOKENS]: (state, action) => {
       const { nftTokens } = action.payload

--- a/src/logic/collectibles/utils/index.ts
+++ b/src/logic/collectibles/utils/index.ts
@@ -1,7 +1,7 @@
 import { getNetworkId, getNetworkInfo } from 'src/config'
 import { ETHEREUM_NETWORK } from 'src/config/networks/network.d'
 import { nftAssetsListAddressesSelector } from 'src/logic/collectibles/store/selectors'
-import { TxServiceModel } from 'src/logic/safe/store/actions/transactions/fetchTransactions/loadOutgoingTransactions'
+import { BuildTx, ServiceTx } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
 import { TOKEN_TRANSFER_METHODS_NAMES } from 'src/logic/safe/store/models/types/transactions.d'
 import { getERC721TokenContract, getStandardTokenContract } from 'src/logic/tokens/store/actions/fetchTokens'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
@@ -31,10 +31,10 @@ export const SAFE_TRANSFER_FROM_WITHOUT_DATA_HASH = '42842e0e'
 
 /**
  * Verifies that a tx received by the transaction service is an ERC721 token-related transaction
- * @param {TxServiceModel} tx
+ * @param {BuildTx['tx']} tx
  * @returns boolean
  */
-export const isSendERC721Transaction = (tx: TxServiceModel): boolean => {
+export const isSendERC721Transaction = (tx: BuildTx['tx']): boolean => {
   let hasERC721Transfer = false
 
   if (tx.dataDecoded && sameString(tx.dataDecoded.method, TOKEN_TRANSFER_METHODS_NAMES.SAFE_TRANSFER_FROM)) {
@@ -44,7 +44,7 @@ export const isSendERC721Transaction = (tx: TxServiceModel): boolean => {
   // Note: this is only valid with our current case (client rendering), if we move to server side rendering we need to refactor this
   const state = store.getState()
   const knownAssets = nftAssetsListAddressesSelector(state)
-  return knownAssets.includes(tx.to) || hasERC721Transfer
+  return knownAssets.includes((tx as ServiceTx).to) || hasERC721Transfer
 }
 
 /**

--- a/src/logic/contracts/methodIds.ts
+++ b/src/logic/contracts/methodIds.ts
@@ -25,7 +25,7 @@ const decodeInfo = ({ paramsHash, params }: DecodeInfoProps): DataDecoded['param
   }))
 }
 
-export const decodeParamsFromSafeMethod = (data: string): DataDecoded | null => {
+export const decodeParamsFromSafeMethod = (data: string): DataDecoded | undefined => {
   const [methodId, paramsHash] = [data.slice(0, 10), data.slice(10)]
   const method = SAFE_METHODS_NAMES[methodId]
 
@@ -99,7 +99,7 @@ export const decodeParamsFromSafeMethod = (data: string): DataDecoded | null => 
     }
 
     default:
-      return null
+      return
   }
 }
 
@@ -113,7 +113,7 @@ export const isDeleteAllowanceMethod = (data: string): boolean => {
   return sameString(SPENDING_LIMIT_METHOD_ID_TO_NAME[methodId], SPENDING_LIMIT_METHODS_NAMES.DELETE_ALLOWANCE)
 }
 
-export const decodeParamsFromSpendingLimit = (data: string): DataDecoded | null => {
+export const decodeParamsFromSpendingLimit = (data: string): DataDecoded | undefined => {
   const [methodId, paramsHash] = [data.slice(0, 10), data.slice(10)]
   const method = SPENDING_LIMIT_METHOD_ID_TO_NAME[methodId]
 
@@ -171,7 +171,7 @@ export const decodeParamsFromSpendingLimit = (data: string): DataDecoded | null 
     }
 
     default:
-      return null
+      return
   }
 }
 
@@ -183,9 +183,9 @@ const isSpendingLimitMethod = (methodId: string): boolean => {
   return !!SPENDING_LIMIT_METHOD_ID_TO_NAME[methodId]
 }
 
-export const decodeMethods = (data: string | null): DataDecoded | null => {
+export const decodeMethods = (data: string | null): DataDecoded | undefined => {
   if (!data?.length) {
-    return null
+    return
   }
 
   const [methodId, paramsHash] = [data.slice(0, 10), data.slice(10)]
@@ -226,6 +226,6 @@ export const decodeMethods = (data: string | null): DataDecoded | null => {
     }
 
     default:
-      return null
+      return
   }
 }

--- a/src/logic/cookies/store/reducer/cookies.ts
+++ b/src/logic/cookies/store/reducer/cookies.ts
@@ -2,10 +2,13 @@ import { Map } from 'immutable'
 import { handleActions } from 'redux-actions'
 
 import { OPEN_COOKIE_BANNER } from 'src/logic/cookies/store/actions/openCookieBanner'
+import { AppReduxState } from 'src/store'
 
 export const COOKIES_REDUCER_ID = 'cookies'
 
-export default handleActions(
+type OpenCookieBannerPayload = { cookieBannerOpen: boolean }
+
+export default handleActions<AppReduxState['cookies'], OpenCookieBannerPayload>(
   {
     [OPEN_COOKIE_BANNER]: (state, action) => {
       const { cookieBannerOpen } = action.payload

--- a/src/logic/currencyValues/store/actions/fetchCurrencyRate.ts
+++ b/src/logic/currencyValues/store/actions/fetchCurrencyRate.ts
@@ -1,13 +1,18 @@
+import { Action } from 'redux-actions'
+import { ThunkDispatch } from 'redux-thunk'
+
 import fetchCurrenciesRates from 'src/logic/currencyValues/api/fetchCurrenciesRates'
 import { setCurrencyRate } from 'src/logic/currencyValues/store/actions/setCurrencyRate'
 import { AVAILABLE_CURRENCIES } from 'src/logic/currencyValues/store/model/currencyValues'
-import { Dispatch } from 'redux'
+import { CurrencyRatePayload } from 'src/logic/currencyValues/store/reducer/currencyValues'
+import { AppReduxState } from 'src/store'
 
 const fetchCurrencyRate = (safeAddress: string, selectedCurrency: string) => async (
-  dispatch: Dispatch<typeof setCurrencyRate>,
+  dispatch: ThunkDispatch<AppReduxState, undefined, Action<CurrencyRatePayload>>,
 ): Promise<void> => {
   if (AVAILABLE_CURRENCIES.USD === selectedCurrency) {
-    return dispatch(setCurrencyRate(safeAddress, 1))
+    dispatch(setCurrencyRate(safeAddress, 1))
+    return
   }
 
   const selectedCurrencyRateInBaseCurrency: number = await fetchCurrenciesRates(

--- a/src/logic/currencyValues/store/actions/fetchSelectedCurrency.ts
+++ b/src/logic/currencyValues/store/actions/fetchSelectedCurrency.ts
@@ -1,12 +1,14 @@
-import { setCurrencyBalances } from 'src/logic/currencyValues/store/actions/setCurrencyBalances'
-import { setCurrencyRate } from 'src/logic/currencyValues/store/actions/setCurrencyRate'
+import { Action } from 'redux-actions'
+import { ThunkDispatch } from 'redux-thunk'
+
 import { setSelectedCurrency } from 'src/logic/currencyValues/store/actions/setSelectedCurrency'
 import { AVAILABLE_CURRENCIES } from 'src/logic/currencyValues/store/model/currencyValues'
+import { CurrencyPayloads, CurrentCurrencyPayload } from 'src/logic/currencyValues/store/reducer/currencyValues'
 import { loadSelectedCurrency } from 'src/logic/currencyValues/store/utils/currencyValuesStorage'
-import { Dispatch } from 'redux'
+import { AppReduxState } from 'src/store'
 
 export const fetchSelectedCurrency = (safeAddress: string) => async (
-  dispatch: Dispatch<typeof setCurrencyBalances | typeof setSelectedCurrency | typeof setCurrencyRate>,
+  dispatch: ThunkDispatch<AppReduxState, undefined, Action<CurrentCurrencyPayload>>,
 ): Promise<void> => {
   try {
     const storedSelectedCurrency = await loadSelectedCurrency()

--- a/src/logic/currencyValues/store/actions/fetchSelectedCurrency.ts
+++ b/src/logic/currencyValues/store/actions/fetchSelectedCurrency.ts
@@ -3,7 +3,7 @@ import { ThunkDispatch } from 'redux-thunk'
 
 import { setSelectedCurrency } from 'src/logic/currencyValues/store/actions/setSelectedCurrency'
 import { AVAILABLE_CURRENCIES } from 'src/logic/currencyValues/store/model/currencyValues'
-import { CurrencyPayloads, CurrentCurrencyPayload } from 'src/logic/currencyValues/store/reducer/currencyValues'
+import { CurrentCurrencyPayload } from 'src/logic/currencyValues/store/reducer/currencyValues'
 import { loadSelectedCurrency } from 'src/logic/currencyValues/store/utils/currencyValuesStorage'
 import { AppReduxState } from 'src/store'
 

--- a/src/logic/currencyValues/store/actions/setSelectedCurrency.ts
+++ b/src/logic/currencyValues/store/actions/setSelectedCurrency.ts
@@ -1,6 +1,7 @@
-import { createAction } from 'redux-actions'
+import { Action, createAction } from 'redux-actions'
 import { ThunkDispatch } from 'redux-thunk'
-import { AnyAction } from 'redux'
+
+import { CurrencyPayloads } from 'src/logic/currencyValues/store/reducer/currencyValues'
 import { AppReduxState } from 'src/store'
 import fetchCurrencyRate from 'src/logic/currencyValues/store/actions/fetchCurrencyRate'
 
@@ -12,7 +13,7 @@ const setCurrentCurrency = createAction(SET_CURRENT_CURRENCY, (safeAddress: stri
 }))
 
 export const setSelectedCurrency = (safeAddress: string, selectedCurrency: string) => (
-  dispatch: ThunkDispatch<AppReduxState, undefined, AnyAction>,
+  dispatch: ThunkDispatch<AppReduxState, undefined, Action<CurrencyPayloads>>,
 ): void => {
   dispatch(setCurrentCurrency(safeAddress, selectedCurrency))
   dispatch(fetchCurrencyRate(safeAddress, selectedCurrency))

--- a/src/logic/currencyValues/store/reducer/currencyValues.ts
+++ b/src/logic/currencyValues/store/reducer/currencyValues.ts
@@ -1,10 +1,10 @@
 import { Map } from 'immutable'
-import { handleActions } from 'redux-actions'
+import { Action, handleActions } from 'redux-actions'
 
 import { SET_CURRENCY_BALANCES } from 'src/logic/currencyValues/store/actions/setCurrencyBalances'
 import { SET_CURRENCY_RATE } from 'src/logic/currencyValues/store/actions/setCurrencyRate'
 import { SET_CURRENT_CURRENCY } from 'src/logic/currencyValues/store/actions/setSelectedCurrency'
-import { CurrencyRateValue } from 'src/logic/currencyValues/store/model/currencyValues'
+import { BalanceCurrencyList, CurrencyRateValue } from 'src/logic/currencyValues/store/model/currencyValues'
 
 export const CURRENCY_VALUES_KEY = 'currencyValues'
 
@@ -15,19 +15,26 @@ export interface CurrencyReducerMap extends Map<string, any> {
 
 export type CurrencyValuesState = Map<string, CurrencyReducerMap>
 
-export default handleActions(
+type CurrencyBasePayload = { safeAddress: string }
+export type CurrencyRatePayload = CurrencyBasePayload & { currencyRate: number }
+export type CurrencyBalancesPayload = CurrencyBasePayload & { currencyBalances: BalanceCurrencyList }
+export type CurrentCurrencyPayload = CurrencyBasePayload & { selectedCurrency: string }
+
+export type CurrencyPayloads = CurrencyRatePayload | CurrencyBalancesPayload | CurrentCurrencyPayload
+
+export default handleActions<CurrencyReducerMap, CurrencyPayloads>(
   {
-    [SET_CURRENCY_RATE]: (state: CurrencyReducerMap, action) => {
+    [SET_CURRENCY_RATE]: (state, action: Action<CurrencyRatePayload>) => {
       const { currencyRate, safeAddress } = action.payload
 
       return state.setIn([safeAddress, 'currencyRate'], currencyRate)
     },
-    [SET_CURRENCY_BALANCES]: (state: CurrencyReducerMap, action) => {
-      const { currencyBalances, safeAddress } = action.payload
+    [SET_CURRENCY_BALANCES]: (state, action: Action<CurrencyBalancesPayload>) => {
+      const { safeAddress, currencyBalances } = action.payload
 
       return state.setIn([safeAddress, 'currencyBalances'], currencyBalances)
     },
-    [SET_CURRENT_CURRENCY]: (state: CurrencyReducerMap, action) => {
+    [SET_CURRENT_CURRENCY]: (state, action: Action<CurrentCurrencyPayload>) => {
       const { safeAddress, selectedCurrency } = action.payload
 
       return state.setIn([safeAddress, 'selectedCurrency'], selectedCurrency)

--- a/src/logic/currentSession/store/reducer/currentSession.ts
+++ b/src/logic/currentSession/store/reducer/currentSession.ts
@@ -1,8 +1,9 @@
-import { handleActions } from 'redux-actions'
+import { Action, handleActions } from 'redux-actions'
 
 import { LOAD_CURRENT_SESSION } from 'src/logic/currentSession/store/actions/loadCurrentSession'
 import { UPDATE_VIEWED_SAFES } from 'src/logic/currentSession/store/actions/updateViewedSafes'
 import { saveCurrentSessionToStorage } from 'src/logic/currentSession/utils'
+import { AppReduxState } from 'src/store'
 
 export const CURRENT_SESSION_REDUCER_ID = 'currentSession'
 
@@ -14,13 +15,15 @@ export const initialState = {
   viewedSafes: [],
 }
 
-export default handleActions(
+type CurrentSessionPayloads = CurrentSessionState | string
+
+export default handleActions<AppReduxState['currentSession'], CurrentSessionPayloads>(
   {
-    [LOAD_CURRENT_SESSION]: (state = initialState, action) => ({
+    [LOAD_CURRENT_SESSION]: (state = initialState, action: Action<CurrentSessionState>) => ({
       ...state,
       ...action.payload,
     }),
-    [UPDATE_VIEWED_SAFES]: (state, action) => {
+    [UPDATE_VIEWED_SAFES]: (state, action: Action<string>) => {
       const safeAddress = action.payload
       const viewedSafes = state.viewedSafes
       const newState = {

--- a/src/logic/notifications/notificationBuilder.tsx
+++ b/src/logic/notifications/notificationBuilder.tsx
@@ -231,7 +231,7 @@ export const getNotificationsFromTxType: any = (txType, origin) => {
 
 export const enhanceSnackbarForAction = (
   notification: Notification,
-  key?: number | string,
+  key?: string,
   onClick?: () => void,
 ): Notification => ({
   ...notification,

--- a/src/logic/notifications/notificationTypes.ts
+++ b/src/logic/notifications/notificationTypes.ts
@@ -15,7 +15,8 @@ export type NotificationId = keyof typeof NOTIFICATION_IDS
 export type Notification = {
   message: string
   options: OptionsObject
-  key?: number | string
+  key?: string
+  dismissed?: boolean
 }
 
 const NOTIFICATION_IDS = {

--- a/src/logic/notifications/store/models/notification.ts
+++ b/src/logic/notifications/store/models/notification.ts
@@ -1,8 +1,0 @@
-import { Record } from 'immutable'
-
-export const makeNotification = Record({
-  key: 0,
-  message: '',
-  options: {},
-  dismissed: false,
-})

--- a/src/logic/notifications/store/reducer/notifications.ts
+++ b/src/logic/notifications/store/reducer/notifications.ts
@@ -1,38 +1,55 @@
 import { Map } from 'immutable'
-import { handleActions } from 'redux-actions'
+import { Action, handleActions } from 'redux-actions'
 
+import { Notification } from 'src/logic/notifications/notificationTypes'
+import { AppReduxState } from 'src/store'
 import { CLOSE_SNACKBAR } from '../actions/closeSnackbar'
 import { ENQUEUE_SNACKBAR } from '../actions/enqueueSnackbar'
 import { REMOVE_SNACKBAR } from '../actions/removeSnackbar'
 
-import { makeNotification } from 'src/logic/notifications/store/models/notification'
-
 export const NOTIFICATIONS_REDUCER_ID = 'notifications'
 
-export default handleActions(
+type CloseSnackBarPayload = { key: string; dismissAll: boolean }
+type Payloads = Notification | CloseSnackBarPayload | string
+
+export default handleActions<AppReduxState['notifications'], Payloads>(
   {
-    [ENQUEUE_SNACKBAR]: (state, action) => {
+    [ENQUEUE_SNACKBAR]: (state, action: Action<Notification>) => {
       const notification = action.payload
 
-      return state.set(notification.key, makeNotification(notification))
+      if (!notification.key) {
+        return state
+      }
+
+      return state.set(notification.key, notification)
     },
-    [CLOSE_SNACKBAR]: (state, action) => {
+    [CLOSE_SNACKBAR]: (state, action: Action<CloseSnackBarPayload>) => {
       const { dismissAll, key } = action.payload
 
-      if (key) {
-        return state.update(key, (prev) => prev.set('dismissed', true))
+      if (key && state.get(key)) {
+        return state.update(key, (notification) => {
+          if (notification) {
+            return {
+              ...notification,
+              dismissed: true,
+            }
+          }
+
+          return notification
+        })
       }
+
       if (dismissAll) {
         return state.withMutations((map) => {
           map.forEach((notification, notificationKey) => {
-            map.set(notificationKey, notification.set('dismissed', true))
+            map.set(notificationKey, { ...notification, dismissed: true })
           })
         })
       }
 
       return state
     },
-    [REMOVE_SNACKBAR]: (state, action) => {
+    [REMOVE_SNACKBAR]: (state, action: Action<string>) => {
       const key = action.payload
 
       return state.delete(key)

--- a/src/logic/safe/store/actions/addOrUpdateSafe.ts
+++ b/src/logic/safe/store/actions/addOrUpdateSafe.ts
@@ -12,7 +12,6 @@ export const buildOwnersFrom = (names: string[], addresses: string[]): List<Safe
   return List(owners)
 }
 
-export const addOrUpdateSafe = createAction(ADD_OR_UPDATE_SAFE, (safe: SafeRecordProps, loadedFromStorage = false) => ({
+export const addOrUpdateSafe = createAction(ADD_OR_UPDATE_SAFE, (safe: SafeRecordProps) => ({
   safe,
-  loadedFromStorage,
 }))

--- a/src/logic/safe/store/actions/loadSafesFromStorage.ts
+++ b/src/logic/safe/store/actions/loadSafesFromStorage.ts
@@ -13,7 +13,7 @@ const loadSafesFromStorage = () => async (dispatch: Dispatch): Promise<void> => 
 
     if (safes) {
       Object.values(safes).forEach((safeProps) => {
-        dispatch(addOrUpdateSafe(buildSafe(safeProps), true))
+        dispatch(addOrUpdateSafe(buildSafe(safeProps)))
       })
     }
   } catch (err) {

--- a/src/logic/safe/store/models/types/transaction.ts
+++ b/src/logic/safe/store/models/types/transaction.ts
@@ -89,7 +89,7 @@ export type TransactionProps = {
   value: string
 }
 
-export type Transaction = RecordOf<TransactionProps>
+export type Transaction = RecordOf<TransactionProps> & Readonly<TransactionProps>
 
 export type TxArgs = {
   baseGas: number

--- a/src/logic/safe/store/reducer/cancellationTransactions.ts
+++ b/src/logic/safe/store/reducer/cancellationTransactions.ts
@@ -1,18 +1,25 @@
 import { Map } from 'immutable'
-import { handleActions } from 'redux-actions'
+import { Action, handleActions } from 'redux-actions'
 
 import { Transaction } from 'src/logic/safe/store/models/types/transaction'
 import { ADD_OR_UPDATE_CANCELLATION_TRANSACTIONS } from 'src/logic/safe/store/actions/transactions/addOrUpdateCancellationTransactions'
 import { REMOVE_CANCELLATION_TRANSACTION } from 'src/logic/safe/store/actions/transactions/removeCancellationTransaction'
+import { AppReduxState } from 'src/store'
 
 export const CANCELLATION_TRANSACTIONS_REDUCER_ID = 'cancellationTransactions'
 
 export type CancellationTransactions = Map<string, Transaction>
 export type CancellationTxState = Map<string, CancellationTransactions>
 
-export default handleActions(
+type CancellationTransactionsPayload = { safeAddress: string; transactions: CancellationTransactions }
+type CancellationTransactionPayload = { safeAddress: string; transaction: Transaction }
+
+export default handleActions<
+  AppReduxState['cancellationTransactions'],
+  CancellationTransactionsPayload | CancellationTransactionPayload
+>(
   {
-    [ADD_OR_UPDATE_CANCELLATION_TRANSACTIONS]: (state, action) => {
+    [ADD_OR_UPDATE_CANCELLATION_TRANSACTIONS]: (state, action: Action<CancellationTransactionsPayload>) => {
       const { safeAddress, transactions } = action.payload
 
       if (!safeAddress || !transactions || !transactions.size) {
@@ -41,7 +48,7 @@ export default handleActions(
         }
       })
     },
-    [REMOVE_CANCELLATION_TRANSACTION]: (state, action) => {
+    [REMOVE_CANCELLATION_TRANSACTION]: (state, action: Action<CancellationTransactionPayload>) => {
       const { safeAddress, transaction } = action.payload
 
       if (!safeAddress || !transaction) {

--- a/src/logic/safe/store/reducer/incomingTransactions.ts
+++ b/src/logic/safe/store/reducer/incomingTransactions.ts
@@ -2,10 +2,11 @@ import { Map } from 'immutable'
 import { handleActions } from 'redux-actions'
 
 import { ADD_INCOMING_TRANSACTIONS } from 'src/logic/safe/store/actions/addIncomingTransactions'
+import { AppReduxState } from 'src/store'
 
 export const INCOMING_TRANSACTIONS_REDUCER_ID = 'incomingTransactions'
 
-export default handleActions(
+export default handleActions<AppReduxState['incomingTransactions']>(
   {
     [ADD_INCOMING_TRANSACTIONS]: (state, action) => action.payload,
   },

--- a/src/logic/safe/store/reducer/transactions.ts
+++ b/src/logic/safe/store/reducer/transactions.ts
@@ -1,14 +1,22 @@
-import { Map } from 'immutable'
-import { handleActions } from 'redux-actions'
+import { List, Map } from 'immutable'
+import { Action, handleActions } from 'redux-actions'
 
 import { ADD_OR_UPDATE_TRANSACTIONS } from 'src/logic/safe/store/actions/transactions/addOrUpdateTransactions'
 import { REMOVE_TRANSACTION } from 'src/logic/safe/store/actions/transactions/removeTransaction'
+import { Transaction } from 'src/logic/safe/store/models/types/transaction'
+import { AppReduxState } from 'src/store'
 
 export const TRANSACTIONS_REDUCER_ID = 'transactions'
 
-export default handleActions(
+type TransactionBasePayload = { safeAddress: string }
+type TransactionsPayload = TransactionBasePayload & { transactions: List<Transaction> }
+type TransactionPayload = TransactionBasePayload & { transaction: Transaction }
+
+type Payload = TransactionsPayload | TransactionPayload
+
+export default handleActions<AppReduxState['transactions'], Payload>(
   {
-    [ADD_OR_UPDATE_TRANSACTIONS]: (state, action) => {
+    [ADD_OR_UPDATE_TRANSACTIONS]: (state, action: Action<TransactionsPayload>) => {
       const { safeAddress, transactions } = action.payload
 
       if (!safeAddress || !transactions || !transactions.size) {
@@ -46,7 +54,7 @@ export default handleActions(
         }
       })
     },
-    [REMOVE_TRANSACTION]: (state, action) => {
+    [REMOVE_TRANSACTION]: (state, action: Action<TransactionPayload>) => {
       const { safeAddress, transaction } = action.payload
 
       if (!safeAddress || !transaction) {

--- a/src/logic/safe/store/selectors/index.ts
+++ b/src/logic/safe/store/selectors/index.ts
@@ -93,7 +93,7 @@ export const safeCancellationTransactionsSelector = createSelector(
       return Map()
     }
 
-    return cancellationTransactions.get(address, Map({}))
+    return cancellationTransactions.get(address, Map())
   },
 )
 
@@ -109,7 +109,7 @@ export const safeIncomingTransactionsSelector = createSelector(
       return List([])
     }
 
-    return incomingTransactions.get(address, List([]))
+    return incomingTransactions.get(address, List())
   },
 )
 

--- a/src/logic/safe/store/selectors/transactions.ts
+++ b/src/logic/safe/store/selectors/transactions.ts
@@ -10,5 +10,7 @@ export const extendedTransactionsSelector = createSelector(
   safeIncomingTransactionsSelector,
   safeModuleTransactionsSelector,
   (transactions, incomingTransactions, moduleTransactions): List<Transaction | SafeModuleTransaction> =>
-    List([...transactions, ...incomingTransactions, ...moduleTransactions]),
+    List().withMutations((list) => {
+      list.concat(transactions).concat(incomingTransactions).concat(moduleTransactions)
+    }),
 )

--- a/src/logic/tokens/store/reducer/tokens.ts
+++ b/src/logic/tokens/store/reducer/tokens.ts
@@ -1,17 +1,22 @@
-import { Map } from 'immutable'
-import { handleActions } from 'redux-actions'
+import { List, Map } from 'immutable'
+import { Action, handleActions } from 'redux-actions'
 
 import { ADD_TOKEN } from 'src/logic/tokens/store/actions/addToken'
 import { ADD_TOKENS } from 'src/logic/tokens/store/actions/saveTokens'
 import { makeToken, Token } from 'src/logic/tokens/store/model/token'
+import { AppReduxState } from 'src/store'
 
 export const TOKEN_REDUCER_ID = 'tokens'
 
 export type TokenState = Map<string, Token>
 
-export default handleActions(
+type TokensPayload = { tokens: List<Token> }
+type TokenPayload = { token: Token }
+type Payloads = TokensPayload | TokenPayload
+
+export default handleActions<AppReduxState['tokens'], Payloads>(
   {
-    [ADD_TOKENS]: (state: TokenState, action) => {
+    [ADD_TOKENS]: (state: TokenState, action: Action<TokensPayload>) => {
       const { tokens } = action.payload
 
       return state.withMutations((map) => {
@@ -20,7 +25,7 @@ export default handleActions(
         })
       })
     },
-    [ADD_TOKEN]: (state: TokenState, action) => {
+    [ADD_TOKEN]: (state: TokenState, action: Action<TokenPayload>) => {
       const { token } = action.payload
       const { address: tokenAddress } = token
 

--- a/src/logic/tokens/utils/tokenHelpers.ts
+++ b/src/logic/tokens/utils/tokenHelpers.ts
@@ -8,8 +8,7 @@ import { isSendERC721Transaction } from 'src/logic/collectibles/utils'
 import { makeToken, Token } from 'src/logic/tokens/store/model/token'
 import { ALTERNATIVE_TOKEN_ABI } from 'src/logic/tokens/utils/alternativeAbi'
 import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
-import { isEmptyData } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
-import { TxServiceModel } from 'src/logic/safe/store/actions/transactions/fetchTransactions/loadOutgoingTransactions'
+import { BuildTx, isEmptyData, ServiceTx } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
 import { CALL } from 'src/logic/safe/transactions'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 
@@ -35,7 +34,7 @@ export const isAddressAToken = async (tokenAddress: string): Promise<boolean> =>
   return call !== '0x'
 }
 
-export const isTokenTransfer = (tx: TxServiceModel): boolean => {
+export const isTokenTransfer = (tx: BuildTx['tx']): boolean => {
   return (
     !isEmptyData(tx.data) &&
     // Check if contains 'transfer' method code
@@ -70,11 +69,11 @@ export const getERC20DecimalsAndSymbol = async (
   return tokenInfo
 }
 
-export const isSendERC20Transaction = async (tx: TxServiceModel): Promise<boolean> => {
+export const isSendERC20Transaction = async (tx: BuildTx['tx']): Promise<boolean> => {
   let isSendTokenTx = !isSendERC721Transaction(tx) && isTokenTransfer(tx)
 
   if (isSendTokenTx) {
-    const { decimals, symbol } = await getERC20DecimalsAndSymbol(tx.to)
+    const { decimals, symbol } = await getERC20DecimalsAndSymbol((tx as ServiceTx).to)
 
     // some contracts may implement the same methods as in ERC20 standard
     // we may falsely treat them as tokens, so in case we get any errors when getting token info

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -295,7 +295,7 @@ const SendFunds = ({ onClose, onNext, recipientAddress, selectedToken = '', amou
                     <Field
                       component={TextField}
                       inputAdornment={{
-                        endAdornment: <InputAdornment position="end">{selectedToken?.symbol}</InputAdornment>,
+                        endAdornment: <InputAdornment position="end">{selectedToken?.symbol || ''}</InputAdornment>,
                       }}
                       name="amount"
                       placeholder="Amount*"

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,6 +22,7 @@ import currentSession, {
   CURRENT_SESSION_REDUCER_ID,
   CurrentSessionState,
 } from 'src/logic/currentSession/store/reducer/currentSession'
+import { Notification } from 'src/logic/notifications'
 import notifications, { NOTIFICATIONS_REDUCER_ID } from 'src/logic/notifications/store/reducer/notifications'
 import tokens, { TOKEN_REDUCER_ID, TokenState } from 'src/logic/tokens/store/reducer/tokens'
 import providerWatcher from 'src/logic/wallets/store/middlewares/providerWatcher'
@@ -91,7 +92,7 @@ export type AppReduxState = CombinedState<{
   [CANCELLATION_TRANSACTIONS_REDUCER_ID]: CancellationTxState
   [INCOMING_TRANSACTIONS_REDUCER_ID]: Map<string, any>
   [MODULE_TRANSACTIONS_REDUCER_ID]: ModuleTransactionsState
-  [NOTIFICATIONS_REDUCER_ID]: Map<string, any>
+  [NOTIFICATIONS_REDUCER_ID]: Map<string, Notification>
   [CURRENCY_VALUES_KEY]: CurrencyValuesState
   [COOKIES_REDUCER_ID]: Map<string, any>
   [ADDRESS_BOOK_REDUCER_ID]: AddressBookState

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,4 @@
-import { Map } from 'immutable'
+import { List, Map } from 'immutable'
 import { connectRouter, routerMiddleware, RouterState } from 'connected-react-router'
 import { createHashHistory } from 'history'
 import { applyMiddleware, combineReducers, compose, createStore, CombinedState, PreloadedState, Store } from 'redux'
@@ -24,6 +24,7 @@ import currentSession, {
 } from 'src/logic/currentSession/store/reducer/currentSession'
 import { Notification } from 'src/logic/notifications'
 import notifications, { NOTIFICATIONS_REDUCER_ID } from 'src/logic/notifications/store/reducer/notifications'
+import { Transaction } from 'src/logic/safe/store/models/types/transaction'
 import tokens, { TOKEN_REDUCER_ID, TokenState } from 'src/logic/tokens/store/reducer/tokens'
 import providerWatcher from 'src/logic/wallets/store/middlewares/providerWatcher'
 import provider, { PROVIDER_REDUCER_ID, ProviderState } from 'src/logic/wallets/store/reducer/provider'
@@ -88,9 +89,9 @@ export type AppReduxState = CombinedState<{
   [NFT_ASSETS_REDUCER_ID]: NFTAssets
   [NFT_TOKENS_REDUCER_ID]: NFTTokens
   [TOKEN_REDUCER_ID]: TokenState
-  [TRANSACTIONS_REDUCER_ID]: Map<string, any>
+  [TRANSACTIONS_REDUCER_ID]: Map<string, List<Transaction>>
   [CANCELLATION_TRANSACTIONS_REDUCER_ID]: CancellationTxState
-  [INCOMING_TRANSACTIONS_REDUCER_ID]: Map<string, any>
+  [INCOMING_TRANSACTIONS_REDUCER_ID]: Map<string, List<Transaction>>
   [MODULE_TRANSACTIONS_REDUCER_ID]: ModuleTransactionsState
   [NOTIFICATIONS_REDUCER_ID]: Map<string, Notification>
   [CURRENCY_VALUES_KEY]: CurrencyValuesState

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,11 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/redux-actions@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@types/redux-actions/-/redux-actions-2.6.1.tgz#0940e97fa35ad3004316bddb391d8e01d2efa605"
+  integrity sha512-zKgK+ATp3sswXs6sOYo1tk8xdXTy4CTaeeYrVQlClCjeOpag5vzPo0ASWiiBJ7vsiQRAdb3VkuFLnDoBimF67g==
+
 "@types/resolve@0.0.8", "@types/resolve@^0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"


### PR DESCRIPTION
Given that mixing different txs types were getting messy, I decided to add @types/redux-actions and fix all the typing issues.


Anyway, most of the transaction-related types will be refactored/removed by the end of epic #820.

This is part of #1614