### PR TITLE
(Feature) Disable gas estimation for WalletConnect

### DIFF
--- a/src/components/TransactionsFees/index.tsx
+++ b/src/components/TransactionsFees/index.tsx
@@ -3,6 +3,10 @@ import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
 import Paragraph from 'src/components/layout/Paragraph'
 import { getNetworkInfo } from 'src/config'
 import { TransactionFailText } from 'src/components/TransactionFailText'
+import { useSelector } from 'react-redux'
+import { providerNameSelector } from 'src/logic/wallets/store/selectors'
+import { sameString } from 'src/utils/strings'
+import { WALLETS } from 'src/config/networks/network.d'
 
 type TransactionFailTextProps = {
   txEstimationExecutionStatus: EstimationStatus
@@ -20,6 +24,8 @@ export const TransactionFees = ({
   isOffChainSignature,
   txEstimationExecutionStatus,
 }: TransactionFailTextProps): React.ReactElement | null => {
+  const providerName = useSelector(providerNameSelector)
+
   let transactionAction
   if (isCreation) {
     transactionAction = 'create'
@@ -27,6 +33,10 @@ export const TransactionFees = ({
     transactionAction = 'execute'
   } else {
     transactionAction = 'approve'
+  }
+
+  if (!providerName || sameString(providerName, WALLETS.WALLET_CONNECT)) {
+    return null
   }
 
   return (

--- a/src/components/TransactionsFees/index.tsx
+++ b/src/components/TransactionsFees/index.tsx
@@ -35,6 +35,7 @@ export const TransactionFees = ({
     transactionAction = 'approve'
   }
 
+  // FIXME this should be removed when estimating with WalletConnect correctly
   if (!providerName || sameString(providerName, WALLETS.WALLET_CONNECT)) {
     return null
   }

--- a/src/logic/contracts/safeContracts.ts
+++ b/src/logic/contracts/safeContracts.ts
@@ -130,7 +130,11 @@ export const estimateGasForDeployingSafe = async (
   const proxyFactoryData = proxyFactoryMaster.methods
     .createProxyWithNonce(safeMaster.options.address, gnosisSafeData, safeCreationSalt)
     .encodeABI()
-  const gas = await calculateGasOf(proxyFactoryData, userAccount, proxyFactoryMaster.options.address)
+  const gas = await calculateGasOf({
+    data: proxyFactoryData,
+    from: userAccount,
+    to: proxyFactoryMaster.options.address,
+  })
   const gasPrice = await calculateGasPrice()
 
   return gas * parseInt(gasPrice, 10)

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -168,6 +168,7 @@ export const useEstimateTransactionGas = ({
       if (!txData.length) {
         return
       }
+      // FIXME this should be removed when estimating with WalletConnect correctly
       if (!providerName || sameString(providerName, WALLETS.WALLET_CONNECT)) {
         return null
       }

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -22,6 +22,7 @@ import { Confirmation } from 'src/logic/safe/store/models/types/confirmation'
 import { checkIfOffChainSignatureIsPossible } from 'src/logic/safe/safeTxSigner'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { sameString } from 'src/utils/strings'
+import { WALLETS } from 'src/config/networks/network.d'
 
 export enum EstimationStatus {
   LOADING = 'LOADING',
@@ -160,12 +161,15 @@ export const useEstimateTransactionGas = ({
   const safeAddress = useSelector(safeParamAddressFromStateSelector)
   const threshold = useSelector(safeThresholdSelector)
   const safeVersion = useSelector(safeCurrentVersionSelector)
-  const { account: from, smartContractWallet } = useSelector(providerSelector)
+  const { account: from, smartContractWallet, name: providerName } = useSelector(providerSelector)
 
   useEffect(() => {
     const estimateGas = async () => {
       if (!txData.length) {
         return
+      }
+      if (!providerName || sameString(providerName, WALLETS.WALLET_CONNECT)) {
+        return null
       }
 
       const isExecution = checkIfTxIsExecution(Number(threshold), preApprovingOwner, txConfirmations?.size, txType)
@@ -245,6 +249,7 @@ export const useEstimateTransactionGas = ({
     smartContractWallet,
     safeTxGas,
     txType,
+    providerName,
   ])
 
   return gasEstimation

--- a/src/logic/safe/transactions/gas.ts
+++ b/src/logic/safe/transactions/gas.ts
@@ -251,5 +251,9 @@ export const estimateGasForTransactionApproval = async ({
       from,
     })
   const approveTransactionTxData = await safeInstance.methods.approveHash(txHash).encodeABI()
-  return calculateGasOf(approveTransactionTxData, from, safeAddress)
+  return calculateGasOf({
+    data: approveTransactionTxData,
+    from,
+    to: safeAddress,
+  })
 }

--- a/src/logic/wallets/ethTransactions.ts
+++ b/src/logic/wallets/ethTransactions.ts
@@ -50,10 +50,16 @@ export const calculateGasPrice = async (): Promise<string> => {
   }
 }
 
-export const calculateGasOf = async (data: string, from: string, to: string): Promise<number> => {
+export const calculateGasOf = async (txConfig: {
+  to: string
+  from: string
+  data: string
+  gasPrice?: number
+  gas?: number
+}): Promise<number> => {
   const web3 = getWeb3()
   try {
-    const gas = await web3.eth.estimateGas({ data, from, to })
+    const gas = await web3.eth.estimateGas(txConfig)
 
     return gas * 2
   } catch (err) {


### PR DESCRIPTION
## Description
- We are having a problem with walletConnect, seems that `web3.call` is not returning a value of `requiredTxGas`, instead it's returning `undefined`. We put the same params (to, from and data) that we used on a test on metamask but the problems seems still there. So I'll disable the feature until we find a solution for walletConnect