### PR TITLE
(Fix) - #1804 Tx gas estimation fail for threshold >= 3

### DIFF
--- a/src/logic/hooks/__tests__/useEstimateTransactionGas.test.ts
+++ b/src/logic/hooks/__tests__/useEstimateTransactionGas.test.ts
@@ -1,0 +1,161 @@
+import {
+  checkIfTxIsApproveAndExecution,
+  checkIfTxIsCreation,
+  checkIfTxIsExecution,
+} from 'src/logic/hooks/useEstimateTransactionGas'
+
+
+describe('checkIfTxIsExecution', () => {
+  const mockedEthAccount = "0x29B1b813b6e84654Ca698ef5d7808E154364900B"
+  it(`should return true if the safe threshold is 1`, () => {
+    // given
+    const threshold = 1
+    const preApprovingOwner = undefined
+    const transactionConfirmations = 0
+    const transactionType = ''
+
+
+    // when
+    const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(true)
+  })
+  it(`should return true if the safe threshold is reached for the transaction`, () => {
+    // given
+    const threshold = 3
+    const preApprovingOwner = mockedEthAccount
+    const transactionConfirmations = 3
+    const transactionType = ''
+
+
+    // when
+    const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(true)
+  })
+  it(`should return true if the transaction is spendingLimit`, () => {
+    // given
+    const threshold = 5
+    const preApprovingOwner = undefined
+    const transactionConfirmations = 0
+    const transactionType = 'spendingLimit'
+
+
+    // when
+    const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(true)
+  })
+  it(`should return true if the number of confirmations is one bellow the threshold but there is a preApprovingOwner`, () => {
+    // given
+    const threshold = 5
+    const preApprovingOwner = mockedEthAccount
+    const transactionConfirmations = 4
+    const transactionType = undefined
+
+
+    // when
+    const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(true)
+  })
+  it(`should return false if the number of confirmations is one bellow the threshold and there is no preApprovingOwner`, () => {
+    // given
+    const threshold = 5
+    const preApprovingOwner = undefined
+    const transactionConfirmations = 4
+    const transactionType = undefined
+
+
+    // when
+    const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(false)
+  })
+})
+describe('checkIfTxIsCreation', () => {
+  it(`should return true if there are no confirmations for the transaction and the transaction is not spendingLimit`, () => {
+    // given
+    const transactionConfirmations = 0
+    const transactionType = ''
+
+
+    // when
+    const result = checkIfTxIsCreation(transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(true)
+  })
+  it(`should return false if there are no confirmations for the transaction and the transaction is spendingLimit`, () => {
+    // given
+    const transactionConfirmations = 0
+    const transactionType = 'spendingLimit'
+
+
+    // when
+    const result = checkIfTxIsCreation(transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(false)
+  })
+  it(`should return false if there are confirmations for the transaction`, () => {
+    // given
+    const transactionConfirmations = 2
+    const transactionType = ''
+
+
+    // when
+    const result = checkIfTxIsCreation(transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(false)
+  })
+})
+
+describe('checkIfTxIsApproveAndExecution', () => {
+  it(`should return true if there is only one confirmation left to reach the safe threshold`, () => {
+    // given
+    const transactionConfirmations = 2
+    const safeThreshold = 3
+    const transactionType = ''
+
+
+    // when
+    const result = checkIfTxIsApproveAndExecution(safeThreshold, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(true)
+  })
+  it(`should return true if the transaction is spendingLimit`, () => {
+    // given
+    const transactionConfirmations = 0
+    const transactionType = 'spendingLimit'
+    const safeThreshold = 3
+
+
+    // when
+    const result = checkIfTxIsApproveAndExecution(safeThreshold, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(true)
+  })
+  it(`should return false if the are missing more than one confirmations to reach the safe threshold and the transaction is not spendingLimit`, () => {
+    // given
+    const transactionConfirmations = 0
+    const transactionType = ''
+    const safeThreshold = 3
+
+
+    // when
+    const result = checkIfTxIsApproveAndExecution(safeThreshold, transactionConfirmations, transactionType)
+
+    // then
+    expect(result).toBe(false)
+  })
+})
+

--- a/src/logic/hooks/__tests__/useEstimateTransactionGas.test.ts
+++ b/src/logic/hooks/__tests__/useEstimateTransactionGas.test.ts
@@ -4,16 +4,14 @@ import {
   checkIfTxIsExecution,
 } from 'src/logic/hooks/useEstimateTransactionGas'
 
-
 describe('checkIfTxIsExecution', () => {
-  const mockedEthAccount = "0x29B1b813b6e84654Ca698ef5d7808E154364900B"
+  const mockedEthAccount = '0x29B1b813b6e84654Ca698ef5d7808E154364900B'
   it(`should return true if the safe threshold is 1`, () => {
     // given
     const threshold = 1
     const preApprovingOwner = undefined
     const transactionConfirmations = 0
     const transactionType = ''
-
 
     // when
     const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
@@ -28,7 +26,6 @@ describe('checkIfTxIsExecution', () => {
     const transactionConfirmations = 3
     const transactionType = ''
 
-
     // when
     const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
 
@@ -41,7 +38,6 @@ describe('checkIfTxIsExecution', () => {
     const preApprovingOwner = undefined
     const transactionConfirmations = 0
     const transactionType = 'spendingLimit'
-
 
     // when
     const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
@@ -56,7 +52,6 @@ describe('checkIfTxIsExecution', () => {
     const transactionConfirmations = 4
     const transactionType = undefined
 
-
     // when
     const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
 
@@ -69,7 +64,6 @@ describe('checkIfTxIsExecution', () => {
     const preApprovingOwner = undefined
     const transactionConfirmations = 4
     const transactionType = undefined
-
 
     // when
     const result = checkIfTxIsExecution(threshold, preApprovingOwner, transactionConfirmations, transactionType)
@@ -84,7 +78,6 @@ describe('checkIfTxIsCreation', () => {
     const transactionConfirmations = 0
     const transactionType = ''
 
-
     // when
     const result = checkIfTxIsCreation(transactionConfirmations, transactionType)
 
@@ -96,7 +89,6 @@ describe('checkIfTxIsCreation', () => {
     const transactionConfirmations = 0
     const transactionType = 'spendingLimit'
 
-
     // when
     const result = checkIfTxIsCreation(transactionConfirmations, transactionType)
 
@@ -107,7 +99,6 @@ describe('checkIfTxIsCreation', () => {
     // given
     const transactionConfirmations = 2
     const transactionType = ''
-
 
     // when
     const result = checkIfTxIsCreation(transactionConfirmations, transactionType)
@@ -124,7 +115,6 @@ describe('checkIfTxIsApproveAndExecution', () => {
     const safeThreshold = 3
     const transactionType = ''
 
-
     // when
     const result = checkIfTxIsApproveAndExecution(safeThreshold, transactionConfirmations, transactionType)
 
@@ -136,7 +126,6 @@ describe('checkIfTxIsApproveAndExecution', () => {
     const transactionConfirmations = 0
     const transactionType = 'spendingLimit'
     const safeThreshold = 3
-
 
     // when
     const result = checkIfTxIsApproveAndExecution(safeThreshold, transactionConfirmations, transactionType)
@@ -150,7 +139,6 @@ describe('checkIfTxIsApproveAndExecution', () => {
     const transactionType = ''
     const safeThreshold = 3
 
-
     // when
     const result = checkIfTxIsApproveAndExecution(safeThreshold, transactionConfirmations, transactionType)
 
@@ -158,4 +146,3 @@ describe('checkIfTxIsApproveAndExecution', () => {
     expect(result).toBe(false)
   })
 })
-

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -36,9 +36,10 @@ export const checkIfTxIsExecution = (
   txConfirmations?: number,
   txType?: string,
 ): boolean => {
-  if (threshold === 1) return true
-  if (sameString(txType, 'spendingLimit')) return true
-  if (txConfirmations === threshold) return true
+  if (threshold === 1 || sameString(txType, 'spendingLimit') || txConfirmations === threshold) {
+    return true
+  }
+
   if (preApprovingOwner && txConfirmations) {
     return txConfirmations + 1 === threshold
   }

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -30,18 +30,26 @@ export enum EstimationStatus {
   SUCCESS = 'SUCCESS',
 }
 
-const checkIfTxIsExecution = (
+export const checkIfTxIsExecution = (
   threshold: number,
   preApprovingOwner?: string,
   txConfirmations?: number,
   txType?: string,
-): boolean =>
-  txConfirmations === threshold || !!preApprovingOwner || threshold === 1 || sameString(txType, 'spendingLimit')
+): boolean => {
+  if (threshold === 1) return true
+  if (sameString(txType, 'spendingLimit')) return true
+  if (txConfirmations === threshold) return true
+  if (preApprovingOwner && txConfirmations) {
+    return txConfirmations + 1 === threshold
+  }
 
-const checkIfTxIsApproveAndExecution = (threshold: number, txConfirmations: number, txType?: string): boolean =>
+  return false
+}
+
+export const checkIfTxIsApproveAndExecution = (threshold: number, txConfirmations: number, txType?: string): boolean =>
   txConfirmations + 1 === threshold || sameString(txType, 'spendingLimit')
 
-const checkIfTxIsCreation = (txConfirmations: number, txType?: string): boolean =>
+export const checkIfTxIsCreation = (txConfirmations: number, txType?: string): boolean =>
   txConfirmations === 0 && !sameString(txType, 'spendingLimit')
 
 type TransactionEstimationProps = {
@@ -173,7 +181,7 @@ export const useEstimateTransactionGas = ({
         return null
       }
 
-      const isExecution = checkIfTxIsExecution(Number(threshold), preApprovingOwner, txConfirmations?.size, txType)
+      const isExecution = checkIfTxIsExecution(Number(threshold), undefined, txConfirmations?.size, txType)
       const isCreation = checkIfTxIsCreation(txConfirmations?.size || 0, txType)
       const approvalAndExecution = checkIfTxIsApproveAndExecution(Number(threshold), txConfirmations?.size || 0, txType)
 

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -181,7 +181,7 @@ export const useEstimateTransactionGas = ({
         return null
       }
 
-      const isExecution = checkIfTxIsExecution(Number(threshold), undefined, txConfirmations?.size, txType)
+      const isExecution = checkIfTxIsExecution(Number(threshold), preApprovingOwner, txConfirmations?.size, txType)
       const isCreation = checkIfTxIsCreation(txConfirmations?.size || 0, txType)
       const approvalAndExecution = checkIfTxIsApproveAndExecution(Number(threshold), txConfirmations?.size || 0, txType)
 


### PR DESCRIPTION
Closes #1804 by:

- Fixing the `checkIfTxIsExecution` method to validate that if there is preApprovingOwner: it should also reach the threshold to be considered an `executionTransaction` and not a `transactionApproval`
- Add tests