### PR TITLE
Add Zapper exchange safe app

### DIFF
--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -123,6 +123,12 @@ export const staticAppsList: Array<StaticAppInfo> = [
     disabled: false,
     networks: [ETHEREUM_NETWORK.MAINNET],
   },
+  // Zapper Exchange
+  {
+    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmdVF6wvyUkeukB9MQK5DnMm1B9kn4TDC193TA4Z4gptpa`,
+    disabled: false,
+    networks: [ETHEREUM_NETWORK.MAINNET],
+  },
 ]
 
 export const getAppInfoFromOrigin = (origin: string): { url: string; name: string } | null => {


### PR DESCRIPTION
Add Zapper Exchange Safe app. This app only runs on mainnet.

@francovenica  This link can be used for testing:
https://ipfs.io/ipfs/QmdVF6wvyUkeukB9MQK5DnMm1B9kn4TDC193TA4Z4gptpa/