### PR TITLE
Update balancer pool management app with new keys

### DIFF
--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -44,7 +44,7 @@ export const staticAppsList: Array<StaticAppInfo> = [
   },
   // Balancer Pool
   {
-    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmaTucdZYLKTqaewwJduVMM8qfCDhyaEqjd8tBNae26K1J`,
+    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmQsmxUVtcEWmKcXxKwYsZFKJ2kDdqqjqdExujiGY1g3tV`,
     disabled: false,
     networks: [ETHEREUM_NETWORK.MAINNET],
   },


### PR DESCRIPTION
Update balancer management app with new keys to avoid rate limiting

@francovenica this app can only be tested on mainnet:
https://ipfs.io/ipfs/QmQsmxUVtcEWmKcXxKwYsZFKJ2kDdqqjqdExujiGY1g3tV