### PR TITLE
Update balancer exchange app

### DIFF
--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -38,7 +38,7 @@ export const staticAppsList: Array<StaticAppInfo> = [
   },
   //Balancer Exchange
   {
-    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmfPLXne1UrY399RQAcjD1dmBhQrPGZWgp311CDLLW3VTn`,
+    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmRb2VfPVYBrv6gi2zDywgVgTg3A19ZCRMqwL13Ez5f5AS`,
     disabled: false,
     networks: [ETHEREUM_NETWORK.MAINNET],
   },


### PR DESCRIPTION
Update balancer exchange app to latest version


@francovenica this app can only be tested on mainnet:
https://ipfs.io/ipfs/QmRb2VfPVYBrv6gi2zDywgVgTg3A19ZCRMqwL13Ez5f5AS/