### PR TITLE
Update copy during onboarding

### DIFF
--- a/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
+++ b/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
@@ -157,7 +157,8 @@ const SafeOwnersForm = (props): React.ReactElement => {
           <br />
           <br />
           Add additional owners (e.g. wallets of your teammates) and specify how many of them have to confirm a
-          transaction before it gets executed. You can also add/remove owners and change the signature threshold after your Safe is created.
+          transaction before it gets executed. You can also add/remove owners and change the signature threshold after
+          your Safe is created.
         </Paragraph>
       </Block>
       <Hairline />

--- a/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
+++ b/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
@@ -157,8 +157,7 @@ const SafeOwnersForm = (props): React.ReactElement => {
           <br />
           <br />
           Add additional owners (e.g. wallets of your teammates) and specify how many of them have to confirm a
-          transaction before it gets executed. In general, the more confirmations required, the more secure is your
-          Safe.
+          transaction before it gets executed. You can also add/remove owners after your Safe is created.
         </Paragraph>
       </Block>
       <Hairline />

--- a/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
+++ b/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
@@ -157,7 +157,7 @@ const SafeOwnersForm = (props): React.ReactElement => {
           <br />
           <br />
           Add additional owners (e.g. wallets of your teammates) and specify how many of them have to confirm a
-          transaction before it gets executed. You can also add/remove owners after your Safe is created.
+          transaction before it gets executed. You can also add/remove owners and change the signature threshold after your Safe is created.
         </Paragraph>
       </Block>
       <Hairline />


### PR DESCRIPTION
Quite a few users have pointed out that it was not clear that owners can be changed after the Safe is created. E.g. "- Once I’ve created a wallet, it seems it’s possible to revoke and change a signer, but it wasn’t immediately clear if I can change the threshold."