### PR TITLE
[Transaction List v2] Avoid displaying `UNKNOWN` in owner's list

### DIFF
--- a/src/routes/safe/components/Transactions/GatewayTransactions/OwnerRow.tsx
+++ b/src/routes/safe/components/Transactions/GatewayTransactions/OwnerRow.tsx
@@ -11,7 +11,7 @@ export const OwnerRow = ({ ownerAddress }: { ownerAddress: string }): ReactEleme
   return (
     <EthHashInfo
       hash={ownerAddress}
-      name={ownerName}
+      name={ownerName === 'UNKNOWN' ? '' : ownerName}
       showIdenticon
       showCopyBtn
       explorerUrl={getExplorerInfo(ownerAddress)}


### PR DESCRIPTION
If the owner's name is not in the Address Book, show nothing.