### PR TITLE
Fix decoded multisend actions not showing for eth transfers

### DIFF
--- a/src/routes/safe/components/Transactions/GatewayTransactions/MultiSendDetails.tsx
+++ b/src/routes/safe/components/Transactions/GatewayTransactions/MultiSendDetails.tsx
@@ -60,21 +60,21 @@ export const MultiSendDetails = ({ txData }: { txData: TransactionData }): React
         const title = `Send ${amount} ${nativeCoin.name} to:`
 
         if (dataDecoded) {
+          // Backend decoded data
           details = <MethodDetails data={dataDecoded} />
         } else {
+          // We couldn't decode it but we have data
           details = data && <HexEncodedData hexData={data} />
         }
 
         return (
-          details && (
-            <MultiSendTxGroup
-              key={`${data ?? to}-${index}`}
-              actionTitle={actionTitle}
-              txDetails={{ title, address: to, dataDecoded }}
-            >
-              {details}
-            </MultiSendTxGroup>
-          )
+          <MultiSendTxGroup
+            key={`${data ?? to}-${index}`}
+            actionTitle={actionTitle}
+            txDetails={{ title, address: to, dataDecoded }}
+          >
+            {details}
+          </MultiSendTxGroup>
         )
       })}
     </>


### PR DESCRIPTION
When we have a multisend action that it's an ETH transfer is not being shown in transaction details

Before:
![image](https://user-images.githubusercontent.com/25051234/107942936-39289e80-6f8c-11eb-9e6c-f6ed888e1d85.png)


After:
![image](https://user-images.githubusercontent.com/25051234/107942998-4fcef580-6f8c-11eb-9c1d-c5123b8d99e8.png)
