### PR TITLE
Fix UI break after transaction is executed

### DIFF
--- a/src/routes/safe/components/Transactions/GatewayTransactions/QueueTxList.tsx
+++ b/src/routes/safe/components/Transactions/GatewayTransactions/QueueTxList.tsx
@@ -82,11 +82,13 @@ export const QueueTxList = ({ transactions }: QueueTxListProps): ReactElement =>
   const title = txLocation === 'queued.next' ? 'NEXT TRANSACTION' : 'QUEUE'
 
   const { lastItemId, setLastItemId } = useContext(TxsInfiniteScrollContext)
-  const [, lastTransactionsGroup] = transactions[transactions.length - 1]
-  const lastTransaction = lastTransactionsGroup[lastTransactionsGroup.length - 1]
+  if (transactions.length) {
+    const [, lastTransactionsGroup] = transactions[transactions.length - 1]
+    const lastTransaction = lastTransactionsGroup[lastTransactionsGroup.length - 1]
 
-  if (txLocation === 'queued.queued' && !sameString(lastItemId, lastTransaction.id)) {
-    setLastItemId(lastTransaction.id)
+    if (txLocation === 'queued.queued' && !sameString(lastItemId, lastTransaction.id)) {
+      setLastItemId(lastTransaction.id)
+    }
   }
 
   return (


### PR DESCRIPTION
When we execute a transaction there is an issue when the queue gets empty. Add a check on transaction list before trying to assign guard element to infinite scroll in pending list