### PR TITLE
(Feature) - #1991 Prevent that a Safe adds itself as an owner

### DIFF
--- a/src/components/forms/validator.test.ts
+++ b/src/components/forms/validator.test.ts
@@ -10,6 +10,8 @@ import {
   uniqueAddress,
   differentFrom,
   ADDRESS_REPEATED_ERROR,
+  addressIsNotSafe,
+  OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR,
 } from 'src/components/forms/validator'
 
 describe('Forms > Validators', () => {
@@ -176,6 +178,22 @@ describe('Forms > Validators', () => {
       const addresses = ['0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe', '0x2D6F2B448b0F711Eb81f2929566504117d67E44F']
 
       expect(uniqueAddress(addresses)('0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe')).toEqual(ADDRESS_REPEATED_ERROR)
+    })
+  })
+
+  describe('addressIsNotSafe validator', () => {
+    it('Returns undefined if the given `address` it not the given `safeAddress`', async () => {
+      const address = '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe'
+      const safeAddress = '0x2D6F2B448b0F711Eb81f2929566504117d67E44F'
+
+      expect(addressIsNotSafe(safeAddress)(address)).toBeUndefined()
+    })
+
+    it('Returns an error message if the given `address` is the same as the `safeAddress`', async () => {
+      const address = '0x2D6F2B448b0F711Eb81f2929566504117d67E44F'
+      const safeAddress = '0x2D6F2B448b0F711Eb81f2929566504117d67E44F'
+
+      expect(addressIsNotSafe(safeAddress)(address)).toEqual(OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR)
     })
   })
 

--- a/src/components/forms/validator.test.ts
+++ b/src/components/forms/validator.test.ts
@@ -10,7 +10,7 @@ import {
   uniqueAddress,
   differentFrom,
   ADDRESS_REPEATED_ERROR,
-  addressIsNotSafe,
+  addressIsNotCurrentSafe,
   OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR,
 } from 'src/components/forms/validator'
 
@@ -186,14 +186,14 @@ describe('Forms > Validators', () => {
       const address = '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe'
       const safeAddress = '0x2D6F2B448b0F711Eb81f2929566504117d67E44F'
 
-      expect(addressIsNotSafe(safeAddress)(address)).toBeUndefined()
+      expect(addressIsNotCurrentSafe(safeAddress)(address)).toBeUndefined()
     })
 
     it('Returns an error message if the given `address` is the same as the `safeAddress`', async () => {
       const address = '0x2D6F2B448b0F711Eb81f2929566504117d67E44F'
       const safeAddress = '0x2D6F2B448b0F711Eb81f2929566504117d67E44F'
 
-      expect(addressIsNotSafe(safeAddress)(address)).toEqual(OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR)
+      expect(addressIsNotCurrentSafe(safeAddress)(address)).toEqual(OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR)
     })
   })
 

--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -92,11 +92,15 @@ export const minMaxLength = (minLen: number, maxLen: number) => (value: string):
   value.length >= +minLen && value.length <= +maxLen ? undefined : `Should be ${minLen} to ${maxLen} symbols`
 
 export const ADDRESS_REPEATED_ERROR = 'Address already introduced'
+export const OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR = 'Cannot use Safe itself as owner.'
 
 export const uniqueAddress = (addresses: string[] | List<string> = []) => (address?: string): string | undefined => {
   const addressExists = addresses.some((addressFromList) => sameAddress(addressFromList, address))
   return addressExists ? ADDRESS_REPEATED_ERROR : undefined
 }
+
+export const addressIsNotSafe = (safeAddress: string) => (address?: string): string | undefined =>
+  sameAddress(safeAddress, address) ? OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR : undefined
 
 export const composeValidators = (...validators: Validator[]) => (value: unknown): ValidatorReturnType =>
   validators.reduce(

--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -99,7 +99,7 @@ export const uniqueAddress = (addresses: string[] | List<string> = []) => (addre
   return addressExists ? ADDRESS_REPEATED_ERROR : undefined
 }
 
-export const addressIsNotSafe = (safeAddress: string) => (address?: string): string | undefined =>
+export const addressIsNotCurrentSafe = (safeAddress: string) => (address?: string): string | undefined =>
   sameAddress(safeAddress, address) ? OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR : undefined
 
 export const composeValidators = (...validators: Validator[]) => (value: unknown): ValidatorReturnType =>

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/OwnerForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/OwnerForm/index.tsx
@@ -12,7 +12,7 @@ import Field from 'src/components/forms/Field'
 import GnoForm from 'src/components/forms/GnoForm'
 import TextField from 'src/components/forms/TextField'
 import {
-  addressIsNotSafe,
+  addressIsNotCurrentSafe,
   composeValidators,
   minMaxLength,
   required,
@@ -51,7 +51,7 @@ export const OwnerForm = ({ onClose, onSubmit }: OwnerFormProps): React.ReactEle
   const owners = useSelector(safeOwnersAddressesListSelector)
   const safeAddress = useSelector(safeParamAddressFromStateSelector)
   const ownerDoesntExist = uniqueAddress(owners)
-  const ownerAddressIsNotSafeAddress = addressIsNotSafe(safeAddress)
+  const ownerAddressIsNotSafeAddress = addressIsNotCurrentSafe(safeAddress)
 
   return (
     <>

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/OwnerForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/OwnerForm/index.tsx
@@ -11,14 +11,20 @@ import AddressInput from 'src/components/forms/AddressInput'
 import Field from 'src/components/forms/Field'
 import GnoForm from 'src/components/forms/GnoForm'
 import TextField from 'src/components/forms/TextField'
-import { composeValidators, minMaxLength, required, uniqueAddress } from 'src/components/forms/validator'
+import {
+  addressIsNotSafe,
+  composeValidators,
+  minMaxLength,
+  required,
+  uniqueAddress,
+} from 'src/components/forms/validator'
 import Block from 'src/components/layout/Block'
 import Button from 'src/components/layout/Button'
 import Col from 'src/components/layout/Col'
 import Hairline from 'src/components/layout/Hairline'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
-import { safeOwnersAddressesListSelector } from 'src/logic/safe/store/selectors'
+import { safeOwnersAddressesListSelector, safeParamAddressFromStateSelector } from 'src/logic/safe/store/selectors'
 
 export const ADD_OWNER_NAME_INPUT_TEST_ID = 'add-owner-name-input'
 export const ADD_OWNER_ADDRESS_INPUT_TEST_ID = 'add-owner-address-testid'
@@ -43,7 +49,9 @@ export const OwnerForm = ({ onClose, onSubmit }: OwnerFormProps): React.ReactEle
     onSubmit(values)
   }
   const owners = useSelector(safeOwnersAddressesListSelector)
+  const safeAddress = useSelector(safeParamAddressFromStateSelector)
   const ownerDoesntExist = uniqueAddress(owners)
+  const ownerAddressIsNotSafeAddress = addressIsNotSafe(safeAddress)
 
   return (
     <>
@@ -98,7 +106,7 @@ export const OwnerForm = ({ onClose, onSubmit }: OwnerFormProps): React.ReactEle
                       placeholder="Owner address*"
                       testId={ADD_OWNER_ADDRESS_INPUT_TEST_ID}
                       text="Owner address*"
-                      validators={[ownerDoesntExist]}
+                      validators={[ownerDoesntExist, ownerAddressIsNotSafeAddress]}
                     />
                   </Col>
                   <Col center="xs" className={classes} middle="xs" xs={1}>

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/OwnerForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/OwnerForm/index.tsx
@@ -10,7 +10,13 @@ import AddressInput from 'src/components/forms/AddressInput'
 import Field from 'src/components/forms/Field'
 import GnoForm from 'src/components/forms/GnoForm'
 import TextField from 'src/components/forms/TextField'
-import { composeValidators, minMaxLength, required, uniqueAddress } from 'src/components/forms/validator'
+import {
+  addressIsNotSafe,
+  composeValidators,
+  minMaxLength,
+  required,
+  uniqueAddress,
+} from 'src/components/forms/validator'
 import Identicon from 'src/components/Identicon'
 import Block from 'src/components/layout/Block'
 import Button from 'src/components/layout/Button'
@@ -19,7 +25,7 @@ import Hairline from 'src/components/layout/Hairline'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
-import { safeOwnersAddressesListSelector } from 'src/logic/safe/store/selectors'
+import { safeOwnersAddressesListSelector, safeParamAddressFromStateSelector } from 'src/logic/safe/store/selectors'
 
 import { styles } from './style'
 import { getExplorerInfo } from 'src/config'
@@ -40,7 +46,9 @@ const OwnerForm = ({ classes, onClose, onSubmit, ownerAddress, ownerName }) => {
     onSubmit(values)
   }
   const owners = useSelector(safeOwnersAddressesListSelector)
+  const safeAddress = useSelector(safeParamAddressFromStateSelector)
   const ownerDoesntExist = uniqueAddress(owners)
+  const ownerAddressIsNotSafeAddress = addressIsNotSafe(safeAddress)
 
   return (
     <>
@@ -126,7 +134,7 @@ const OwnerForm = ({ classes, onClose, onSubmit, ownerAddress, ownerName }) => {
                       placeholder="Owner address*"
                       testId={REPLACE_OWNER_ADDRESS_INPUT_TEST_ID}
                       text="Owner address*"
-                      validators={[ownerDoesntExist]}
+                      validators={[ownerDoesntExist, ownerAddressIsNotSafeAddress]}
                     />
                   </Col>
                   <Col center="xs" className={classes} middle="xs" xs={1}>

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/OwnerForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/OwnerForm/index.tsx
@@ -11,7 +11,7 @@ import Field from 'src/components/forms/Field'
 import GnoForm from 'src/components/forms/GnoForm'
 import TextField from 'src/components/forms/TextField'
 import {
-  addressIsNotSafe,
+  addressIsNotCurrentSafe,
   composeValidators,
   minMaxLength,
   required,
@@ -48,7 +48,7 @@ const OwnerForm = ({ classes, onClose, onSubmit, ownerAddress, ownerName }) => {
   const owners = useSelector(safeOwnersAddressesListSelector)
   const safeAddress = useSelector(safeParamAddressFromStateSelector)
   const ownerDoesntExist = uniqueAddress(owners)
-  const ownerAddressIsNotSafeAddress = addressIsNotSafe(safeAddress)
+  const ownerAddressIsNotSafeAddress = addressIsNotCurrentSafe(safeAddress)
 
   return (
     <>


### PR DESCRIPTION
Closes #1991 by:
- Adding `addressIsNotSafe` validator and using it on both `replace` and `addOwner` modal