### PR TITLE
(Fix) Invalid amounts in Send Funds modal

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.tsx
@@ -34,7 +34,7 @@ const SelectedToken = ({ tokenAddress, tokens }: SelectTokenProps): ReactElement
           <ListItemText
             className={classes.tokenData}
             primary={token.name}
-            secondary={`${formatAmount(token.balance?.toString() ?? '0')} ${token.symbol}`}
+            secondary={`${formatAmount(token.balance?.tokenBalance.toString() ?? '0')} ${token.symbol}`}
           />
         </>
       ) : (
@@ -73,7 +73,7 @@ const TokenSelectField = ({ initialValue, isValid = true, tokens }: TokenSelectF
           </ListItemIcon>
           <ListItemText
             primary={token.name}
-            secondary={`${formatAmount(token.balance?.toString() ?? '0')} ${token.symbol}`}
+            secondary={`${formatAmount(token.balance?.tokenBalance.toString() ?? '0')} ${token.symbol}`}
             data-testid={`select-token-${token.name}`}
           />
         </MenuItem>


### PR DESCRIPTION
Discovered by @francovenica, in `development`

![image](https://user-images.githubusercontent.com/3315606/111532786-cf471480-8744-11eb-9129-fa0a4702bc47.png)

The fix updates where the token's balance is extracted.