### PR TITLE
(Chore) Update `nativeCoin` address to ZERO_ADDRESS

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -286,7 +286,7 @@ const xDai: NetworkConfig = {
     label: 'xDai',
     isTestNet: false,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'xDai',
       symbol: 'xDai',
       decimals: 18,
@@ -343,7 +343,7 @@ const mainnet: NetworkConfig = {
     label: 'Mainnet',
     isTestNet: false,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'Ether',
       symbol: 'ETH',
       decimals: 18,

--- a/src/config/networks/energy_web_chain.ts
+++ b/src/config/networks/energy_web_chain.ts
@@ -38,7 +38,7 @@ const mainnet: NetworkConfig = {
     label: 'EWC',
     isTestNet: false,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'Energy web token',
       symbol: 'EWT',
       decimals: 18,

--- a/src/config/networks/local.ts
+++ b/src/config/networks/local.ts
@@ -29,7 +29,7 @@ const local: NetworkConfig = {
     label: 'LocalRPC',
     isTestNet: true,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'Ether',
       symbol: 'ETH',
       decimals: 18,

--- a/src/config/networks/mainnet.ts
+++ b/src/config/networks/mainnet.ts
@@ -38,7 +38,7 @@ const mainnet: NetworkConfig = {
     label: 'Mainnet',
     isTestNet: false,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'Ether',
       symbol: 'ETH',
       decimals: 18,

--- a/src/config/networks/rinkeby.ts
+++ b/src/config/networks/rinkeby.ts
@@ -38,7 +38,7 @@ const rinkeby: NetworkConfig = {
     label: 'Rinkeby',
     isTestNet: true,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'Ether',
       symbol: 'ETH',
       decimals: 18,

--- a/src/config/networks/volta.ts
+++ b/src/config/networks/volta.ts
@@ -35,7 +35,7 @@ const mainnet: NetworkConfig = {
     label: 'Volta',
     isTestNet: true,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'Energy web token',
       symbol: 'EWT',
       decimals: 18,

--- a/src/config/networks/xdai.ts
+++ b/src/config/networks/xdai.ts
@@ -29,7 +29,7 @@ const xDai: NetworkConfig = {
     label: 'xDai',
     isTestNet: false,
     nativeCoin: {
-      address: '0x000',
+      address: '0x0000000000000000000000000000000000000000',
       name: 'xDai',
       symbol: 'xDai',
       decimals: 18,

--- a/src/logic/safe/hooks/useTokenInfo.tsx
+++ b/src/logic/safe/hooks/useTokenInfo.tsx
@@ -1,18 +1,14 @@
 import { useSelector } from 'react-redux'
 
-import { getNetworkInfo } from 'src/config'
 import { Token } from 'src/logic/tokens/store/model/token'
-import { sameAddress, ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
+import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { safeKnownCoins } from 'src/routes/safe/container/selector'
-
-const { nativeCoin } = getNetworkInfo()
 
 const useTokenInfo = (address: string): Token | undefined => {
   const tokens = useSelector(safeKnownCoins)
 
   if (tokens) {
-    const tokenAddress = sameAddress(address, ZERO_ADDRESS) ? nativeCoin.address : address
-    return tokens.find((token) => sameAddress(token.address, tokenAddress)) ?? undefined
+    return tokens.find((token) => sameAddress(token.address, address))
   }
 }
 

--- a/src/logic/safe/utils/spendingLimits.ts
+++ b/src/logic/safe/utils/spendingLimits.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from 'bignumber.js'
-import { getNetworkInfo } from 'src/config'
 import { AbiItem } from 'web3-utils'
 
 import { CreateTransactionArgs } from 'src/logic/safe/store/actions/createTransaction'
@@ -9,7 +8,7 @@ import SpendingLimitModule from 'src/logic/contracts/artifacts/AllowanceModule.j
 import generateBatchRequests from 'src/logic/contracts/generateBatchRequests'
 import { getSpendingLimitContract, MULTI_SEND_ADDRESS } from 'src/logic/contracts/safeContracts'
 import { SpendingLimit } from 'src/logic/safe/store/models/safe'
-import { sameAddress, ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
+import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { getWeb3, web3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { SPENDING_LIMIT_MODULE_ADDRESS } from 'src/utils/constants'
 import { getEncodedMultiSendCallData, MultiSendTx } from './upgradeSafe'

--- a/src/logic/tokens/store/actions/fetchSafeTokens.ts
+++ b/src/logic/tokens/store/actions/fetchSafeTokens.ts
@@ -11,8 +11,6 @@ import { AppReduxState } from 'src/store'
 import { humanReadableValue } from 'src/logic/tokens/utils/humanReadableValue'
 import { safeActiveTokensSelector, safeSelector } from 'src/logic/safe/store/selectors'
 import { tokensSelector } from 'src/logic/tokens/store/selectors'
-import { sameAddress, ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
-import { getNetworkInfo } from 'src/config'
 import BigNumber from 'bignumber.js'
 import { currentCurrencySelector } from 'src/logic/currencyValues/store/selectors'
 

--- a/src/logic/tokens/store/actions/fetchSafeTokens.ts
+++ b/src/logic/tokens/store/actions/fetchSafeTokens.ts
@@ -27,24 +27,20 @@ interface ExtractedData {
   tokens: List<Token>
 }
 
-const { nativeCoin } = getNetworkInfo()
-
 const extractDataFromResult = (currentTokens: TokenState) => (
   acc: ExtractedData,
   { balance, fiatBalance, tokenInfo }: TokenBalance,
 ): ExtractedData => {
-  const { address: tokenAddress, decimals } = tokenInfo
-  if (sameAddress(tokenAddress, ZERO_ADDRESS) || sameAddress(tokenAddress, nativeCoin.address)) {
-    acc.ethBalance = humanReadableValue(balance, 18)
-  }
+  const { address, decimals } = tokenInfo
+
   acc.balances = acc.balances.merge({
-    [tokenAddress]: {
+    [address]: {
       fiatBalance,
       tokenBalance: humanReadableValue(balance, Number(decimals)),
     },
   })
 
-  if (currentTokens && !currentTokens.get(tokenAddress)) {
+  if (currentTokens && !currentTokens.get(address)) {
     acc.tokens = acc.tokens.push(makeToken({ ...tokenInfo }))
   }
 

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import Block from 'src/components/layout/Block'
 import Col from 'src/components/layout/Col'
 import Row from 'src/components/layout/Row'
-import { getNetworkInfo } from 'src/config'
 import { createTransaction, CreateTransactionArgs } from 'src/logic/safe/store/actions/createTransaction'
 import { SafeRecordProps, SpendingLimit } from 'src/logic/safe/store/models/safe'
 import {
@@ -20,7 +19,7 @@ import {
 import { MultiSendTx } from 'src/logic/safe/utils/upgradeSafe'
 import { makeToken, Token } from 'src/logic/tokens/store/model/token'
 import { fromTokenUnit, toTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
-import { sameAddress, ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
+import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { RESET_TIME_OPTIONS } from 'src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime'
 import { AddressInfo, ResetTimeInfo, TokenInfo } from 'src/routes/safe/components/Settings/SpendingLimit/InfoDisplay'
 import Modal from 'src/routes/safe/components/Settings/SpendingLimit/Modal'
@@ -33,8 +32,6 @@ import { ActionCallback, CREATE } from '.'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { TransactionFees } from 'src/components/TransactionsFees'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
-
-const { nativeCoin } = getNetworkInfo()
 
 const useExistentSpendingLimit = ({
   spendingLimits,
@@ -51,9 +48,7 @@ const useExistentSpendingLimit = ({
   return useMemo<SpendingLimit | null>(() => {
     // if `delegate` already exist, check what tokens were delegated to the _beneficiary_ `getTokens(safe, delegate)`
     const currentDelegate = spendingLimits?.find(
-      ({ delegate, token }) =>
-        sameAddress(delegate, values.beneficiary) &&
-        sameAddress(token, sameAddress(values.token, nativeCoin.address) ? ZERO_ADDRESS : values.token),
+      ({ delegate, token }) => sameAddress(delegate, values.beneficiary) && sameAddress(token, values.token),
     )
 
     // let the user know that is about to replace an existent allowance

--- a/src/routes/safe/container/selector.ts
+++ b/src/routes/safe/container/selector.ts
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect'
 import { Token } from 'src/logic/tokens/store/model/token'
 import { tokensSelector } from 'src/logic/tokens/store/selectors'
 import { getEthAsToken } from 'src/logic/tokens/utils/tokenHelpers'
-import { isUserAnOwner, sameAddress, ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
+import { isUserAnOwner, sameAddress } from 'src/logic/wallets/ethAddresses'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 
 import { safeActiveTokensSelector, safeBalancesSelector, safeSelector } from 'src/logic/safe/store/selectors'
@@ -37,7 +37,7 @@ export const extendedSafeTokensSelector = createSelector(
 
         if (baseToken) {
           const updatedBaseToken = baseToken.set('balance', tokenBalance || { tokenBalance: '0', fiatBalance: '0' })
-          if (sameAddress(tokenAddress, ZERO_ADDRESS) || sameAddress(tokenAddress, ethAsToken?.address)) {
+          if (sameAddress(tokenAddress, ethAsToken?.address)) {
             map.set(tokenAddress, updatedBaseToken.set('logoUri', ethAsToken?.logoUri || baseToken.logoUri))
           } else {
             map.set(tokenAddress, updatedBaseToken)


### PR DESCRIPTION
Based on an issue found by @francovenica, this PR migrates the `nativeCoin.address` identifier from `0x000` to `ZERO_ADDRESS`

![image](https://user-images.githubusercontent.com/3315606/111653843-f8b87c80-87e6-11eb-86e6-09b62c6bff2c.png)
