### PR TITLE
border_fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,22 +8,30 @@
     <title>Gnosis Safe Multisig</title>
   </head>
   <style>
-    .logo {
+    .spinner {
       position: absolute;
       top: 50%;
       left: 50%;
       width: 120px;
       height: 120px;
       margin:-60px 0 0 -60px;
-      -webkit-animation:spin 10s cubic-bezier(0,1.13,.5,.97) 1;
-      -moz-animation:spin 10s cubic-bezier(0,1.13,.5,.97) 1;
-      animation:spin 10s cubic-bezier(0,1.13,.5,.97) 1;
+      animation: sk-bounce 2.0s infinite ease-in-out;
+      animation-delay: -1.0s;
     }
-    @-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
-    @-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
-    @keyframes spin { 100% { transform:rotate(360deg); } }
+
+@keyframes sk-bounce {
+  0%, 100% {
+    transform: scale(0.8);
+    -webkit-transform: scale(0.8);
+  }
+  50% {
+    transform: scale(1.0);
+    -webkit-transform: scale(1.0);
+  }
+}
+
   </style>
   <body>
-    <div id="root" style="overflow: hidden;"><img class="logo" src="./resources/safe.png" /></div>
+    <div id="root" style="overflow: hidden;"><img class="spinner" src="./resources/safe.png" /></div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,23 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <title>Gnosis Safe Multisig</title>
   </head>
+  <style>
+    .logo {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 120px;
+      height: 120px;
+      margin:-60px 0 0 -60px;
+      -webkit-animation:spin 10s cubic-bezier(0,1.13,.5,.97) 1;
+      -moz-animation:spin 10s cubic-bezier(0,1.13,.5,.97) 1;
+      animation:spin 10s cubic-bezier(0,1.13,.5,.97) 1;
+    }
+    @-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+    @-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
+    @keyframes spin { 100% { transform:rotate(360deg); } }
+  </style>
   <body>
-    <div id="root" style="overflow: hidden;"></div>
+    <div id="root" style="overflow: hidden;"><img class="logo" src="./resources/safe.png" /></div>
   </body>
 </html>


### PR DESCRIPTION
The current production version doesn't have proper boarders (mix between 1px / 2px) and the shadows are not according to the Zeplin deisgns, with a drop-shadow below the header but none on the right of the sidebar which does not make sense asssuimng the light source comes from the front (see e.g. dropshadow of modals. While this is still not the proper design, it at least looks less messy.)