### PR TITLE
Bug: Safe app communicator is not properly initialized sometimes, thus app fails to communicate

### DIFF
--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -22,7 +22,7 @@ class AppCommunicator {
   constructor(iframeRef: MutableRefObject<HTMLIFrameElement | null>, app: SafeApp) {
     this.iframeRef = iframeRef
     this.app = app
-    console.log('communicator initialized')
+
     window.addEventListener('message', this.handleIncomingMessage)
   }
 

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -55,9 +55,8 @@ class AppCommunicator {
   handleIncomingMessage = async (msg: SDKMessageEvent): Promise<void> => {
     const validMessage = this.isValidMessage(msg)
     const hasHandler = this.canHandleMessage(msg)
-    console.log({ msg })
+
     if (validMessage && hasHandler) {
-      console.log({ msg })
       const handler = this.handlers.get(msg.data.method)
       try {
         // @ts-expect-error Handler existence is checked in this.canHandleMessage
@@ -90,7 +89,7 @@ const useAppCommunicator = (
       communicatorInstance = new AppCommunicator(iframeRef, app)
       setCommunicator(communicatorInstance)
     }
-    console.log({ app, iframeRef })
+
     if (app) {
       initCommunicator(iframeRef as MutableRefObject<HTMLIFrameElement>, app)
     }


### PR DESCRIPTION
**The problem:**
Safe App communicator (class listening to messages from a safe app) sometimes may not initialize properly and it resulted in a safe app failing to communicate.

**The reason:**
The communicator has two constructor parameters - iframe and safe app info. It uses the iframe element to send messages to the app, but AppFrame component has quite some logic that may result in safe app iframe not rendering:
https://github.com/gnosis/safe-react/blob/development/src/routes/safe/components/Apps/components/AppFrame.tsx#L279-L293

But the `useAppCommunicator` hook is still called and inside the hook it checked if `iframeRef.current` exists. The thing is that if it doesn't exist at the time of execution, it wont trigger the hook again because it's a ref.. So I changed the function parameter to accept the ref object itself and use the `.current` property, this way the communicator is always initialised

