### PR TITLE
Update wallet connect to correctly show the banner

### DIFF
--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -133,7 +133,7 @@ export const staticAppsList: Array<StaticAppInfo> = [
   },
   // Wallet-Connect
   {
-    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmU1pT35yPXxpnABcH3pZ1MxFeyYVtftT5RKhWopQmZHQV`,
+    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmX9B982ZAaBzbm6yBoZUS3uLgcizYA6wW65RCXVRZkG6f`,
     disabled: false,
     networks: [
       ETHEREUM_NETWORK.MAINNET,


### PR DESCRIPTION
Wallet connect app wasn't correctly displaying the banner. We uploaded a new version of walletConnect to IPFS with this issue solved