### PR TITLE
Wording enhancements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <title>Gnosis Safe Multisig</title>
+    <title>Gnosis Safe</title>
   </head>
   <style>
     .safe-preloader-animation {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Gnosis Safe Multisig
+# Gnosis Safe
 
 The most trusted platform to store digital assets on Ethereum
 

--- a/src/components/AppLayout/MobileNotSupported/index.tsx
+++ b/src/components/AppLayout/MobileNotSupported/index.tsx
@@ -112,7 +112,7 @@ export const MobileNotSupported = ({ onClose }: Props): ReactElement => {
       <Overlay>
         <ModalApp>
           <StyledCard>
-            <Text size="lg">The Safe Multisig web app is not optimized for mobile.</Text>
+            <Text size="lg">The Gnosis Safe web app is not optimized for mobile.</Text>
             <Text size="lg">Get the mobile app for a better experience.</Text>
             <Button size="md" color="primary" variant="contained">
               <StyledLink target="_blank" href="https://gnosis-safe.io/#mobile" rel="noopener noreferrer">

--- a/src/components/ConnectButton/index.tsx
+++ b/src/components/ConnectButton/index.tsx
@@ -42,7 +42,7 @@ export const onboard = Onboard({
     },
   },
   walletSelect: {
-    description: 'Please select a wallet to connect to Gnosis Safe Multisig',
+    description: 'Please select a wallet to connect to Gnosis Safe',
     wallets,
   },
   walletCheck: [

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -159,7 +159,7 @@ export default (safeAdd: string) => async (
 ): Promise<Action | void> => {
   try {
     const safeAddress = checksumAddress(safeAdd)
-    const safeName = (await getSafeName(safeAddress)) || 'LOADED SAFE'
+    const safeName = (await getSafeName(safeAddress)) || 'Gnosis Safe'
     const latestMasterContractVersion = latestMasterContractVersionSelector(getState())
     const totalFiatBalance = safeTotalFiatBalanceSelector(getState())
     const safeProps = await buildSafe(safeAddress, safeName, latestMasterContractVersion, totalFiatBalance)

--- a/src/logic/safe/store/reducer/safe.ts
+++ b/src/logic/safe/store/reducer/safe.ts
@@ -88,7 +88,7 @@ export default handleActions<AppReduxState['safes'], Payloads>(
       return shouldUpdate
         ? state.updateIn(
             ['safes', safeAddress],
-            makeSafe({ name: safe?.name || 'LOADED SAFE', address: safeAddress }),
+            makeSafe({ name: safe?.name || 'Gnosis Safe', address: safeAddress }),
             (prevSafe) => updateSafeProps(prevSafe, safe),
           )
         : state
@@ -106,7 +106,7 @@ export default handleActions<AppReduxState['safes'], Payloads>(
       return shouldUpdate
         ? state.updateIn(
             ['safes', safeAddress],
-            makeSafe({ name: safe?.name || 'LOADED SAFE', address: safeAddress }),
+            makeSafe({ name: safe?.name || 'Gnosis Safe', address: safeAddress }),
             (prevSafe) => updateSafeProps(prevSafe, safe),
           )
         : state

--- a/src/routes/load/components/Layout.tsx
+++ b/src/routes/load/components/Layout.tsx
@@ -48,7 +48,7 @@ const Layout = ({ network, onLoadSafeSubmit, provider, userAddress }: LayoutProp
           <IconButton disableRipple onClick={back} style={iconStyle}>
             <ChevronLeft />
           </IconButton>
-          <Heading tag="h2">Load existing Safe</Heading>
+          <Heading tag="h2">Add existing Safe</Heading>
         </Row>
         <Stepper<LoadFormValues>
           buttonLabels={buttonLabels}

--- a/src/routes/open/components/Layout.tsx
+++ b/src/routes/open/components/Layout.tsx
@@ -117,7 +117,7 @@ export const Layout = (props: LayoutProps): React.ReactElement => {
           <ChevronLeft />
         </IconButton>
         <Heading tag="h2" testId="create-safe-form-title">
-          Create New Safe
+          Create new Safe
         </Heading>
       </Row>
       <Stepper

--- a/src/routes/open/components/SafeNameForm/index.tsx
+++ b/src/routes/open/components/SafeNameForm/index.tsx
@@ -44,8 +44,8 @@ const SafeNameForm = ({ safeName }: { safeName: string }): React.ReactElement =>
     <>
       <Block margin="lg">
         <Paragraph color="primary" noMargin size="lg">
-          You are about to create a new Gnosis Safe wallet with one or more owners. First, let&apos;s give your new
-          wallet a name. This name is only stored locally and will never be shared with Gnosis or any third parties.
+          You are about to create a new Safe with one or more owners. First, let&apos;s give your new Safe a name. This
+          name is only stored locally and will never be shared with Gnosis or any third parties.
         </Paragraph>
       </Block>
       <Block className={classes.root} margin="lg">

--- a/src/routes/safe/components/Settings/Advanced/index.tsx
+++ b/src/routes/safe/components/Settings/Advanced/index.tsx
@@ -57,8 +57,8 @@ export const Advanced = (): React.ReactElement => {
           Safe Nonce
         </Title>
         <InfoText size="lg">
-          For security reasons, transactions made with the Safe need to be executed in order. The nonce shows you which
-          transaction was executed most recently. You can find the nonce for a transaction in the transaction details.
+          For security reasons, transactions made with Gnosis Safe need to be executed in order. The nonce shows you
+          which transaction will be executed next. You can find the nonce for a transaction in the transaction details.
         </InfoText>
         <InfoText color="secondaryLight" size="xl">
           Current Nonce: <Bold>{nonce}</Bold>

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -120,7 +120,7 @@ const SafeDetails = (): React.ReactElement => {
       {() => (
         <>
           <Block className={classes.formContainer}>
-            <Heading tag="h2">Safe Version</Heading>
+            <Heading tag="h2">Contract Version</Heading>
             <Row align="end" grow>
               <StyledLink rel="noreferrer noopener" target="_blank" href={safeInfo?.deployerRepoUrl}>
                 <Text size="xl" as="span" color="primary">

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitSteps.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitSteps.tsx
@@ -38,7 +38,7 @@ export const NewLimitSteps = (): ReactElement => (
       </Text>
 
       <Text size="lg" color="placeHolder" center>
-        Choose an account that will benefit from this allowance.
+        Define beneficiary that will be able to use the allowance.
       </Text>
 
       <Text size="lg" color="placeHolder" center>

--- a/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
@@ -16,7 +16,7 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
       <div className="tx-summary">
         <div className="tx-hash">
           <Text size="xl" strong as="span">
-            Hash:{' '}
+            Transaction hash:{' '}
           </Text>
           <InlineEthHashInfo
             textSize="xl"

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -17,7 +17,7 @@ export const TxSummary = ({ txDetails }: { txDetails: ExpandedTxDetails }): Reac
     <>
       <div className="tx-hash">
         <Text size="xl" strong as="span">
-          Hash:{' '}
+          Transaction hash:{' '}
         </Text>
         {txHash ? (
           <InlineEthHashInfo textSize="xl" hash={txHash} shortenHash={8} showCopyBtn explorerUrl={explorerUrl} />

--- a/src/routes/welcome/components/index.tsx
+++ b/src/routes/welcome/components/index.tsx
@@ -107,7 +107,7 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
               </StyledTitle>
             </TitleWrapper>
             <Text size="xl">
-              Gnosis Safe supports a wide range of wallets that you can choose to be one of the authentication factors.
+              Gnosis Safe supports a wide range of wallets that you can choose to interact with your Safe.
             </Text>
             <StyledButtonLink textSize="xl" color="primary" iconType="externalLink" iconSize="sm">
               <LinkSRC
@@ -115,9 +115,9 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
                 href="https://help.gnosis-safe.io/en/articles/4689442-why-do-i-need-to-connect-a-wallet"
                 target="_blank"
                 rel="noopener noreferrer"
-                title="More info about: Why do I need to connect wallet?"
+                title="More info about: Why do I need to connect a wallet?"
               >
-                Why do I need to connect wallet?
+                Why do I need to connect a wallet?
               </LinkSRC>
             </StyledButtonLink>
             <StyledButton
@@ -146,7 +146,7 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
                 </StyledTitle>
               </TitleWrapper>
               <Text size="xl">
-                Create a new Safe Multisig that is controlled by one or multiple owners. <br />
+                Create a new Safe that is controlled by one or multiple owners. <br />
                 You will be required to pay a network fee for creating your new Safe.
               </Text>
               <StyledButton size="lg" color="primary" variant="contained" component={Link} to={OPEN_ADDRESS}>
@@ -161,11 +161,11 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
             {/* Load safe */}
             <CardsCol>
               <StyledTitleOnly size="sm" strong withoutMargin>
-                Load existing Safe
+                Add existing Safe
               </StyledTitleOnly>
               <Text size="xl">
-                Already have a Safe? Do you want to access your Safe Multisig from a different device? Easily load your
-                Safe Multisig using your Safe address.
+                Already have a Safe? Do you want to access your Safe from a different device? Easily add it using your
+                Safe address.
               </Text>
               <StyledButton
                 variant="bordered"
@@ -177,7 +177,7 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
                 to={LOAD_ADDRESS}
               >
                 <Text size="xl" color="secondary">
-                  Load existing Safe
+                  Add existing Safe
                 </Text>
               </StyledButton>
             </CardsCol>

--- a/src/routes/welcome/components/index.tsx
+++ b/src/routes/welcome/components/index.tsx
@@ -77,7 +77,7 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
     <Block>
       {/* Title */}
       <Title size="md" strong>
-        Welcome to Gnosis Safe Multisig.
+        Welcome to Gnosis Safe.
       </Title>
 
       {/* Subtitle */}
@@ -89,8 +89,7 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
           </>
         ) : (
           <>
-            Gnosis Safe Multisig is the most trusted platform to manage digital assets. <br /> Here is how to get
-            started:{' '}
+            Gnosis Safe is the most trusted platform to manage digital assets. <br /> Here is how to get started:{' '}
           </>
         )}
       </Title>
@@ -108,8 +107,7 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
               </StyledTitle>
             </TitleWrapper>
             <Text size="xl">
-              Gnosis Safe Multisig supports a wide range of wallets that you can choose to be one of the authentication
-              factors.
+              Gnosis Safe supports a wide range of wallets that you can choose to be one of the authentication factors.
             </Text>
             <StyledButtonLink textSize="xl" color="primary" iconType="externalLink" iconSize="sm">
               <LinkSRC


### PR DESCRIPTION
- Replace "Gnosis Safe Multisig" and "Safe Multisig" with "Gnosis Safe" or "Safe" everywhere

- Align wording with mobile app (Hash -> Transaction hash, Safe Version -> Contract Version)

- Replace "Loaded Safe" and "load Safe" as "loaded" has a double-meaning (rich, lots of money) which is not ideal in this context. Also, "load Safe" might indicate temporary adding a Safe whereas "add Safe" is more explicit about the permenant nature of adding a Safe to the list.