### PR TITLE
Prevent rendering safe-app outside its container while loading

### DIFF
--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -59,11 +59,12 @@ const StyledCard = styled(Card)`
   padding: 0;
 `
 
-const StyledIframe = styled.iframe`
+const StyledIframe = styled.iframe<{ isLoading: boolean }>`
   height: 100%;
   width: 100%;
   overflow: auto;
   box-sizing: border-box;
+  display: ${({ isLoading }) => (isLoading ? 'none' : 'block')};
 `
 
 const Breadcrumb = styled.div`
@@ -326,6 +327,7 @@ const AppFrame = ({ appUrl }: Props): React.ReactElement => {
         )}
 
         <StyledIframe
+          isLoading={appIsLoading}
           frameBorder="0"
           id={`iframe-${appUrl}`}
           ref={iframeRef}


### PR DESCRIPTION
closes #1753.

The problem is produced because of a loading placeholder we are using while the safe-app is being fetched. That placeholder pushed down the iframe. To fix this problem I added a `display` property (css) to hide the Iframe while the safe-app loads. 

@dasanra perhaps we can include this fix in the current sprint as the fix is really straightforward, with no risk that anything could break. 