### PR TITLE
[Hotfix v3.3.2] Rollback offchain signing to require v >= 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/logic/safe/transactions/offchainSigner/index.ts
+++ b/src/logic/safe/transactions/offchainSigner/index.ts
@@ -17,7 +17,7 @@ const SIGNERS = {
 const getSignersByWallet = (isHW) =>
   isHW ? [SIGNERS.ETH_SIGN] : [SIGNERS.EIP712_V3, SIGNERS.EIP712_V4, SIGNERS.EIP712, SIGNERS.ETH_SIGN]
 
-export const SAFE_VERSION_FOR_OFFCHAIN_SIGNATURES = '>=1.0.0'
+export const SAFE_VERSION_FOR_OFFCHAIN_SIGNATURES = '>=1.1.1'
 
 export const tryOffchainSigning = async (safeTxHash: string, txArgs, isHW: boolean): Promise<string> => {
   let signature


### PR DESCRIPTION
Offchain signing is not working propperly for v1.0.0 of the smart contracts as reported in #2130 

We are rolling back this change to avoid issues for people using safes with smart contract version v1.0.0