### PR TITLE
Bugfix: fix off-chain signatures for safes 1.0.0

### DIFF
--- a/src/logic/safe/safeTxSigner.ts
+++ b/src/logic/safe/safeTxSigner.ts
@@ -2,7 +2,7 @@ import { List } from 'immutable'
 import { Confirmation } from 'src/logic/safe/store/models/types/confirmation'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import semverSatisfies from 'semver/functions/satisfies'
-import { SAFE_VERSION_FOR_OFFCHAIN_SIGNATURES } from './transactions/offchainSigner'
+import { SAFE_VERSION_FOR_OFF_CHAIN_SIGNATURES } from './transactions/offchainSigner'
 
 // Here we're checking that safe contract version is greater or equal 1.1.1, but
 // theoretically EIP712 should also work for 1.0.0 contracts
@@ -17,7 +17,7 @@ export const checkIfOffChainSignatureIsPossible = (
   !isExecution &&
   !isSmartContractWallet &&
   !!safeVersion &&
-  semverSatisfies(safeVersion, SAFE_VERSION_FOR_OFFCHAIN_SIGNATURES)
+  semverSatisfies(safeVersion, SAFE_VERSION_FOR_OFF_CHAIN_SIGNATURES)
 
 // https://docs.gnosis.io/safe/docs/contracts_signatures/#pre-validated-signatures
 export const getPreValidatedSignatures = (from: string, initialString: string = EMPTY_DATA): string => {

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -9,7 +9,7 @@ import {
   getApprovalTransaction,
   getExecutionTransaction,
   saveTxToHistory,
-  tryOffchainSigning,
+  tryOffChainSigning,
 } from 'src/logic/safe/transactions'
 import { estimateSafeTxGas } from 'src/logic/safe/transactions/gas'
 import * as aboutToExecuteTx from 'src/logic/safe/utils/aboutToExecuteTx'
@@ -118,7 +118,7 @@ export const createTransaction = (
 
   try {
     if (checkIfOffChainSignatureIsPossible(isExecution, smartContractWallet, safeVersion)) {
-      const signature = await tryOffchainSigning(safeTxHash, { ...txArgs, safeAddress }, hardwareWallet)
+      const signature = await tryOffChainSigning(safeTxHash, { ...txArgs, safeAddress }, hardwareWallet, safeVersion)
 
       if (signature) {
         dispatch(closeSnackbarAction({ key: beforeExecutionKey }))

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -10,7 +10,7 @@ import {
   getPreValidatedSignatures,
 } from 'src/logic/safe/safeTxSigner'
 import { getApprovalTransaction, getExecutionTransaction, saveTxToHistory } from 'src/logic/safe/transactions'
-import { tryOffchainSigning } from 'src/logic/safe/transactions/offchainSigner'
+import { tryOffChainSigning } from 'src/logic/safe/transactions/offchainSigner'
 import * as aboutToExecuteTx from 'src/logic/safe/utils/aboutToExecuteTx'
 import { getCurrentSafeVersion } from 'src/logic/safe/utils/safeVersion'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
@@ -111,7 +111,7 @@ export const processTransaction = ({
 
   try {
     if (checkIfOffChainSignatureIsPossible(isExecution, smartContractWallet, safeVersion)) {
-      const signature = await tryOffchainSigning(tx.safeTxHash, { ...txArgs, safeAddress }, hardwareWallet)
+      const signature = await tryOffChainSigning(tx.safeTxHash, { ...txArgs, safeAddress }, hardwareWallet, safeVersion)
 
       if (signature) {
         dispatch(closeSnackbarAction({ key: beforeExecutionKey }))

--- a/src/logic/safe/transactions/offchainSigner/index.ts
+++ b/src/logic/safe/transactions/offchainSigner/index.ts
@@ -1,6 +1,8 @@
+import semverSatisfies from 'semver/functions/satisfies'
+
+import { METAMASK_REJECT_CONFIRM_TX_ERROR_CODE } from 'src/logic/safe/store/actions/createTransaction'
 import { getEIP712Signer } from './EIP712Signer'
 import { ethSigner } from './ethSigner'
-import { METAMASK_REJECT_CONFIRM_TX_ERROR_CODE } from 'src/logic/safe/store/actions/createTransaction'
 
 // 1. we try to sign via EIP-712 if user's wallet supports it
 // 2. If not, try to use eth_sign (Safe version has to be >1.1.1)
@@ -13,16 +15,32 @@ const SIGNERS = {
   ETH_SIGN: ethSigner,
 }
 
+export const SAFE_VERSION_FOR_OFF_CHAIN_SIGNATURES = '>=1.0.0'
+
 // hardware wallets support eth_sign only
-const getSignersByWallet = (isHW) =>
-  isHW ? [SIGNERS.ETH_SIGN] : [SIGNERS.EIP712_V3, SIGNERS.EIP712_V4, SIGNERS.EIP712, SIGNERS.ETH_SIGN]
+// eth_sign is only supported by safes >= 1.1.0
+const getSignersByWallet = (isHW: boolean, safeVersion: string) => {
+  debugger
+  const safeSupportsEthSigner = semverSatisfies(safeVersion, '>=1.1.0')
 
-export const SAFE_VERSION_FOR_OFFCHAIN_SIGNATURES = '>=1.0.0'
+  const signers = isHW ? [] : [SIGNERS.EIP712_V3, SIGNERS.EIP712_V4, SIGNERS.EIP712]
 
-export const tryOffchainSigning = async (safeTxHash: string, txArgs, isHW: boolean): Promise<string> => {
+  if (safeSupportsEthSigner) {
+    signers.push(SIGNERS.ETH_SIGN)
+  }
+
+  return signers
+}
+
+export const tryOffChainSigning = async (
+  safeTxHash: string,
+  txArgs,
+  isHW: boolean,
+  safeVersion: string,
+): Promise<string | undefined> => {
   let signature
 
-  const signerByWallet = getSignersByWallet(isHW)
+  const signerByWallet = getSignersByWallet(isHW, safeVersion)
   for (const signingFunc of signerByWallet) {
     try {
       signature = await signingFunc({ ...txArgs, safeTxHash })


### PR DESCRIPTION
Closes #2130.

### Fix ###
`eth_sign` method was [excluded](https://github.com/gnosis/safe-react/compare/issue-2130?expand=1#diff-9beb629ba8fb174d9d2140203066acc216889f40595f0f62a71dbd5f44aaa737R24) for off-chain signatures for safes with versions lower than v1.1.0

### How to test ###
- Open a save with version v1.0.0
- Create a Tx and sign it off-chain
- After collecting all the signatures and executing the tx should succeed.
- *NOTE* for hardware wallets off-chain won't be possible for these safes v1.0.0