### PR TITLE
Fix: toInfo could be null

### DIFF
--- a/src/logic/safe/store/models/types/gateway.d.ts
+++ b/src/logic/safe/store/models/types/gateway.d.ts
@@ -133,7 +133,7 @@ type BaseCustom = {
   dataSize: string
   value: string
   isCancellation: boolean
-  toInfo: AddressInfo
+  toInfo?: AddressInfo
 }
 
 type Custom = BaseCustom & {

--- a/src/routes/safe/components/Transactions/TxList/TxData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxData.tsx
@@ -33,7 +33,7 @@ const DetailsWithTxInfo = ({ children, txData, txInfo }: DetailsWithTxInfoProps)
   let name
   let avatarUrl
 
-  if (isCustomTxInfo(txInfo)) {
+  if (isCustomTxInfo(txInfo) && txInfo.toInfo) {
     name = txInfo.toInfo.name
     avatarUrl = txInfo.toInfo.logoUri
   }


### PR DESCRIPTION
Closes #2136.

As franco a Lylia reported, some tx could explode when the details are opened in the tx list. It only happens when it's consuming the client gateway in production, but it does not in staging. That's why we requested Jose to verify this via slack.

Independently of what Jose says, we could add a simple fix to prevent this error and that's validating if `toInfo` is defined before accessing its data.

