### PR TITLE
Bug: Apps SDK won't work if you change an origin within iframe

### DIFF
--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -33,10 +33,9 @@ class AppCommunicator {
   private isValidMessage = (msg: SDKMessageEvent): boolean => {
     // @ts-expect-error .parent doesn't exist on some possible types
     const sentFromIframe = msg.source.parent === window.parent
-    const knownOrigin = this.app.url.includes(msg.origin)
     const knownMethod = Object.values(METHODS).includes(msg.data.method)
 
-    return knownOrigin && sentFromIframe && knownMethod
+    return sentFromIframe && knownMethod
   }
 
   private canHandleMessage = (msg: SDKMessageEvent): boolean => {
@@ -49,7 +48,7 @@ class AppCommunicator {
       ? MessageFormatter.makeErrorResponse(requestId, data, sdkVersion)
       : MessageFormatter.makeResponse(requestId, data, sdkVersion)
 
-    this.iframeRef.current?.contentWindow?.postMessage(msg, this.app.url)
+    this.iframeRef.current?.contentWindow?.postMessage(msg, '*')
   }
 
   handleIncomingMessage = async (msg: SDKMessageEvent): Promise<void> => {


### PR DESCRIPTION
**The problem:**

curve.fi links to their DAO app from their safe app, when you land there, it won't work.

**The reason:**

We use apps URL when sending a message to the app and the URL gets changed within the iframe

**The solution:**

Use a wildcard for sending messages. We cannot listen to URL changes within the iframe because browsers restrict it for cross-origin iframes. I'm not 100% sure about possible security risks, the only one I can think of is if someone can load a malicious app within the iframe.

**Testing**
1. Add curve.fi as a custom app
2. Click "DAO" in the app header

Current production:
3. DAO app doesn't connect to a safe
This PR:
3. DAO app connects to a safe