### PR TITLE
Fix the address book, don't filter the addresses

### DIFF
--- a/src/logic/addressBook/store/middleware/addressBookMiddleware.ts
+++ b/src/logic/addressBook/store/middleware/addressBookMiddleware.ts
@@ -23,11 +23,7 @@ const addressBookMiddleware = (store) => (next) => async (action) => {
     const safes = safesListSelector(state)
 
     if (addressBook.length) {
-      const filteredSafeAddresses = safes
-        .filter((safe) => !safe.loadedViaUrl)
-        .map((safe) => safe.address)
-        .toJS()
-      await saveAddressBook(addressBook.filter((entry) => filteredSafeAddresses.includes(entry.address)))
+      await saveAddressBook(addressBook)
     }
 
     switch (action.type) {


### PR DESCRIPTION
Fixes the 1st bug in #2189.

Not sure what the intention of this code was (introduced in #2101) but it seems to be breaking some of the existing use cases.

Let's revert it for now and re-think what we wanted to achieve there.