### PR TITLE
Fix v3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {


### PR DESCRIPTION
### Fixed
 - When opening a safe that is stored locally after v3.5.0 update the app crashes

There was a type change in one of the parameters in local store. For already loaded safes is not stored correctly. The object is properly created once the information is fetch from the client-gateway again.

We will return an empty list when we detect an error and wait until we update the information from the client-gateway to show the assets list