### PR TITLE
Known addresses: Fallback image when image is broken.

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@gnosis.pm/safe-apps-sdk": "1.0.3",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-contracts": "1.1.1-dev.2",
-    "@gnosis.pm/safe-react-components": "https://github.com/gnosis/safe-react-components.git#5a4b1fe",
+    "@gnosis.pm/safe-react-components": "https://github.com/gnosis/safe-react-components.git#5a96910",
     "@gnosis.pm/util-contracts": "2.0.6",
     "@ledgerhq/hw-transport-node-hid-singleton": "5.49.0",
     "@material-ui/core": "^4.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,9 +1637,9 @@
     solc "0.5.14"
     truffle "^5.1.21"
 
-"@gnosis.pm/safe-react-components@https://github.com/gnosis/safe-react-components.git#5a4b1fe":
+"@gnosis.pm/safe-react-components@https://github.com/gnosis/safe-react-components.git#5a96910":
   version "0.5.0"
-  resolved "https://github.com/gnosis/safe-react-components.git#5a4b1fee2af7c41c3093fd3fa040f47d1eec8941"
+  resolved "https://github.com/gnosis/safe-react-components.git#5a96910529f2d108f48bfa5f117f06b3578d7b9e"
   dependencies:
     classnames "^2.2.6"
     react-media "^1.10.0"


### PR DESCRIPTION
Closes #2133.

The only change needed for fixing the bug is an update of SRC.

In SRC I've worked on a modification for `EthHanInfo` in order to fallback to Identicon if a broken image was provided in `customAvatar` without `customAvatarFallback`. That change was enough to fix the bug reported. 
