### PR TITLE
Feature: Remove logging about message without a messageId in Safe Apps

### DIFF
--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -66,7 +66,6 @@ const useIframeMessageHandler = (
       requestId: RequestId,
     ): void => {
       if (!messageId) {
-        console.error('ThirdPartyApp: A message was received without message id.')
         return
       }
 


### PR DESCRIPTION
This PR:
- removes console.error about a message without a message-id

Safe Apps developers are overwhelmed with this message thinking this is an error. This message comes from sdk v0.1 beta integration and doesn't really mean anything