### PR TITLE
(Fix) Remove exponential back-off strategy for balance fetching

### DIFF
--- a/src/logic/tokens/store/actions/fetchSafeTokens.ts
+++ b/src/logic/tokens/store/actions/fetchSafeTokens.ts
@@ -1,4 +1,3 @@
-import { backOff } from 'exponential-backoff'
 import { List } from 'immutable'
 import { Dispatch } from 'redux'
 
@@ -60,9 +59,10 @@ export const fetchSafeTokens = (safeAddress: string, currencySelected?: string) 
     }
     const selectedCurrency = currentCurrencySelector(state)
 
-    const tokenCurrenciesBalances = await backOff(() =>
-      fetchTokenCurrenciesBalances({ safeAddress, selectedCurrency: currencySelected ?? selectedCurrency }),
-    )
+    const tokenCurrenciesBalances = await fetchTokenCurrenciesBalances({
+      safeAddress,
+      selectedCurrency: currencySelected ?? selectedCurrency,
+    })
 
     const { balances, ethBalance, tokens } = tokenCurrenciesBalances.items.reduce<ExtractedData>(
       extractDataFromResult,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

This PR template was copied from https://github.com/testing-library/react-testing-library/blob/main/.github/PULL_REQUEST_TEMPLATE.md

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes #2224

<br />
<!-- Why are these changes necessary? -->

**Why**:
> We use exponential backoff to refetch the balances in case of an error with increasing delay. Because the initial delay is not set this will result in an increased amount of balances request in case of an error.

<br />
<!-- How were these changes implemented? -->

**How**:
Getting rid of the exponential backoff strategy as it's not necessary to have balances up to date.
We're already polling (every 15s) for updated data.

Also, by accessing the `balances` URL, there's an additional request for balances https://github.com/gnosis/safe-react/blob/15ae933a18c2fbd6c092e3cd95445678247621c6/src/routes/safe/components/Balances/index.tsx#L56


<br />
<!-- If applicable, add the steps to test your changes -->

**How to test it**:
* go to "Network" tab in devTools
* filter by "trusted=false" or "balances/USD" (the latter will depend on the currency you've selected)
* select any of the requests that appear in the list and block by URL (see https://github.com/gnosis/safe-react/issues/2053#issuecomment-819538608)
* before this fix you'll see several requests piling up (with this fix you'll see one failed request every ~15s)

<br />
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

|||
|---|---|
|**before**|![before](https://user-images.githubusercontent.com/3315606/116632064-9f3a8600-a92c-11eb-8a2c-9793ac0439cf.gif)|
|**after**|![after](https://user-images.githubusercontent.com/3315606/116632068-a497d080-a92c-11eb-9f7c-779c1c1f0b2a.gif)|