### PR TITLE
Fix GA problem after disabling cookies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
     "@typechain/web3-v1": "^2.2.0",
     "@types/history": "4.6.2",
     "@types/jest": "^26.0.22",
+    "@types/js-cookie": "^2.2.6",
     "@types/lodash.get": "^4.4.6",
     "@types/lodash.memoize": "^4.1.6",
     "@types/node": "^14.14.37",

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -10,7 +10,7 @@ import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBann
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
 import { loadFromCookie, saveCookie, removeCookie } from 'src/logic/cookies/utils'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
-import { COOKIE_GAT, COOKIE_GA, COOKIE_GIT, loadGoogleAnalytics } from 'src/utils/googleAnalytics'
+import { COOKIES_LIST, loadGoogleAnalytics } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
 import AlertRedIcon from './assets/alert-red.svg'
 import IntercomIcon from './assets/intercom.png'
@@ -163,9 +163,7 @@ const CookiesBanner = (): ReactElement => {
 
     // we remove GA cookies manually as react-ga does not provides a utility for it.
     if (!localAnalytics) {
-      removeCookie(COOKIE_GA.name, COOKIE_GA.path)
-      removeCookie(COOKIE_GAT.name, COOKIE_GAT.path)
-      removeCookie(COOKIE_GIT.name, COOKIE_GIT.path)
+      COOKIES_LIST.forEach((cookie) => removeCookie(cookie.name, cookie.path))
     }
 
     if (!localIntercom && isIntercomLoaded()) {

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -8,7 +8,7 @@ import Link from 'src/components/layout/Link'
 import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
-import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
+import { loadFromCookie, saveCookie, removeCookie } from 'src/logic/cookies/utils'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
 import { loadGoogleAnalytics } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
@@ -160,6 +160,14 @@ const CookiesBanner = (): ReactElement => {
     await saveCookie(COOKIES_KEY, newState, expDays)
     setShowAnalytics(localAnalytics)
     setShowIntercom(localIntercom)
+
+    // we remove GA cookies manually as react-ga does not provides a utility for it.
+    if (!localAnalytics) {
+      removeCookie('_ga')
+      removeCookie('_gat')
+      removeCookie('_gid')
+    }
+
     if (!localIntercom && isIntercomLoaded()) {
       closeIntercom()
     }

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -163,7 +163,8 @@ const CookiesBanner = (): ReactElement => {
 
     // we remove GA cookies manually as react-ga does not provides a utility for it.
     if (!localAnalytics) {
-      COOKIES_LIST.forEach((cookie) => removeCookie(cookie.name, cookie.path))
+      const subDomain = location.host.split('.').slice(-2).join('.')
+      COOKIES_LIST.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${subDomain}`))
     }
 
     if (!localIntercom && isIntercomLoaded()) {

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -10,7 +10,7 @@ import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBann
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
 import { loadFromCookie, saveCookie, removeCookie } from 'src/logic/cookies/utils'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
-import { loadGoogleAnalytics } from 'src/utils/googleAnalytics'
+import { COOKIE_GAT, COOKIE_GA, COOKIE_GIT, loadGoogleAnalytics } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
 import AlertRedIcon from './assets/alert-red.svg'
 import IntercomIcon from './assets/intercom.png'
@@ -163,9 +163,9 @@ const CookiesBanner = (): ReactElement => {
 
     // we remove GA cookies manually as react-ga does not provides a utility for it.
     if (!localAnalytics) {
-      removeCookie('_ga')
-      removeCookie('_gat')
-      removeCookie('_gid')
+      removeCookie(COOKIE_GA.name, COOKIE_GA.path)
+      removeCookie(COOKIE_GAT.name, COOKIE_GAT.path)
+      removeCookie(COOKIE_GIT.name, COOKIE_GIT.path)
     }
 
     if (!localIntercom && isIntercomLoaded()) {

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -8,9 +8,9 @@ import Link from 'src/components/layout/Link'
 import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
-import { loadFromCookie, saveCookie, removeCookie } from 'src/logic/cookies/utils'
+import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
-import { COOKIES_LIST, loadGoogleAnalytics } from 'src/utils/googleAnalytics'
+import { loadGoogleAnalytics, removeCookies } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
 import AlertRedIcon from './assets/alert-red.svg'
 import IntercomIcon from './assets/intercom.png'
@@ -161,10 +161,8 @@ const CookiesBanner = (): ReactElement => {
     setShowAnalytics(localAnalytics)
     setShowIntercom(localIntercom)
 
-    // we remove GA cookies manually as react-ga does not provides a utility for it.
     if (!localAnalytics) {
-      const subDomain = location.host.split('.').slice(-2).join('.')
-      COOKIES_LIST.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${subDomain}`))
+      removeCookies()
     }
 
     if (!localIntercom && isIntercomLoaded()) {

--- a/src/logic/cookies/utils/index.ts
+++ b/src/logic/cookies/utils/index.ts
@@ -29,9 +29,4 @@ export const saveCookie = async (key: string, value: Record<string, any>, expira
   }
 }
 
-export const removeCookie = (key: string, path: string): void => {
-  console.log(path)
-  console.log(document.cookie)
-  debugger
-  Cookies.remove(key, { path: '/', domain: '.gnosisdev.com' })
-}
+export const removeCookie = (key: string, path: string, domain: string): void => Cookies.remove(key, { path, domain })

--- a/src/logic/cookies/utils/index.ts
+++ b/src/logic/cookies/utils/index.ts
@@ -4,9 +4,10 @@ import { getNetworkName } from 'src/config'
 
 const PREFIX = `v1_${getNetworkName()}`
 
-export const loadFromCookie = async (key: string): Promise<undefined | Record<string, any>> => {
+export const loadFromCookie = async (key: string, withoutPrefix = false): Promise<undefined | Record<string, any>> => {
+  const prefix = withoutPrefix ? '' : `${PREFIX}__`
   try {
-    const stringifiedValue = await Cookies.get(`${PREFIX}__${key}`)
+    const stringifiedValue = await Cookies.get(`${prefix}${key}`)
     if (stringifiedValue === null || stringifiedValue === undefined) {
       return undefined
     }
@@ -28,4 +29,4 @@ export const saveCookie = async (key: string, value: Record<string, any>, expira
   }
 }
 
-export const removeCookie = (key: string): void => Cookies.remove(key)
+export const removeCookie = (key: string, path: string): void => Cookies.remove(key, { path })

--- a/src/logic/cookies/utils/index.ts
+++ b/src/logic/cookies/utils/index.ts
@@ -29,4 +29,9 @@ export const saveCookie = async (key: string, value: Record<string, any>, expira
   }
 }
 
-export const removeCookie = (key: string, path: string): void => Cookies.remove(key, { path })
+export const removeCookie = (key: string, path: string): void => {
+  console.log(path)
+  console.log(document.cookie)
+  debugger
+  Cookies.remove(key, { path: '/', domain: '.gnosisdev.com' })
+}

--- a/src/logic/cookies/utils/index.ts
+++ b/src/logic/cookies/utils/index.ts
@@ -4,7 +4,7 @@ import { getNetworkName } from 'src/config'
 
 const PREFIX = `v1_${getNetworkName()}`
 
-export const loadFromCookie = async (key) => {
+export const loadFromCookie = async (key: string): Promise<undefined | Record<string, any>> => {
   try {
     const stringifiedValue = await Cookies.get(`${PREFIX}__${key}`)
     if (stringifiedValue === null || stringifiedValue === undefined) {
@@ -18,7 +18,7 @@ export const loadFromCookie = async (key) => {
   }
 }
 
-export const saveCookie = async (key, value, expirationDays) => {
+export const saveCookie = async (key: string, value: Record<string, any>, expirationDays: number): Promise<void> => {
   try {
     const stringifiedValue = JSON.stringify(value)
     const expiration = expirationDays ? { expires: expirationDays } : undefined
@@ -27,3 +27,5 @@ export const saveCookie = async (key, value, expirationDays) => {
     console.error(`Failed to save ${key} in cookies:`, err)
   }
 }
+
+export const removeCookie = (key: string): void => Cookies.remove(key)

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -50,12 +50,15 @@ export const useAnalytics = (): UseAnalyticsResponse => {
     fetchCookiesFromStorage()
   }, [])
 
-  const trackPage = (page) => {
-    if (!analyticsAllowed || !analyticsLoaded) {
-      return
-    }
-    ReactGA.pageview(page)
-  }
+  const trackPage = useCallback(
+    (page) => {
+      if (!analyticsAllowed || !analyticsLoaded) {
+        return
+      }
+      ReactGA.pageview(page)
+    },
+    [analyticsAllowed],
+  )
 
   const trackEvent = useCallback(
     (event: EventArgs) => {

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -9,9 +9,9 @@ import { loadFromCookie } from 'src/logic/cookies/utils'
 export const SAFE_NAVIGATION_EVENT = 'Safe Navigation'
 
 export const COOKIES_LIST = [
-  { name: '_ga', path: '' },
-  { name: '_gat', path: '' },
-  { name: '_gid', path: '' },
+  { name: '_ga', path: '/' },
+  { name: '_gat', path: '/' },
+  { name: '_gid', path: '/' },
 ]
 
 let analyticsLoaded = false

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -4,7 +4,7 @@ import { getNetworkInfo } from 'src/config'
 
 import { getGoogleAnalyticsTrackingID } from 'src/config'
 import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
-import { loadFromCookie } from 'src/logic/cookies/utils'
+import { loadFromCookie, removeCookie } from 'src/logic/cookies/utils'
 
 export const SAFE_NAVIGATION_EVENT = 'Safe Navigation'
 
@@ -77,4 +77,10 @@ export const useAnalytics = (): UseAnalyticsResponse => {
   )
 
   return { trackPage, trackEvent }
+}
+
+// we remove GA cookies manually as react-ga does not provides a utility for it.
+export const removeCookies = (): void => {
+  const subDomain = location.host.split('.').slice(-2).join('.')
+  COOKIES_LIST.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${subDomain}`))
 }

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -8,9 +8,11 @@ import { loadFromCookie } from 'src/logic/cookies/utils'
 
 export const SAFE_NAVIGATION_EVENT = 'Safe Navigation'
 
-export const COOKIE_GA = { name: '_ga', path: '/' }
-export const COOKIE_GAT = { name: '_gat', path: '/' }
-export const COOKIE_GIT = { name: '_gid', path: '/' }
+export const COOKIES_LIST = [
+  { name: '_ga', path: '' },
+  { name: '_gat', path: '' },
+  { name: '_gid', path: '' },
+]
 
 let analyticsLoaded = false
 export const loadGoogleAnalytics = (): void => {

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -8,6 +8,10 @@ import { loadFromCookie } from 'src/logic/cookies/utils'
 
 export const SAFE_NAVIGATION_EVENT = 'Safe Navigation'
 
+export const COOKIE_GA = { name: '_ga', path: '/' }
+export const COOKIE_GAT = { name: '_gat', path: '/' }
+export const COOKIE_GIT = { name: '_gid', path: '/' }
+
 let analyticsLoaded = false
 export const loadGoogleAnalytics = (): void => {
   if (analyticsLoaded) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,6 +3501,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/js-cookie@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
+  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"


### PR DESCRIPTION
Closes #1930.

Some GA reports were being sent even so the user has disabled them in preferences. 

I wrapper `trackPage` method of `useAnalytics` hook to be recalculated when `analyticsAllowed` changes