### PR TITLE
Fix: remove auto checksum address from InputAddress

### DIFF
--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -62,9 +62,6 @@ const AddressInput = ({
           } catch (err) {
             console.error('Failed to resolve address for ENS name: ', err)
           }
-        } else {
-          const formattedAddress = checksumAddress(address)
-          fieldMutator(formattedAddress)
         }
       }}
     </OnChange>

--- a/src/components/forms/validator.test.ts
+++ b/src/components/forms/validator.test.ts
@@ -130,7 +130,7 @@ describe('Forms > Validators', () => {
   })
 
   describe('mustBeEthereumAddress validator', () => {
-    const MUST_BE_ETH_ADDRESS_ERR_MSG = 'Input must be a valid Ethereum address, ENS or Unstoppable domain'
+    const MUST_BE_ETH_ADDRESS_ERR_MSG = 'Must be a valid address, ENS or Unstoppable domain'
 
     it('Returns undefined for a valid ethereum address', async () => {
       expect(await mustBeEthereumAddress('0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe')).toBeUndefined()

--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -68,7 +68,7 @@ export const mustBeEthereumAddress = memoize(
     const startsWith0x = address?.startsWith('0x')
     const isAddress = getWeb3().utils.isAddress(address)
 
-    const errorMessage = `Input must be a valid Ethereum address${
+    const errorMessage = `Must be a valid checksummed address${
       isFeatureEnabled(FEATURES.DOMAIN_LOOKUP) ? ', ENS or Unstoppable domain' : ''
     }`
 

--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -68,7 +68,7 @@ export const mustBeEthereumAddress = memoize(
     const startsWith0x = address?.startsWith('0x')
     const isAddress = getWeb3().utils.isAddress(address)
 
-    const errorMessage = `Must be a valid checksummed address${
+    const errorMessage = `Must be a valid address${
       isFeatureEnabled(FEATURES.DOMAIN_LOOKUP) ? ', ENS or Unstoppable domain' : ''
     }`
 


### PR DESCRIPTION
Closes #1928.

When users enter all-lower case address, we checksum them automatically. That's nice. But it's not safe.

This PR removes the auto-checksum address and modifies the error message. I removed the word `Ethreum` for two reasons, it a hardcoded blockchain and also because the message was too long and wasn't fitting in the input. 
