### PR TITLE
Fix: don't use DELEGATE_CALL in spending limits

### DIFF
--- a/src/logic/safe/utils/spendingLimits.ts
+++ b/src/logic/safe/utils/spendingLimits.ts
@@ -177,7 +177,6 @@ export const getResetSpendingLimitTx = (beneficiary: string, token: string): Mul
     to: SPENDING_LIMIT_MODULE_ADDRESS,
     value: 0,
     data: spendingLimitContract.methods.resetAllowance(beneficiary, token).encodeABI(),
-    operation: CALL,
   }
 }
 

--- a/src/logic/safe/utils/spendingLimits.ts
+++ b/src/logic/safe/utils/spendingLimits.ts
@@ -157,7 +157,6 @@ export const enableSpendingLimitModuleMultiSendTx = (safeAddress: string): Multi
     to: multiSendTx.to,
     value: Number(multiSendTx.valueInWei),
     data: multiSendTx.txData as string,
-    operation: DELEGATE_CALL,
   }
 }
 
@@ -168,7 +167,6 @@ export const addSpendingLimitBeneficiaryMultiSendTx = (beneficiary: string): Mul
     to: SPENDING_LIMIT_MODULE_ADDRESS,
     value: 0,
     data: spendingLimitContract.methods.addDelegate(beneficiary).encodeABI(),
-    operation: DELEGATE_CALL,
   }
 }
 
@@ -210,7 +208,6 @@ export const setSpendingLimitMultiSendTx = (args: SpendingLimitTxParams): MultiS
     to: tx.to,
     value: Number(tx.valueInWei),
     data: tx.txData as string,
-    operation: DELEGATE_CALL,
   }
 }
 

--- a/src/logic/safe/utils/upgradeSafe.test.ts
+++ b/src/logic/safe/utils/upgradeSafe.test.ts
@@ -15,13 +15,11 @@ describe('Upgrade a Safe', () => {
     const updateSafeTxData = safeInstance.methods.changeMasterCopy(SAFE_MASTER_COPY_ADDRESS).encodeABI()
     const txs = [
       {
-        operation: 0,
         to: safeAddress,
         value: 0,
         data: updateSafeTxData,
       },
       {
-        operation: 0,
         to: safeAddress,
         value: 0,
         data: fallbackHandlerTxData,

--- a/src/logic/safe/utils/upgradeSafe.ts
+++ b/src/logic/safe/utils/upgradeSafe.ts
@@ -10,7 +10,6 @@ import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { MultiSend } from 'src/types/contracts/MultiSend.d'
 
 export interface MultiSendTx {
-  operation: number
   to: string
   value: number
   data: string
@@ -54,13 +53,11 @@ export const getUpgradeSafeTransactionHash = async (safeAddress: string): Promis
   const updateSafeTxData = safeInstance.methods.changeMasterCopy(SAFE_MASTER_COPY_ADDRESS).encodeABI()
   const txs = [
     {
-      operation: 0,
       to: safeAddress,
       value: 0,
       data: updateSafeTxData,
     },
     {
-      operation: 0,
       to: safeAddress,
       value: 0,
       data: fallbackHandlerTxData,


### PR DESCRIPTION
**What**:
Replace DELEGATE_CALL with CALL spending limits.
<!-- Why are these changes necessary? -->

**Why**:
According to #2263 it's a potential critical issue.
<!-- How were these changes implemented? -->

**How**:
I've replaced the op in spending limits, it still remains in the safe creation tx and in multi-send txs.

**How to test it**:
Nothing changes visually or functionally. Need to test only for regressions.

* Creation, editing, removing, send funds using spending limits, reset time
<!-- If applicable, add the steps to test your changes -->