### PR TITLE
Remove TS definition from checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,6 @@ merge of your pull request!
 <!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
 - [ ] Tests added/updated
-- [ ] TypeScript definitions updated
 - [ ] Ready to be merged
       <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
 


### PR DESCRIPTION
**What**:
remove `- [ ] TypeScript definitions updated` from PR template

**Why**:
As we are not a third-party library, we shouldn't use make use TS definition (.d.ts) https://stackoverflow.com/questions/21247278/about-d-ts-in-typescript/21247316#21247316. 
Indeed, we should remove them from our code.

An example of misuse can be found here 
![image](https://user-images.githubusercontent.com/4376509/117446760-f0411000-af12-11eb-82ca-dfbe7ff1982d.png) 
In the PR there was no .d.ts file modified but the checkbox was checked. 

So to avoid confusion about checking it when we haven't modified any `.d.ts` file, I propose removing it. 

Also **we should not use .d.ts** at all.

**How**:
-

**How to test it**:
-

**Checklist**:
- [ ] Tests added/updated
- [ ] TypeScript definitions updated
- [x] Ready to be merged