### PR TITLE
[Spending Limit] Integration PR

### DIFF
--- a/src/logic/safe/utils/spendingLimits.ts
+++ b/src/logic/safe/utils/spendingLimits.ts
@@ -157,7 +157,6 @@ export const enableSpendingLimitModuleMultiSendTx = (safeAddress: string): Multi
     to: multiSendTx.to,
     value: Number(multiSendTx.valueInWei),
     data: multiSendTx.txData as string,
-    operation: DELEGATE_CALL,
   }
 }
 
@@ -168,7 +167,16 @@ export const addSpendingLimitBeneficiaryMultiSendTx = (beneficiary: string): Mul
     to: SPENDING_LIMIT_MODULE_ADDRESS,
     value: 0,
     data: spendingLimitContract.methods.addDelegate(beneficiary).encodeABI(),
-    operation: DELEGATE_CALL,
+  }
+}
+
+export const getResetSpendingLimitTx = (beneficiary: string, token: string): MultiSendTx => {
+  const spendingLimitContract = getSpendingLimitContract()
+
+  return {
+    to: SPENDING_LIMIT_MODULE_ADDRESS,
+    value: 0,
+    data: spendingLimitContract.methods.resetAllowance(beneficiary, token).encodeABI(),
   }
 }
 
@@ -210,7 +218,6 @@ export const setSpendingLimitMultiSendTx = (args: SpendingLimitTxParams): MultiS
     to: tx.to,
     value: Number(tx.valueInWei),
     data: tx.txData as string,
-    operation: DELEGATE_CALL,
   }
 }
 

--- a/src/logic/safe/utils/upgradeSafe.test.ts
+++ b/src/logic/safe/utils/upgradeSafe.test.ts
@@ -15,13 +15,11 @@ describe('Upgrade a Safe', () => {
     const updateSafeTxData = safeInstance.methods.changeMasterCopy(SAFE_MASTER_COPY_ADDRESS).encodeABI()
     const txs = [
       {
-        operation: 0,
         to: safeAddress,
         value: 0,
         data: updateSafeTxData,
       },
       {
-        operation: 0,
         to: safeAddress,
         value: 0,
         data: fallbackHandlerTxData,

--- a/src/logic/safe/utils/upgradeSafe.ts
+++ b/src/logic/safe/utils/upgradeSafe.ts
@@ -10,7 +10,6 @@ import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { MultiSend } from 'src/types/contracts/MultiSend.d'
 
 export interface MultiSendTx {
-  operation: number
   to: string
   value: number
   data: string
@@ -54,13 +53,11 @@ export const getUpgradeSafeTransactionHash = async (safeAddress: string): Promis
   const updateSafeTxData = safeInstance.methods.changeMasterCopy(SAFE_MASTER_COPY_ADDRESS).encodeABI()
   const txs = [
     {
-      operation: 0,
       to: safeAddress,
       value: 0,
       data: updateSafeTxData,
     },
     {
-      operation: 0,
       to: safeAddress,
       value: 0,
       data: fallbackHandlerTxData,

--- a/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/dataFetcher.ts
+++ b/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/dataFetcher.ts
@@ -55,6 +55,7 @@ export const generateColumns = (): List<TableColumn> => {
     id: SPENDING_LIMIT_TABLE_SPENT_ID,
     label: 'Spent',
     order: false,
+    static: true,
   }
 
   const resetColumn: TableColumn = {
@@ -64,6 +65,7 @@ export const generateColumns = (): List<TableColumn> => {
     id: SPENDING_LIMIT_TABLE_RESET_TIME_ID,
     label: 'Reset Time',
     order: false,
+    static: true,
   }
 
   const actionsColumn: TableColumn = {

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -81,7 +81,7 @@ const calculateSpendingLimitsTxData = (
     resetBaseMin: number
   }
 } => {
-  const isSpendingLimitEnabled = spendingLimits !== null
+  const isSpendingLimitEnabled = !spendingLimits
   const transactions: MultiSendTx[] = []
 
   // is spendingLimit module enabled? -> if not, create the tx to enable it, and encode it

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -81,7 +81,8 @@ const calculateSpendingLimitsTxData = (
     resetBaseMin: number
   }
 } => {
-  const isSpendingLimitEnabled = !spendingLimits
+  // enabled if it's an array with at least one element
+  const isSpendingLimitEnabled = !!spendingLimits?.length
   const transactions: MultiSendTx[] = []
 
   // is spendingLimit module enabled? -> if not, create the tx to enable it, and encode it

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -11,6 +11,7 @@ import {
   addSpendingLimitBeneficiaryMultiSendTx,
   currentMinutes,
   enableSpendingLimitModuleMultiSendTx,
+  getResetSpendingLimitTx,
   setSpendingLimitMultiSendTx,
   setSpendingLimitTx,
   spendingLimitMultiSendTx,
@@ -96,6 +97,10 @@ const calculateSpendingLimitsTxData = (
   // if `delegate` does not exist, add it by calling `addDelegate(beneficiary)`
   if (!isDelegateAlreadyAdded && values?.beneficiary) {
     transactions.push(addSpendingLimitBeneficiaryMultiSendTx(values.beneficiary))
+  }
+
+  if (existentSpendingLimit && existentSpendingLimit.spent !== '0') {
+    transactions.push(getResetSpendingLimitTx(existentSpendingLimit.delegate, txToken.address))
   }
 
   // prepare the setAllowance tx


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

This PR template was copied from https://github.com/testing-library/react-testing-library/blob/main/.github/PULL_REQUEST_TEMPLATE.md

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR is an integration branch for changes of the following PRs:
#2262
#2295
#2299 

Following issues can be tested on this PR
Fixes #1700 #1698 #1896 #2298

<!-- Why are these changes necessary? -->

**Why**:
In order to make full regression easier for QA without taking changes to `development` yet
<!-- How were these changes implemented? -->

**How to test it**:

Changes from #2262
1. Allow an owner 1 of a token (ETH for example)
2. With the owner use the 0.5 ETH
3. Edit the Spending limit, from 1ETH to 0.25 ETH
4. You should see the new spending limit with the spent on 0

Changes from #2299
1. create a new safe
2. add a new spending limit
3. it shows the tx with 3 actions (`enableModule`, `addDelegate`, and `seAllowance`)
<!-- If applicable, add the steps to test your changes -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
