### PR TITLE
2321 - Catch backend error and send controlled form error

### DIFF
--- a/src/routes/load/components/DetailsForm/index.tsx
+++ b/src/routes/load/components/DetailsForm/index.tsx
@@ -54,8 +54,8 @@ export const safeFieldsValidation = async (values): Promise<Record<string, strin
     return errors
   }
 
-  // if getSafeInfo does not provide data, it's not a valid safe.
-  const safeInfo = await getSafeInfo(address)
+  // If getSafeInfo does not provide data, it's not a valid safe.
+  const safeInfo = await getSafeInfo(address).catch(() => null)
   if (!safeInfo) {
     errors[FIELD_LOAD_ADDRESS] = SAFE_ADDRESS_NOT_VALID
   }


### PR DESCRIPTION
## What it solves
Closes issue #2321 problems validating that an address is a safe when adding a new safe

## How this PR fixes it
When we send an address that is nota Safe we get an error from the `client-gateway`. We are not catching this error so the validation script is broken and no error message is shown.
We catch the error and we show an error message in the form

## How to test it
Try to add an invalid address in add safe form.
Check that the correct error is shown

