### PR TITLE
Feature: Allow passing additional context to CodedException

### DIFF
--- a/src/logic/exceptions/CodedException.test.ts
+++ b/src/logic/exceptions/CodedException.test.ts
@@ -50,7 +50,7 @@ describe('CodedException', () => {
       '901: Error processing Safe Apps SDK request (getSafeBalance: Server responded with 429 Too Many Requests)',
     )
     expect(err.code).toBe(901)
-    expect(err.sentryContext).toEqual(context)
+    expect(err.context).toEqual(context)
   })
 
   describe('Logging', () => {

--- a/src/logic/exceptions/CodedException.test.ts
+++ b/src/logic/exceptions/CodedException.test.ts
@@ -29,7 +29,19 @@ describe('CodedException', () => {
   it('creates an error with an extra message and a context', () => {
     const context = {
       tags: {
-        app: 'Sorbet.Finance',
+        error_category: 'Safe Apps',
+      },
+      contexts: {
+        safeApp: {
+          name: 'Zorbed.Finance',
+          url: 'https://zorbed.finance',
+        },
+        message: {
+          method: 'getSafeBalance',
+          params: {
+            address: '0x000000',
+          },
+        },
       },
     }
 

--- a/src/logic/exceptions/CodedException.test.ts
+++ b/src/logic/exceptions/CodedException.test.ts
@@ -27,15 +27,18 @@ describe('CodedException', () => {
   })
 
   it('creates an error with an extra message and a context', () => {
-    const err = new CodedException(Errors._901, 'getSafeBalance: Server responded with 429 Too Many Requests', {
+    const context = {
       tags: {
         app: 'Sorbet.Finance',
       },
-    })
+    }
+
+    const err = new CodedException(Errors._901, 'getSafeBalance: Server responded with 429 Too Many Requests', context)
     expect(err.message).toBe(
-      '901: Error processing Safe Apps SDK request (getSafeBalance: Server responded with 429 Too Many Request',
+      '901: Error processing Safe Apps SDK request (getSafeBalance: Server responded with 429 Too Many Requests)',
     )
-    expect(err.code).toBe(100)
+    expect(err.code).toBe(901)
+    expect(err.sentryContext).toEqual(context)
   })
 
   describe('Logging', () => {

--- a/src/logic/exceptions/CodedException.test.ts
+++ b/src/logic/exceptions/CodedException.test.ts
@@ -26,6 +26,18 @@ describe('CodedException', () => {
     expect(err.code).toBe(100)
   })
 
+  it('creates an error with an extra message and a context', () => {
+    const err = new CodedException(Errors._901, 'getSafeBalance: Server responded with 429 Too Many Requests', {
+      tags: {
+        app: 'Sorbet.Finance',
+      },
+    })
+    expect(err.message).toBe(
+      '901: Error processing Safe Apps SDK request (getSafeBalance: Server responded with 429 Too Many Request',
+    )
+    expect(err.code).toBe(100)
+  })
+
   describe('Logging', () => {
     beforeAll(() => {
       jest.mock('console')
@@ -70,7 +82,7 @@ describe('CodedException', () => {
 
     it("doesn't track when isTracked is false", () => {
       ;(constants as any).IS_PRODUCTION = true
-      logError(Errors._100, '', false)
+      logError(Errors._100, '', undefined, false)
       expect(Sentry.captureException).not.toHaveBeenCalled()
     })
 

--- a/src/logic/exceptions/CodedException.ts
+++ b/src/logic/exceptions/CodedException.ts
@@ -8,7 +8,7 @@ export class CodedException extends Error {
   // the context allows to enrich events, for the list of allowed context keys/data, please check the type or go to
   // https://docs.sentry.io/platforms/javascript/enriching-events/context/
   // The context is not searchable, that means its goal is just to provide additional data for the error
-  public readonly sentryContext?: CaptureContext
+  public readonly context?: CaptureContext
 
   constructor(content: ErrorCodes, extraMessage?: string, context?: CaptureContext) {
     super()
@@ -22,7 +22,7 @@ export class CodedException extends Error {
     const extraInfo = extraMessage ? ` (${extraMessage})` : ''
     this.message = `${content}${extraInfo}`
     this.code = code
-    this.sentryContext = context
+    this.context = context
   }
 
   /**
@@ -33,7 +33,7 @@ export class CodedException extends Error {
     console.error(IS_PRODUCTION ? this.message : this)
 
     if (IS_PRODUCTION && isTracked) {
-      Sentry.captureException(this, this.sentryContext)
+      Sentry.captureException(this, this.context)
     }
   }
 }

--- a/src/logic/exceptions/CodedException.ts
+++ b/src/logic/exceptions/CodedException.ts
@@ -1,23 +1,25 @@
 import * as Sentry from '@sentry/react'
+import { CaptureContext } from '@sentry/types'
 import ErrorCodes from './registry'
 import { IS_PRODUCTION } from 'src/utils/constants'
 
 export class CodedException extends Error {
-  public readonly message: string
   public readonly code: number
+  public readonly context?: CaptureContext
 
-  constructor(content: ErrorCodes, extraMessage?: string) {
+  constructor(content: ErrorCodes, extraMessage?: string, context?: CaptureContext) {
     super()
 
     const codePrefix = content.split(':')[0]
     const code = Number(codePrefix)
     if (isNaN(code)) {
-      throw new CodedException(ErrorCodes.___0, codePrefix)
+      throw new CodedException(ErrorCodes.___0, extraMessage, context)
     }
 
     const extraInfo = extraMessage ? ` (${extraMessage})` : ''
     this.message = `${content}${extraInfo}`
     this.code = code
+    this.context = context
   }
 
   /**
@@ -28,13 +30,18 @@ export class CodedException extends Error {
     console.error(IS_PRODUCTION ? this.message : this)
 
     if (IS_PRODUCTION && isTracked) {
-      Sentry.captureException(this)
+      Sentry.captureException(this, this.context)
     }
   }
 }
 
-export function logError(content: ErrorCodes, extraMessage?: string, isTracked?: boolean): CodedException {
-  const error = new CodedException(content, extraMessage)
+export function logError(
+  content: ErrorCodes,
+  extraMessage?: string,
+  context?: CaptureContext,
+  isTracked?: boolean,
+): CodedException {
+  const error = new CodedException(content, extraMessage, context)
   error.log(isTracked)
   return error
 }

--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -9,6 +9,8 @@ enum ErrorCodes {
   _100 = '100: Invalid input in the address field',
   _600 = '600: Error fetching token list',
   _601 = '601: Error fetching balances',
+  _900 = '900: Error loading Safe App',
+  _901 = '901: Error processing Safe Apps SDK request',
 }
 
 export default ErrorCodes

--- a/src/logic/tokens/store/actions/fetchSafeTokens.ts
+++ b/src/logic/tokens/store/actions/fetchSafeTokens.ts
@@ -70,7 +70,7 @@ export const fetchSafeTokens = (safeAddress: string, currencySelected?: string) 
       selectedCurrency: currencySelected ?? selectedCurrency,
     })
   } catch (e) {
-    logError(Errors._601, e.message, false)
+    logError(Errors._601, e.message, undefined, false)
     return
   }
 

--- a/src/logic/tokens/store/actions/fetchTokens.ts
+++ b/src/logic/tokens/store/actions/fetchTokens.ts
@@ -61,7 +61,7 @@ export const fetchTokens = () => async (
     const resp = await fetchErc20AndErc721AssetsList()
     tokenList = resp.data.results
   } catch (e) {
-    logError(Errors._600, e.message, false)
+    logError(Errors._600, e.message, undefined, false)
     return
   }
 


### PR DESCRIPTION
## What it solves
In https://github.com/gnosis/safe-react/pull/2316 I and @katspaugh started a discussion on how to handle exceptions when using safe apps. The tricky thing about safe apps that in the essence there are two errors: one is about the safe app and one about some of the underlying functions we have in our codebase plus we need additional data to have enough context for debugging: app name, URL, what method it was trying to call, arguments, etc. The only possible way to do that with the current `CodedException` is to fit everything into an error message which is not ideal. Luckily, sentry supports enriching error events with additional context: https://docs.sentry.io/platforms/javascript/enriching-events/context/

## How this PR fixes it
Allows passing additional context to the `CodedException` class. 

## How to test it
It adds a test for the unit test suite for CodedException. Properly testing it includes sending a message to sentry.

## Any extra info
I left functionality for concatenating messages (`extraMessage`) because from context fields only the tag field is searchable. Thought it would be handy in case we get a bunch of the same errors and we're able to search and remove them.