### PR TITLE
add back `loadedViaUrl` flag

### DIFF
--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -20,7 +20,8 @@ import { buildSafeOwners, extractRemoteSafeInfo } from './utils'
  */
 export const buildSafe = async (safeAddress: string): Promise<SafeRecordProps> => {
   const address = checksumAddress(safeAddress)
-  const safeInfo: Partial<SafeRecordProps> = { address }
+  // setting `loadedViaUrl` to false, as `buildSafe` is called on safe Load or Open flows
+  const safeInfo: Partial<SafeRecordProps> = { address, loadedViaUrl: false }
 
   const [remote, localSafeInfo] = await allSettled<[SafeInfo | null, SafeRecordProps | undefined | null]>(
     getSafeInfo(safeAddress),

--- a/src/logic/safe/store/models/safe.ts
+++ b/src/logic/safe/store/models/safe.ts
@@ -36,6 +36,7 @@ export type SafeRecordProps = {
   currentVersion: string
   needsUpdate: boolean
   featuresEnabled: Array<FEATURES>
+  loadedViaUrl: boolean
 }
 
 const makeSafe = Record<SafeRecordProps>({
@@ -52,6 +53,7 @@ const makeSafe = Record<SafeRecordProps>({
   currentVersion: '',
   needsUpdate: false,
   featuresEnabled: [],
+  loadedViaUrl: true,
 })
 
 export type SafeRecord = RecordOf<SafeRecordProps>

--- a/src/logic/safe/store/selectors/index.ts
+++ b/src/logic/safe/store/selectors/index.ts
@@ -32,6 +32,7 @@ export const safesListWithAddressBookNameSelector = createSelector(
     const addressBook = addressBookMap?.[chainId]
 
     return safesList
+      .filter((safeRecord) => !safeRecord.loadedViaUrl)
       .map((safeRecord) => {
         const safe = safeRecord.toObject()
         const name = addressBook?.[safe.address]?.name

--- a/src/logic/safe/utils/__tests__/shouldSafeStoreBeUpdated.test.ts
+++ b/src/logic/safe/utils/__tests__/shouldSafeStoreBeUpdated.test.ts
@@ -38,6 +38,7 @@ const getMockedOldSafe = ({
     needsUpdate: needsUpdate || false,
     featuresEnabled: featuresEnabled || [],
     totalFiatBalance: '110',
+    loadedViaUrl: false,
   }
 }
 

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -73,8 +73,8 @@ const SafeDetails = (): ReactElement => {
 
   const handleSubmit = (values) => {
     dispatch(addressBookAddOrUpdate(makeAddressBookEntry({ address: safeAddress, name: values.safeName })))
-    // used to trigger safe middleware and persist safe to localStorage
-    dispatch(updateSafe({ address: safeAddress }))
+    // setting `loadedViaUrl` to `false` as setting a safe's name is considered to intentionally add the safe
+    dispatch(updateSafe({ address: safeAddress, loadedViaUrl: false }))
 
     const notification = getNotificationsFromTxType(TX_NOTIFICATION_TYPES.SAFE_NAME_CHANGE_TX)
     dispatch(enqueueSnackbar(enhanceSnackbarForAction(notification.afterExecution.noMoreConfirmationsNeeded)))

--- a/src/routes/safe/components/Settings/index.tsx
+++ b/src/routes/safe/components/Settings/index.tsx
@@ -25,7 +25,11 @@ import Img from 'src/components/layout/Img'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import Span from 'src/components/layout/Span'
-import { safeNeedsUpdateSelector, safeOwnersWithAddressBookDataSelector } from 'src/logic/safe/store/selectors'
+import {
+  safeNeedsUpdateSelector,
+  safeOwnersWithAddressBookDataSelector,
+  safeSelector,
+} from 'src/logic/safe/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 
 export const OWNERS_SETTINGS_TAB_TEST_ID = 'owner-settings-tab'
@@ -45,6 +49,7 @@ const Settings: React.FC = () => {
   const owners = useSelector((state) => safeOwnersWithAddressBookDataSelector(state, chainId))
   const needsUpdate = useSelector(safeNeedsUpdateSelector)
   const granted = useSelector(grantedSelector)
+  const safe = useSelector(safeSelector)
 
   const handleChange = (menuOptionIndex) => () => {
     setState((prevState) => ({ ...prevState, menuOptionIndex }))
@@ -67,11 +72,15 @@ const Settings: React.FC = () => {
   ) : (
     <>
       <Row className={classes.message}>
-        <ButtonLink className={classes.removeSafeBtn} color="error" onClick={onShow('RemoveSafe')} size="lg">
-          <Span className={classes.links}>Remove Safe</Span>
-          <Img alt="Trash Icon" className={classes.removeSafeIcon} src={RemoveSafeIcon} />
-        </ButtonLink>
-        <RemoveSafeModal isOpen={showRemoveSafe} onClose={onHide('RemoveSafe')} />
+        {!safe?.loadedViaUrl && (
+          <>
+            <ButtonLink className={classes.removeSafeBtn} color="error" onClick={onShow('RemoveSafe')} size="lg">
+              <Span className={classes.links}>Remove Safe</Span>
+              <Img alt="Trash Icon" className={classes.removeSafeIcon} src={RemoveSafeIcon} />
+            </ButtonLink>
+            <RemoveSafeModal isOpen={showRemoveSafe} onClose={onHide('RemoveSafe')} />
+          </>
+        )}
       </Row>
       <Block className={classes.root}>
         <Col className={classes.menuWrapper} layout="column">


### PR DESCRIPTION
## What it solves
The "Safe added via URL" behavior

## How this PR fixes it
By re-adding the `loadedViaUrl` flag to the Safe object, but changing a bit the approach on how to use it.

Previously it was based on the `safe.name` value (if it was "Gnosis Safe", then it was considered as added via URL). Now, `safe.name` has been removed, so we no longer have that field to do the verification.

The current solution assumes all safes as being loaded via URL except for those added via Load/Open forms or when a Safe's name is being updated via Settings.

## How to test it
Check that all the "safe loaded via URL" functionality work as expected.

## Any extra information
it's using the PR #2336 as base branch