### PR TITLE
Feature: Better error handling for Safe apps things

### DIFF
--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -69,9 +69,12 @@ class AppCommunicator {
         }
       } catch (err) {
         this.send(err.message, msg.data.id, true)
-        // TODO: Allow passing method/message as an extra context
-        // Tweak CodedException class to accept it as a second argument
-        logError(Errors._901, `${msg.data.method} ${err.message}`)
+        logError(Errors._901, err.message, {
+          contexts: {
+            app: this.app,
+            req: msg.data,
+          },
+        })
       }
     }
   }

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -71,8 +71,8 @@ class AppCommunicator {
         this.send(err.message, msg.data.id, true)
         logError(Errors._901, err.message, {
           contexts: {
-            app: this.app,
-            req: msg.data,
+            safeApp: this.app,
+            request: msg.data,
           },
         })
       }

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -274,16 +274,13 @@ export const getAppInfoFromUrl = memoize(
       }
       return res
     } catch (error) {
-      logError(
-        Errors._900,
-        error.message,
-        {
-          extra: {
-            appUrl,
+      logError(Errors._900, error.message, {
+        contexts: {
+          safeApp: {
+            url: appUrl,
           },
         },
-        false,
-      )
+      })
       return res
     }
   },

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -274,7 +274,16 @@ export const getAppInfoFromUrl = memoize(
       }
       return res
     } catch (error) {
-      logError(Errors._900, `${res.url}: ${error.message}`, undefined, false)
+      logError(
+        Errors._900,
+        `${res.url}: ${error.message}`,
+        {
+          extra: {
+            appUrl,
+          },
+        },
+        false,
+      )
       return res
     }
   },

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -276,7 +276,7 @@ export const getAppInfoFromUrl = memoize(
     } catch (error) {
       logError(
         Errors._900,
-        `${res.url}: ${error.message}`,
+        error.message,
         {
           extra: {
             appUrl,


### PR DESCRIPTION
## What it solves

Sentry error logging for failing safe app loading and a failed attempt to fetch a safe balance from the sdk

## How this PR fixes it

It makes use of additional error contexts introduced in https://github.com/gnosis/safe-react/pull/2334. The initial solution makes use of a generic safe app request error code (_901). If it doesn't work out, we may introduce an error code for each request method.

## How to test it
There are two errors added:
* `900: Error loading Safe App`
* `901: Error processing Safe Apps SDK request`

They will be both logged to the console.

To reproduce:

1. Safe app loading - Using chrome dev tools turn off the internet after opening the safe apps tab
2. The 901 error will be logged when an app tries to call an SDK method but it fails.
E.g. the error when fetching safe balances. Via safe apps SDK attempt to fetch safe's balances of a non-existing safe. https://github.com/gnosis/safe-test-app may be handy.
This one is tricky to reproduce, so it can be skipped.

