### PR TITLE
Bugfix - Owners table sorting is not working correctly

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -150,7 +150,7 @@ class GnoTable extends React.Component<any, any> {
     const columnSort = columns.find((column) => column.id === orderByParam)
     let sortedData = stableSort(
       data,
-      getSorting(orderParam, orderByParam, orderProp, columnSort['formatTypeSort']),
+      getSorting(orderParam, orderByParam, orderProp, columnSort?.formatTypeSort),
       fixedParam,
     )
 

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -142,14 +142,17 @@ class GnoTable extends React.Component<any, any> {
     const orderParam = order || defaultOrder
     const displayRows = rowsPerPage || defaultRowsPerPage
     const fixedParam = typeof fixed !== 'undefined' ? fixed : !!defaultFixed
-
     const paginationClasses = {
       selectRoot: classes.selectRoot,
       root: !noBorder && classes.paginationRoot,
       input: classes.white,
     }
-
-    let sortedData = stableSort(data, getSorting(orderParam, orderByParam, orderProp), fixedParam)
+    const columnSort = columns.find((column) => column.id === orderByParam)
+    let sortedData = stableSort(
+      data,
+      getSorting(orderParam, orderByParam, orderProp, columnSort['formatTypeSort']),
+      fixedParam,
+    )
 
     if (!disablePagination) {
       sortedData = sortedData.slice(page * displayRows, page * displayRows + displayRows)

--- a/src/components/Table/sorting.ts
+++ b/src/components/Table/sorting.ts
@@ -4,7 +4,13 @@ export const FIXED = 'fixed'
 
 export const buildOrderFieldFrom = (attr: string): string => `${attr}Order`
 
-const desc = (a: string, b: string, orderBy: string, orderProp: boolean, format: (value: any) => any): number => {
+const desc = (
+  a: string,
+  b: string,
+  orderBy: string,
+  orderProp: boolean,
+  format: (value: string | number) => string | number,
+): number => {
   const order = orderProp ? buildOrderFieldFrom(orderBy) : orderBy
 
   if (format(b[order]) < format(a[order])) {
@@ -42,7 +48,7 @@ export const getSorting = (
   order: 'desc' | 'asc',
   orderBy: string,
   orderProp: boolean,
-  format: (value: any) => any = (value) => value,
+  format: (value: string | number) => string | number = (value) => value,
 ): ((a: string, b: string) => number) =>
   order === 'desc'
     ? (a, b) => desc(a, b, orderBy, orderProp, format)

--- a/src/components/Table/sorting.ts
+++ b/src/components/Table/sorting.ts
@@ -4,13 +4,13 @@ export const FIXED = 'fixed'
 
 export const buildOrderFieldFrom = (attr: string): string => `${attr}Order`
 
-const desc = (a: string, b: string, orderBy: string, orderProp: boolean): number => {
+const desc = (a: string, b: string, orderBy: string, orderProp: boolean, format: (value: any) => any): number => {
   const order = orderProp ? buildOrderFieldFrom(orderBy) : orderBy
 
-  if (b[order] < a[order]) {
+  if (format(b[order]) < format(a[order])) {
     return -1
   }
-  if (b[order] > a[order]) {
+  if (format(b[order]) > format(a[order])) {
     return 1
   }
 
@@ -42,5 +42,8 @@ export const getSorting = (
   order: 'desc' | 'asc',
   orderBy: string,
   orderProp: boolean,
+  format: (value: any) => any = (value) => value,
 ): ((a: string, b: string) => number) =>
-  order === 'desc' ? (a, b) => desc(a, b, orderBy, orderProp) : (a, b) => -desc(a, b, orderBy, orderProp)
+  order === 'desc'
+    ? (a, b) => desc(a, b, orderBy, orderProp, format)
+    : (a, b) => -desc(a, b, orderBy, orderProp, format)

--- a/src/components/Table/types.d.ts
+++ b/src/components/Table/types.d.ts
@@ -7,6 +7,6 @@ export interface TableColumn {
   order: boolean
   static?: boolean
   style?: any
-  formatTypeSort?: (value: any) => any
+  formatTypeSort?: (value: string | number) => string | number
   width?: number
 }

--- a/src/components/Table/types.d.ts
+++ b/src/components/Table/types.d.ts
@@ -7,5 +7,6 @@ export interface TableColumn {
   order: boolean
   static?: boolean
   style?: any
+  formatTypeSort?: (value: any) => any
   width?: number
 }

--- a/src/routes/safe/components/Settings/ManageOwners/dataFetcher.ts
+++ b/src/routes/safe/components/Settings/ManageOwners/dataFetcher.ts
@@ -17,6 +17,7 @@ export const generateColumns = (): List<TableColumn> => {
   const nameColumn: TableColumn = {
     id: OWNERS_TABLE_NAME_ID,
     order: false,
+    formatTypeSort: (value: string) => value.toLowerCase(),
     disablePadding: false,
     label: 'Name',
     width: 150,


### PR DESCRIPTION
## What it solves
This PR fixes #459 

## How this PR fixes it
We extended the sorting functionality in order to allow custom sorting methods for each column of the table.

## How to test it
1. Open/Load a safe with owners
2. Go to Settings 
3. Go to Owners tab
4. Sort Name column by clicking on the column name
