### PR TITLE
Fix: don't display Intercom in Safe Apps

### DIFF
--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -9,7 +9,7 @@ import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
 import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
-import { useGetSafeAppUrl } from 'src/logic/hooks/useGetSafeAppUrl'
+import { useSafeAppUrl } from 'src/logic/hooks/useSafeAppUrl'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
 import { loadGoogleAnalytics, removeCookies } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
@@ -98,7 +98,7 @@ interface CookiesBannerFormProps {
 const CookiesBanner = (): ReactElement => {
   const classes = useStyles()
   const dispatch = useRef(useDispatch())
-  const { url: appUrl } = useGetSafeAppUrl()
+  const { url: appUrl } = useSafeAppUrl()
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showIntercom, setShowIntercom] = useState(false)
   const [localNecessary, setLocalNecessary] = useState(true)

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -3,6 +3,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel'
 import { makeStyles } from '@material-ui/core/styles'
 import React, { ReactElement, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { useHistory } from 'react-router-dom'
 import Button from 'src/components/layout/Button'
 import Link from 'src/components/layout/Link'
 import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
@@ -97,7 +98,7 @@ interface CookiesBannerFormProps {
 const CookiesBanner = (): ReactElement => {
   const classes = useStyles()
   const dispatch = useRef(useDispatch())
-
+  const history = useHistory()
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showIntercom, setShowIntercom] = useState(false)
   const [localNecessary, setLocalNecessary] = useState(true)
@@ -105,6 +106,13 @@ const CookiesBanner = (): ReactElement => {
   const [localIntercom, setLocalIntercom] = useState(false)
 
   const showBanner = useSelector(cookieBannerOpen)
+  const safeAppView = history.location.search.substr(0, 7) === '?appUrl'
+
+  useEffect(() => {
+    if (safeAppView) {
+      closeIntercom()
+    }
+  }, [safeAppView])
 
   useEffect(() => {
     async function fetchCookiesFromStorage() {
@@ -171,7 +179,7 @@ const CookiesBanner = (): ReactElement => {
     dispatch.current(openCookieBanner({ cookieBannerOpen: false }))
   }
 
-  if (showIntercom) {
+  if (showIntercom && !safeAppView) {
     loadIntercom()
   }
 

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -3,13 +3,13 @@ import FormControlLabel from '@material-ui/core/FormControlLabel'
 import { makeStyles } from '@material-ui/core/styles'
 import React, { ReactElement, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 import Button from 'src/components/layout/Button'
 import Link from 'src/components/layout/Link'
 import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
 import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
+import { useGetSafeAppUrl } from 'src/logic/hooks/useGetSafeAppUrl'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
 import { loadGoogleAnalytics, removeCookies } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
@@ -98,7 +98,7 @@ interface CookiesBannerFormProps {
 const CookiesBanner = (): ReactElement => {
   const classes = useStyles()
   const dispatch = useRef(useDispatch())
-  const history = useHistory()
+  const { url: appUrl } = useGetSafeAppUrl()
   const [showAnalytics, setShowAnalytics] = useState(false)
   const [showIntercom, setShowIntercom] = useState(false)
   const [localNecessary, setLocalNecessary] = useState(true)
@@ -106,13 +106,12 @@ const CookiesBanner = (): ReactElement => {
   const [localIntercom, setLocalIntercom] = useState(false)
 
   const showBanner = useSelector(cookieBannerOpen)
-  const safeAppView = history.location.search.substr(0, 7) === '?appUrl'
 
   useEffect(() => {
-    if (safeAppView) {
-      closeIntercom()
+    if (appUrl) {
+      setTimeout(closeIntercom, 50)
     }
-  }, [safeAppView])
+  }, [appUrl])
 
   useEffect(() => {
     async function fetchCookiesFromStorage() {
@@ -179,7 +178,7 @@ const CookiesBanner = (): ReactElement => {
     dispatch.current(openCookieBanner({ cookieBannerOpen: false }))
   }
 
-  if (showIntercom && !safeAppView) {
+  if (showIntercom && !appUrl) {
     loadIntercom()
   }
 

--- a/src/logic/hooks/useGetSafeAppUrl.tsx
+++ b/src/logic/hooks/useGetSafeAppUrl.tsx
@@ -1,0 +1,22 @@
+import { useLocation } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+
+type AppUrlReturnType = {
+  url: string | null
+}
+
+export const useGetSafeAppUrl = (): AppUrlReturnType => {
+  const [url, setUrl] = useState<string | null>(null)
+  const { search } = useLocation()
+
+  useEffect(() => {
+    if (search !== url) {
+      const query = new URLSearchParams(search)
+      setUrl(query.get('appUrl'))
+    }
+  }, [search])
+
+  return {
+    url,
+  }
+}

--- a/src/logic/hooks/useSafeAppUrl.tsx
+++ b/src/logic/hooks/useSafeAppUrl.tsx
@@ -5,7 +5,7 @@ type AppUrlReturnType = {
   url: string | null
 }
 
-export const useGetSafeAppUrl = (): AppUrlReturnType => {
+export const useSafeAppUrl = (): AppUrlReturnType => {
   const [url, setUrl] = useState<string | null>(null)
   const { search } = useLocation()
 
@@ -14,7 +14,7 @@ export const useGetSafeAppUrl = (): AppUrlReturnType => {
       const query = new URLSearchParams(search)
       setUrl(query.get('appUrl'))
     }
-  }, [search])
+  }, [search, url])
 
   return {
     url,

--- a/src/routes/safe/components/Apps/index.tsx
+++ b/src/routes/safe/components/Apps/index.tsx
@@ -1,20 +1,14 @@
 import React from 'react'
-
-import { useLocation } from 'react-router-dom'
+import { useGetSafeAppUrl } from 'src/logic/hooks/useGetSafeAppUrl'
 
 import AppFrame from './components/AppFrame'
 import AppsList from './components/AppsList'
 
-const useQuery = () => {
-  return new URLSearchParams(useLocation().search)
-}
-
 const Apps = (): React.ReactElement => {
-  const query = useQuery()
-  const appUrl = query.get('appUrl')
+  const { url } = useGetSafeAppUrl()
 
-  if (appUrl) {
-    return <AppFrame appUrl={appUrl} />
+  if (url) {
+    return <AppFrame appUrl={url} />
   } else {
     return <AppsList />
   }

--- a/src/routes/safe/components/Apps/index.tsx
+++ b/src/routes/safe/components/Apps/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { useGetSafeAppUrl } from 'src/logic/hooks/useGetSafeAppUrl'
+import { useSafeAppUrl } from 'src/logic/hooks/useSafeAppUrl'
 
 import AppFrame from './components/AppFrame'
 import AppsList from './components/AppsList'
 
 const Apps = (): React.ReactElement => {
-  const { url } = useGetSafeAppUrl()
+  const { url } = useSafeAppUrl()
 
   if (url) {
     return <AppFrame appUrl={url} />


### PR DESCRIPTION
## What it solves

Closes #2238 

## How this PR fixes it

Checks if the current view is the safe app view and hides the intercom

## How to test it

Enter any safe app view and check if intercom is hidden in the bottom right side
