### PR TITLE
[Address Book v2] - Avoid deleting addressBook entry when deleting a safe

### DIFF
--- a/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
@@ -11,7 +11,6 @@ import Block from 'src/components/layout/Block'
 import Hairline from 'src/components/layout/Hairline'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
-import { addressBookRemove } from 'src/logic/addressBook/store/actions'
 import { addressBookMapSelector } from 'src/logic/addressBook/store/selectors'
 import { defaultSafeSelector, safeParamAddressFromStateSelector } from 'src/logic/safe/store/selectors'
 import { WELCOME_ADDRESS } from 'src/routes/routes'
@@ -41,8 +40,7 @@ export const RemoveSafeModal = ({ isOpen, onClose }: RemoveSafeModalProps): Reac
   const onRemoveSafeHandler = async () => {
     // ToDo: review if this is necessary or we should directly use the `removeSafe` action.
     await dispatch(removeLocalSafe(safeAddress))
-    // remove safe from the address book
-    safeAddressBookEntry && dispatch(addressBookRemove(safeAddressBookEntry))
+
     if (sameAddress(safeAddress, defaultSafe)) {
       await saveDefaultSafe('')
     }

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -17,8 +17,6 @@ import Col from 'src/components/layout/Col'
 import Heading from 'src/components/layout/Heading'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
-import { makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
-import { addressBookAddOrUpdate } from 'src/logic/addressBook/store/actions'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
 import { getNotificationsFromTxType, enhanceSnackbarForAction } from 'src/logic/notifications'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
@@ -71,8 +69,7 @@ const SafeDetails = (): ReactElement => {
     setModalOpen((prevOpen) => !prevOpen)
   }
 
-  const handleSubmit = (values) => {
-    dispatch(addressBookAddOrUpdate(makeAddressBookEntry({ address: safeAddress, name: values.safeName })))
+  const handleSubmit = () => {
     // setting `loadedViaUrl` to `false` as setting a safe's name is considered to intentionally add the safe
     dispatch(updateSafe({ address: safeAddress, loadedViaUrl: false }))
 

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -17,6 +17,8 @@ import Col from 'src/components/layout/Col'
 import Heading from 'src/components/layout/Heading'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
+import { makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
+import { addressBookAddOrUpdate } from 'src/logic/addressBook/store/actions'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
 import { getNotificationsFromTxType, enhanceSnackbarForAction } from 'src/logic/notifications'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
@@ -69,7 +71,8 @@ const SafeDetails = (): ReactElement => {
     setModalOpen((prevOpen) => !prevOpen)
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = (values) => {
+    dispatch(addressBookAddOrUpdate(makeAddressBookEntry({ address: safeAddress, name: values.safeName })))
     // setting `loadedViaUrl` to `false` as setting a safe's name is considered to intentionally add the safe
     dispatch(updateSafe({ address: safeAddress, loadedViaUrl: false }))
 


### PR DESCRIPTION
## What it solves
fixes #2353

## How this PR fixes it
Stop from dispatching `addressBook/remove` action when deleting a Safe

## How to test it
Follow steps in issue #2353
