### PR TITLE
Use the same link in the import and export modals

### DIFF
--- a/src/routes/safe/components/AddressBook/ExportEntriesModal/index.tsx
+++ b/src/routes/safe/components/AddressBook/ExportEntriesModal/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useEffect, useState } from 'react'
 import { format } from 'date-fns'
 import { useSelector, useDispatch } from 'react-redux'
 import { CSVDownloader, jsonToCSV } from 'react-papaparse'
-import { Button, Icon, Link, Loader, Text } from '@gnosis.pm/safe-react-components'
+import { Button, Loader, Text } from '@gnosis.pm/safe-react-components'
 import styled from 'styled-components'
 
 import { enhanceSnackbarForAction, getNotificationsFromTxType } from 'src/logic/notifications'
@@ -17,6 +17,7 @@ import { lg, md, background } from 'src/theme/variables'
 import { Modal } from 'src/components/Modal'
 import Img from 'src/components/layout/Img'
 import Row from 'src/components/layout/Row'
+import HelpInfo from 'src/routes/safe/components/AddressBook/HelpInfo'
 
 import SuccessSvg from './assets/success.svg'
 import ErrorSvg from './assets/error.svg'
@@ -60,14 +61,6 @@ const StyledCSVLink = styled(CSVDownloader)`
   flex: 1;
   justify-content: center;
   align-items: center;
-`
-
-const StyledIcon = styled(Icon)`
-  svg {
-    position: relative;
-    top: 4px;
-    left: 4px;
-  }
 `
 
 export const ExportEntriesModal = ({ isOpen, onClose }: ExportEntriesModalProps): ReactElement => {
@@ -132,17 +125,7 @@ export const ExportEntriesModal = ({ isOpen, onClose }: ExportEntriesModalProps)
                 You&apos;re about to export a CSV file with{' '}
                 <Text size="xl" strong as="span">
                   {addressBook.length} address book entries. <br />
-                  <Link
-                    href="https://help.gnosis-safe.io/en/"
-                    target="_blank"
-                    rel="noreferrer"
-                    title="Learn more about importing / exporting an address book."
-                  >
-                    <Text size="xl" as="span" color="primary">
-                      Learn more about importing / exporting an address book.
-                    </Text>
-                    <StyledIcon size="sm" type="externalLink" color="primary" />
-                  </Link>
+                  <HelpInfo />
                 </Text>
                 .
               </Text>

--- a/src/routes/safe/components/AddressBook/HelpInfo/index.tsx
+++ b/src/routes/safe/components/AddressBook/HelpInfo/index.tsx
@@ -1,0 +1,27 @@
+import React, { ReactElement } from 'react'
+import styled from 'styled-components'
+import { Text, Link, Icon } from '@gnosis.pm/safe-react-components'
+
+const StyledIcon = styled(Icon)`
+  svg {
+    position: relative;
+    top: 4px;
+    left: 4px;
+  }
+`
+
+const HelpInfo = (): ReactElement => (
+  <Link
+    href="https://help.gnosis-safe.io/en/articles/5299068-address-book-export-and-import"
+    target="_blank"
+    rel="noreferrer"
+    title="Export & import info"
+  >
+    <Text size="xl" as="span" color="primary">
+      Learn about the address book import and export
+    </Text>
+    <StyledIcon size="sm" type="externalLink" color="primary" />
+  </Link>
+)
+
+export default HelpInfo

--- a/src/routes/safe/components/AddressBook/ImportEntryModal/index.tsx
+++ b/src/routes/safe/components/AddressBook/ImportEntryModal/index.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 
 import styled from 'styled-components'
-import { Icon, Link, Text } from '@gnosis.pm/safe-react-components'
+import { Text } from '@gnosis.pm/safe-react-components'
 import { Modal } from 'src/components/Modal'
 import { CSVReader } from 'react-papaparse'
 import { AddressBookEntry } from 'src/logic/addressBook/model/addressBook'
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { checksumAddress } from 'src/utils/checksumAddress'
+import HelpInfo from 'src/routes/safe/components/AddressBook/HelpInfo'
 
 const ImportContainer = styled.div`
   flex-direction: column;
@@ -25,13 +26,6 @@ const InfoContainer = styled.div`
   padding: 24px;
   text-align: center;
   margin-top: 16px;
-`
-const StyledIcon = styled(Icon)`
-  svg {
-    position: relative;
-    top: 4px;
-    left: 4px;
-  }
 `
 
 const WRONG_FILE_EXTENSION_ERROR = 'Only CSV files are allowed'
@@ -187,18 +181,8 @@ const ImportEntryModal = ({ importEntryModalHandler, isOpen, onClose }) => {
           )}
           {!csvLoaded && importError === '' && (
             <Text color="text" as="p" size="xl">
-              Only CSV files are allowed in the format [Address, Name] separated by comma. <br />
-              <Link
-                href="https://help.gnosis-safe.io/en/"
-                target="_blank"
-                rel="noreferrer"
-                title="Learn more about importing / exporting an address book."
-              >
-                <Text size="xl" as="span" color="primary">
-                  Learn more about importing / exporting an address book.
-                </Text>
-                <StyledIcon size="sm" type="externalLink" color="primary" />
-              </Link>
+              Only CSV files exported from Gnosis Safe are allowed. <br />
+              <HelpInfo />
             </Text>
           )}
           {csvLoaded && importError === '' && (


### PR DESCRIPTION
## What it solves
See [this comment](https://github.com/gnosis/safe-react/pull/2280#issuecomment-852904740) from @tschubotz 

## How this PR fixes it
Adds a new component `HelpInfo` that is used in both import and export modals.

## How to test it
Click on the link
Make sure it opens the right help article