### PR TITLE
keep safes with no name for the list of safes

### DIFF
--- a/src/logic/safe/store/middleware/safeStorage.ts
+++ b/src/logic/safe/store/middleware/safeStorage.ts
@@ -4,7 +4,7 @@ import { saveDefaultSafe, saveSafes } from 'src/logic/safe/utils'
 import { REMOVE_SAFE } from 'src/logic/safe/store/actions/removeSafe'
 import { SET_DEFAULT_SAFE } from 'src/logic/safe/store/actions/setDefaultSafe'
 import { UPDATE_SAFE } from 'src/logic/safe/store/actions/updateSafe'
-import { safesListWithAddressBookNameSelector, safesMapSelector } from 'src/logic/safe/store/selectors'
+import { safesMapSelector } from 'src/logic/safe/store/selectors'
 import { SafeRecord } from '../models/safe'
 
 const watchedActions = [REMOVE_SAFE, SET_DEFAULT_SAFE, UPDATE_SAFE]
@@ -24,12 +24,7 @@ export const safeStorageMiddleware = (store: Store) => (
   if (watchedActions.includes(action.type)) {
     const state = store.getState()
     const safes = safesMapSelector(state)
-    const safeNameMap = Object.fromEntries(
-      safesListWithAddressBookNameSelector(state)
-        .map((safe) => [safe.address, safe.name])
-        .toJSON(),
-    )
-    await saveSafes(safes.filter((safe) => safeNameMap[safe.address]).toJSON())
+    await saveSafes(safes.filter((safe) => !safe.loadedViaUrl).toJSON())
 
     switch (action.type) {
       case SET_DEFAULT_SAFE: {

--- a/src/logic/safe/store/selectors/index.ts
+++ b/src/logic/safe/store/selectors/index.ts
@@ -35,7 +35,7 @@ export const safesListWithAddressBookNameSelector = createSelector(
       .filter((safeRecord) => !safeRecord.loadedViaUrl)
       .map((safeRecord) => {
         const safe = safeRecord.toObject()
-        const name = addressBook?.[safe.address]?.name
+        const name = addressBook?.[safe.address]?.name ?? ''
         return { ...safe, name }
       })
   },

--- a/src/logic/safe/store/selectors/index.ts
+++ b/src/logic/safe/store/selectors/index.ts
@@ -38,7 +38,6 @@ export const safesListWithAddressBookNameSelector = createSelector(
         const name = addressBook?.[safe.address]?.name
         return { ...safe, name }
       })
-      .filter((safeRecord: SafeRecordWithName) => safeRecord.name)
   },
 )
 

--- a/src/routes/open/container/Open.tsx
+++ b/src/routes/open/container/Open.tsx
@@ -177,12 +177,12 @@ const Open = (): ReactElement => {
       ownersAddresses = getAccountsFrom(pendingCreation)
     }
 
-    const safeProps = await buildSafe(safeAddress)
-    await dispatch(addOrUpdateSafe(safeProps))
-
     const owners = ownersAddresses.map((address, index) => makeAddressBookEntry({ address, name: ownersNames[index] }))
     const safe = makeAddressBookEntry({ address: safeAddress, name })
     await dispatch(addressBookSafeLoad([...owners, safe]))
+
+    const safeProps = await buildSafe(safeAddress)
+    await dispatch(addOrUpdateSafe(safeProps))
 
     trackEvent({
       category: 'User',


### PR DESCRIPTION
## What it solves
Fixes #2386

## How this PR fixes it
By stop filtering out those safes without name from being listed, and by storing safes without `name` leaving outside only those whose `loadedViaUrl` flag is set to `true`

## How to test it
Follow steps specified in the issue
