### PR TITLE
[Address Book v2] Set default order by name

### DIFF
--- a/src/routes/safe/components/AddressBook/index.tsx
+++ b/src/routes/safe/components/AddressBook/index.tsx
@@ -24,6 +24,7 @@ import { CreateEditEntryModal } from 'src/routes/safe/components/AddressBook/Cre
 import { ExportEntriesModal } from 'src/routes/safe/components/AddressBook/ExportEntriesModal'
 import { DeleteEntryModal } from 'src/routes/safe/components/AddressBook/DeleteEntryModal'
 import {
+  AB_NAME_ID,
   AB_ADDRESS_ID,
   ADDRESS_BOOK_ROW_ID,
   SEND_ENTRY_BUTTON,
@@ -199,6 +200,7 @@ const AddressBookTable = (): ReactElement => {
             columns={columns}
             data={addressBook}
             defaultFixed
+            defaultOrderBy={AB_NAME_ID}
             defaultRowsPerPage={25}
             disableLoadingOnEmptyTable
             label="Owners"


### PR DESCRIPTION
## What it solves
Close #2378 where order was by adding date. Instead we will set default order by name.

## How this PR fixes it
Just setting the defaultOrderBy to use the name column

## How to test it
Add a bunch of entries to the address book. Avoid using alphabetic order when introducing them
Check that whenever you open the address book entries are listed by name ascending
