### PR TITLE
(Fix) Preserve contract name in custom contract interaction flow

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/index.tsx
@@ -5,7 +5,7 @@ import React, { Suspense, useEffect, useState } from 'react'
 import Modal from 'src/components/Modal'
 import { Erc721Transfer } from 'src/logic/safe/store/models/types/gateway'
 import { CollectibleTx } from './screens/ReviewCollectible'
-import { CustomTx } from './screens/ContractInteraction/ReviewCustomTx'
+import { ReviewCustomTxProps } from './screens/ContractInteraction/ReviewCustomTx'
 import { ContractInteractionTx } from './screens/ContractInteraction'
 import { CustomTxProps } from './screens/ContractInteraction/SendCustomTx'
 import { ReviewTxProp } from './screens/ReviewSendFundsTx'
@@ -185,7 +185,11 @@ const SendModal = ({
         )}
 
         {activeScreen === 'reviewCustomTx' && (
-          <ReviewCustomTx onClose={onClose} onPrev={() => handleOnPrev('contractInteraction')} tx={tx as CustomTx} />
+          <ReviewCustomTx
+            onClose={onClose}
+            onPrev={() => handleOnPrev('contractInteraction')}
+            tx={tx as ReviewCustomTxProps}
+          />
         )}
 
         {activeScreen === 'sendCollectible' && (

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
@@ -30,23 +30,24 @@ import { EditableTxParameters } from 'src/routes/safe/components/Transactions/he
 import { styles } from './style'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 
-export type CustomTx = {
-  contractAddress?: string
-  data?: string
-  value?: string
+export type ReviewCustomTxProps = {
+  contractAddress: string
+  contractName?: string
+  data: string
+  value: string
 }
 
 type Props = {
   onClose: () => void
   onPrev: () => void
-  tx: CustomTx
+  tx: ReviewCustomTxProps
 }
 
 const useStyles = makeStyles(styles)
 
 const { nativeCoin } = getNetworkInfo()
 
-const ReviewCustomTx = ({ onClose, onPrev, tx }: Props): React.ReactElement => {
+const ReviewCustomTx = ({ onClose, onPrev, tx }: Props): ReactElement => {
   const classes = useStyles()
   const dispatch = useDispatch()
   const safeAddress = useSelector(safeAddressFromUrl)
@@ -125,6 +126,7 @@ const ReviewCustomTx = ({ onClose, onPrev, tx }: Props): React.ReactElement => {
               <Col xs={12}>
                 <EthHashInfo
                   hash={tx.contractAddress as string}
+                  name={tx.contractName ?? ''}
                   showAvatar
                   showCopyBtn
                   explorerUrl={getExplorerInfo(tx.contractAddress as string)}

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/SendCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/SendCustomTx/index.tsx
@@ -30,7 +30,7 @@ import { sameString } from 'src/utils/strings'
 
 import { styles } from './style'
 import { getExplorerInfo, getNetworkInfo } from 'src/config'
-import { addressBookSelector } from 'src/logic/addressBook/store/selectors'
+import { addressBookState } from 'src/logic/addressBook/store/selectors'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 
 export interface CreatedTx {
@@ -66,7 +66,7 @@ const SendCustomTx = ({
 }: Props): ReactElement => {
   const classes = useStyles()
   const ethBalance = useSelector(currentSafeEthBalance)
-  const addressBook = useSelector(addressBookSelector)
+  const addressBook = useSelector(addressBookState)
   const [qrModalOpen, setQrModalOpen] = useState<boolean>(false)
   const [selectedEntry, setSelectedEntry] = useState<{ address?: string; name: string } | null>(() => {
     const defaultEntry = {

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/SendCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/SendCustomTx/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import { EthHashInfo } from '@gnosis.pm/safe-react-components'
+import React, { ReactElement, useState } from 'react'
 import { useSelector } from 'react-redux'
 import IconButton from '@material-ui/core/IconButton'
 import InputAdornment from '@material-ui/core/InputAdornment'
@@ -29,7 +30,8 @@ import { sameString } from 'src/utils/strings'
 
 import { styles } from './style'
 import { getExplorerInfo, getNetworkInfo } from 'src/config'
-import { EthHashInfo } from '@gnosis.pm/safe-react-components'
+import { addressBookSelector } from 'src/logic/addressBook/store/selectors'
+import { sameAddress } from 'src/logic/wallets/ethAddresses'
 
 export interface CreatedTx {
   contractAddress: string
@@ -54,13 +56,36 @@ const useStyles = makeStyles(styles)
 
 const { nativeCoin } = getNetworkInfo()
 
-const SendCustomTx: React.FC<Props> = ({ initialValues, onClose, onNext, contractAddress, switchMethod, isABI }) => {
+const SendCustomTx = ({
+  initialValues,
+  onClose,
+  onNext,
+  contractAddress,
+  switchMethod,
+  isABI,
+}: Props): ReactElement => {
   const classes = useStyles()
   const ethBalance = useSelector(currentSafeEthBalance)
+  const addressBook = useSelector(addressBookSelector)
   const [qrModalOpen, setQrModalOpen] = useState<boolean>(false)
-  const [selectedEntry, setSelectedEntry] = useState<{ address?: string; name: string } | null>({
-    address: contractAddress || initialValues.contractAddress,
-    name: '',
+  const [selectedEntry, setSelectedEntry] = useState<{ address?: string; name: string } | null>(() => {
+    const defaultEntry = {
+      // `initialValue` has precedence over `contractAddress`
+      address: initialValues?.contractAddress ?? contractAddress,
+      name: '',
+    }
+
+    // if there's nothing to lookup for, we return the default entry
+    if (!defaultEntry.address) {
+      return defaultEntry
+    }
+
+    const addressBookEntry = addressBook.find(({ address }) => sameAddress(address, defaultEntry.address))
+    if (addressBookEntry) {
+      return addressBookEntry
+    }
+
+    return defaultEntry
   })
   const [isValidAddress, setIsValidAddress] = useState<boolean>(true)
 
@@ -71,7 +96,14 @@ const SendCustomTx: React.FC<Props> = ({ initialValues, onClose, onNext, contrac
 
   const handleSubmit = (values: any, submit = true) => {
     if (values.data || values.value) {
-      onNext(values, submit)
+      const submitValues = { ...values }
+
+      if (!values.contractAddress) {
+        submitValues.contractAddress = selectedEntry?.address
+      }
+      submitValues.contractName = selectedEntry?.name
+
+      onNext(submitValues, submit)
     }
   }
 


### PR DESCRIPTION
## What it solves
fixes #2384

## How this PR fixes it
By following the same strategy as in `SendFunds` modal. That is, lookup the name in AB, then pass it as param between screens.

## How to test it
Follow steps in the issue.
