### PR TITLE
Dont lower threshold if owner amount is the same as current threshold

### DIFF
--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/ThresholdForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/ThresholdForm/index.tsx
@@ -40,7 +40,8 @@ export const ThresholdForm = ({ onClickBack, onClose, onSubmit, initialValues }:
   const handleSubmit = (values) => {
     onSubmit(values)
   }
-  const defaultThreshold = threshold > 1 ? threshold - 1 : threshold
+  const ownersAmount = owners?.size
+  const defaultThreshold = threshold > 1 && threshold === ownersAmount ? threshold - 1 : threshold
 
   return (
     <>

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/ThresholdForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/ThresholdForm/index.tsx
@@ -40,8 +40,7 @@ export const ThresholdForm = ({ onClickBack, onClose, onSubmit, initialValues }:
   const handleSubmit = (values) => {
     onSubmit(values)
   }
-  const ownersAmount = owners?.size
-  const defaultThreshold = threshold > 1 && threshold === ownersAmount ? threshold - 1 : threshold
+  const defaultThreshold = threshold > 1 && threshold === ownersCount ? threshold - 1 : threshold
 
   return (
     <>


### PR DESCRIPTION
## What it solves

Closes #1649

## How this PR fixes it

When removing an owner and threshold==num_owners then preselect old threshold - 1
When removing an owner and threshold<num_owners then preselect the ol threshold

## How to test it

Add 3 owners with threshold 2
Remove an owner
It should set the default threshold to 2
