### PR TITLE
Catch ENS/unstoppable errors; split logError and trackError

### DIFF
--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -8,6 +8,7 @@ import { trimSpaces } from 'src/utils/strings'
 import { getAddressFromDomain } from 'src/logic/wallets/getWeb3'
 import { isValidEnsName, isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { checksumAddress } from 'src/utils/checksumAddress'
+import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
 // an idea for second field was taken from here
 // https://github.com/final-form/react-final-form-listeners/blob/master/src/OnBlur.js
@@ -52,7 +53,7 @@ const AddressInput = ({
       validate={composeValidators(required, mustBeEthereumAddress, ...validators)}
     />
     <OnChange name={name}>
-      {async (value) => {
+      {async (value: string) => {
         const address = trimSpaces(value)
         if (isValidEnsName(address) || isValidCryptoDomainName(address)) {
           try {
@@ -60,7 +61,7 @@ const AddressInput = ({
             const formattedAddress = checksumAddress(resolverAddr)
             fieldMutator(formattedAddress)
           } catch (err) {
-            console.error('Failed to resolve address for ENS name: ', err)
+            logError(Errors._101, err.message)
           }
         }
       }}

--- a/src/logic/addressBook/utils/v2-migration.ts
+++ b/src/logic/addressBook/utils/v2-migration.ts
@@ -3,7 +3,7 @@ import { saveSafes, StoredSafes } from 'src/logic/safe/utils'
 import { removeFromStorage } from 'src/utils/storage'
 import { getNetworkName } from 'src/config'
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
-import { Errors, logError } from 'src/logic/exceptions/CodedException'
+import { Errors, trackError } from 'src/logic/exceptions/CodedException'
 import { getEntryIndex, isValidAddressBookName } from '.'
 
 interface StorageConfig {
@@ -126,7 +126,7 @@ const migrate = (storageConfig: StorageConfig): void => {
     migrateAddressBook(storageConfig)
     migrateSafeNames(storageConfig)
   } catch (e) {
-    logError(Errors._200, e.message)
+    trackError(Errors._200, e.message)
   }
 }
 

--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -7,6 +7,7 @@
 enum ErrorCodes {
   ___0 = '0: No such error code',
   _100 = '100: Invalid input in the address field',
+  _101 = '101: Failed to resolve the address',
   _200 = '200: Failed migrating to the address book v2',
   _600 = '600: Error fetching token list',
   _601 = '601: Error fetching balances',

--- a/src/logic/tokens/store/actions/fetchSafeTokens.ts
+++ b/src/logic/tokens/store/actions/fetchSafeTokens.ts
@@ -70,7 +70,7 @@ export const fetchSafeTokens = (safeAddress: string, currencySelected?: string) 
       selectedCurrency: currencySelected ?? selectedCurrency,
     })
   } catch (e) {
-    logError(Errors._601, e.message, undefined, false)
+    logError(Errors._601, e.message)
     return
   }
 

--- a/src/logic/tokens/store/actions/fetchTokens.ts
+++ b/src/logic/tokens/store/actions/fetchTokens.ts
@@ -61,7 +61,7 @@ export const fetchTokens = () => async (
     const resp = await fetchErc20AndErc721AssetsList()
     tokenList = resp.data.results
   } catch (e) {
-    logError(Errors._600, e.message, undefined, false)
+    logError(Errors._600, e.message)
     return
   }
 

--- a/src/routes/load/components/ReviewInformation/index.tsx
+++ b/src/routes/load/components/ReviewInformation/index.tsx
@@ -1,6 +1,6 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import TableContainer from '@material-ui/core/TableContainer'
-import React, { ReactElement, ReactNode } from 'react'
+import React, { Fragment, ReactElement, ReactNode } from 'react'
 
 import { getExplorerInfo } from 'src/config'
 import Block from 'src/components/layout/Block'
@@ -104,7 +104,7 @@ const ReviewComponent = ({ userAddress, values }: Props): ReactElement => {
           </Block>
           <Hairline />
           {owners.map((address, index) => (
-            <>
+            <Fragment key={`${address}_${index}`}>
               <Row className={classes.owner} testId={'load-safe-review-owner-name-' + index}>
                 <Col align="center" xs={12}>
                   <EthHashInfo
@@ -117,7 +117,7 @@ const ReviewComponent = ({ userAddress, values }: Props): ReactElement => {
                 </Col>
               </Row>
               {index !== owners.length - 1 && <Hairline />}
-            </>
+            </Fragment>
           ))}
         </TableContainer>
       </Col>

--- a/src/routes/load/components/ReviewInformation/index.tsx
+++ b/src/routes/load/components/ReviewInformation/index.tsx
@@ -104,7 +104,7 @@ const ReviewComponent = ({ userAddress, values }: Props): ReactElement => {
           </Block>
           <Hairline />
           {owners.map((address, index) => (
-            <Fragment key={`${address}_${index}`}>
+            <Fragment key={address}>
               <Row className={classes.owner} testId={'load-safe-review-owner-name-' + index}>
                 <Col align="center" xs={12}>
                   <EthHashInfo

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -9,7 +9,7 @@ import {
   METHODS,
   RequestId,
 } from '@gnosis.pm/safe-apps-sdk'
-import { logError, Errors } from 'src/logic/exceptions/CodedException'
+import { trackError, Errors } from 'src/logic/exceptions/CodedException'
 import { SafeApp } from './types'
 
 type MessageHandler = (
@@ -72,7 +72,7 @@ class AppCommunicator {
         }
       } catch (err) {
         this.send(err.message, msg.data.id, true)
-        logError(Errors._901, err.message, {
+        trackError(Errors._901, err.message, {
           contexts: {
             safeApp: this.app,
             request: msg.data,

--- a/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
@@ -17,6 +17,7 @@ import {
   useTextFieldLabelStyle,
 } from 'src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/style'
 import { trimSpaces } from 'src/utils/strings'
+import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
 const chainId = getNetworkId()
 
@@ -92,7 +93,12 @@ const BaseAddressBookInput = ({
           isFeatureEnabled(FEATURES.DOMAIN_LOOKUP) &&
           (isValidEnsName(normalizedValue) || isValidCryptoDomainName(normalizedValue))
         ) {
-          const address = await getAddressFromDomain(normalizedValue)
+          let address = ''
+          try {
+            address = await getAddressFromDomain(normalizedValue)
+          } catch (err) {
+            logError(Errors._101, err.message)
+          }
 
           const validatedAddress = validateAddress(address)
 


### PR DESCRIPTION
## What it solves
Resolves #1728.

Resolver errors weren't caught.
It wasn't throwing on every keypress like the linked issue says (this has been apparently already fixed), but it was still throwing.

## How this PR fixes it
Catches the errors and logs them.
I've added a new function `trackError` to complement `logError`. We don't have to pass `undefined, false` anymore.

## How to test it
Two test cases:
* create an owner
* send funds

In both cases, enter `brad.crypto` in the address field and observe a 101 error in the console.

<img width="581" alt="Screenshot 2021-06-08 at 11 09 36" src="https://user-images.githubusercontent.com/381895/121157637-06135f00-c84a-11eb-9d6e-18e9985172c1.png">