### PR TITLE
🔥 Fix disappearing safes after migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/logic/addressBook/utils/v2-migration.ts
+++ b/src/logic/addressBook/utils/v2-migration.ts
@@ -45,6 +45,7 @@ const migrateSafeNames = ({ states, namespace, namespaceSeparator }: StorageConf
   Object.values(parsedStoredSafes).forEach((item) => {
     item.owners = item.owners.map((owner: any) => owner.address)
     delete item.name
+    item.loadedViaUrl = false
   })
   const migratedSafes = parsedStoredSafes as StoredSafes
 

--- a/src/logic/safe/store/models/safe.ts
+++ b/src/logic/safe/store/models/safe.ts
@@ -53,7 +53,7 @@ const makeSafe = Record<SafeRecordProps>({
   currentVersion: '',
   needsUpdate: false,
   featuresEnabled: [],
-  loadedViaUrl: false,
+  loadedViaUrl: true,
 })
 
 export type SafeRecord = RecordOf<SafeRecordProps>

--- a/src/logic/safe/store/models/safe.ts
+++ b/src/logic/safe/store/models/safe.ts
@@ -53,7 +53,7 @@ const makeSafe = Record<SafeRecordProps>({
   currentVersion: '',
   needsUpdate: false,
   featuresEnabled: [],
-  loadedViaUrl: true,
+  loadedViaUrl: false,
 })
 
 export type SafeRecord = RecordOf<SafeRecordProps>


### PR DESCRIPTION
If you had safes loaded via URL in your localStorage, it would kill all the safes resulting in an empty object in the storage.