### PR TITLE
Fix infinite placeholder loop

### DIFF
--- a/src/routes/safe/components/Balances/utils/setTokenImgToPlaceholder.ts
+++ b/src/routes/safe/components/Balances/utils/setTokenImgToPlaceholder.ts
@@ -2,7 +2,9 @@ import { SyntheticEvent } from 'react'
 
 import TokenPlaceholder from 'src/routes/safe/components/Balances/assets/token_placeholder.svg'
 
-export const setImageToPlaceholder = (error: SyntheticEvent<HTMLImageElement, Event>): void => {
-  error.currentTarget.onerror = null
-  error.currentTarget.src = TokenPlaceholder
+export const setImageToPlaceholder = (event: SyntheticEvent<HTMLImageElement, Event>): void => {
+  const img = event.currentTarget
+  if (!img.src.endsWith(TokenPlaceholder)) {
+    img.src = TokenPlaceholder
+  }
 }

--- a/src/routes/safe/components/Balances/utils/setTokenImgToPlaceholder.ts
+++ b/src/routes/safe/components/Balances/utils/setTokenImgToPlaceholder.ts
@@ -4,7 +4,7 @@ import TokenPlaceholder from 'src/routes/safe/components/Balances/assets/token_p
 
 export const setImageToPlaceholder = (event: SyntheticEvent<HTMLImageElement, Event>): void => {
   const img = event.currentTarget
-  if (!img.src.endsWith(TokenPlaceholder)) {
+  if (!/token_placeholder/.test(img.src)) {
     img.src = TokenPlaceholder
   }
 }


### PR DESCRIPTION
## What it solves
Fixes #2423.

## How this PR fixes it
Checks if the fallback image is already set.

## How to test it
1. Load the assets
2. Switch off the network just before the tokens appear on the screen
3. Check the console, it shouldn't load the fallback image infinitely anymore
