### PR TITLE
Load currency flags on menu open

### DIFF
--- a/src/routes/safe/components/CurrencyDropdown/index.tsx
+++ b/src/routes/safe/components/CurrencyDropdown/index.tsx
@@ -6,7 +6,6 @@ import MenuItem from '@material-ui/core/MenuItem'
 import { MuiThemeProvider } from '@material-ui/core/styles'
 import SearchIcon from '@material-ui/icons/Search'
 import classNames from 'classnames'
-import 'currency-flags/dist/currency-flags.min.css'
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -37,6 +36,7 @@ export const CurrencyDropdown = (): React.ReactElement | null => {
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget)
+    import('currency-flags/dist/currency-flags.min.css' as any)
   }
 
   const handleClose = () => {

--- a/src/routes/safe/components/CurrencyDropdown/index.tsx
+++ b/src/routes/safe/components/CurrencyDropdown/index.tsx
@@ -36,7 +36,7 @@ export const CurrencyDropdown = (): React.ReactElement | null => {
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget)
-    import('currency-flags/dist/currency-flags.min.css' as any)
+    import('currency-flags/dist/currency-flags.min.css' as string)
   }
 
   const handleClose = () => {


### PR DESCRIPTION
## What it solves
Fixes #941.

## How this PR fixes it
Imports the currency flags on menu open.

## How to test it
* Open the Network in devtools
* Click on the currency menu
* Observe the JS chunk and icons loading
* The menu itself should work like before