### PR TITLE
Erase queued transactions if confirmed

### DIFF
--- a/src/logic/safe/store/actions/transactions/fetchTransactions/index.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/index.ts
@@ -17,9 +17,7 @@ export default (safeAddress: string) => async (
   ) => {
     try {
       const values = (await loadFn(safeAddress)) as any[]
-      if (values.length) {
-        dispatch(actionFn({ safeAddress, values }))
-      }
+      dispatch(actionFn({ safeAddress, values }))
     } catch (e) {
       e.log()
     }


### PR DESCRIPTION
## What it solves

Fixes #2434

## How this PR fixes it

Updates the store when queued tx list comes empty from the backend

## How to test it

Create a safe(preferably use 2 owners with threshold 2 because with 1 owner the queued tx might not even appear(
Create a tx (send funds for example)
Wait for it to be confirmed
Tx should be erased from the queue list and added to the history list
