### PR TITLE
[Address Book v2] - [Fix] - Safe loaded via URL is not working

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -20,7 +20,7 @@ import { getNetworkId } from 'src/config'
 import { ETHEREUM_NETWORK } from 'src/config/networks/network.d'
 import { networkSelector } from 'src/logic/wallets/store/selectors'
 import { SAFELIST_ADDRESS, WELCOME_ADDRESS } from 'src/routes/routes'
-import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
+import { currentSafeWithNames, safeAddressFromUrl } from 'src/logic/safe/store/selectors'
 import { currentCurrencySelector } from 'src/logic/currencyValues/store/selectors'
 import Modal from 'src/components/Modal'
 import SendModal from 'src/routes/safe/components/Balances/SendModal'
@@ -69,11 +69,14 @@ const App: React.FC = ({ children }) => {
   const { address: safeAddress, name: safeName, totalFiatBalance: currentSafeBalance } = useSelector(
     currentSafeWithNames,
   )
+  const addressFromUrl = useSelector(safeAddressFromUrl)
   const { safeActionsState, onShow, onHide, showSendFunds, hideSendFunds } = useSafeActions()
   const currentCurrency = useSelector(currentCurrencySelector)
   const granted = useSelector(grantedSelector)
   const sidebarItems = useSidebarItems()
-  const safeLoaded = useLoadSafe(safeAddress)
+  // if safe is loaded via URL, `safeAddress` won't be available until store is populated with temp information
+  // Temp information will be built from `addressFromUrl`
+  const safeLoaded = useLoadSafe(safeAddress || addressFromUrl)
   useSafeScheduledUpdates(safeLoaded, safeAddress)
 
   const sendFunds = safeActionsState.sendFunds


### PR DESCRIPTION
## What it solves
https://github.com/gnosis/safe-react/pull/2410#issuecomment-859195755

## How this PR fixes it
By using the safe address from the URL, if `safeAddress` is not available in the store.

## How to test it
Paste any Safe link that is not stored in the session. Try with: https://pr2439--safereact.review.gnosisdev.com/rinkeby/app/#/safes/0x9913B9180C20C6b0F21B6480c84422F6ebc4B808/balances