### PR TITLE
Modules can be null

### DIFF
--- a/src/logic/safe/store/actions/utils.ts
+++ b/src/logic/safe/store/actions/utils.ts
@@ -72,7 +72,7 @@ export const extractRemoteSafeInfo = async (remoteSafeInfo: SafeInfo): Promise<P
     modules: undefined,
     spendingLimits: undefined,
   }
-  const safeInfoModules = remoteSafeInfo.modules.map(({ value }) => value)
+  const safeInfoModules = (remoteSafeInfo.modules || []).map(({ value }) => value)
 
   if (safeInfoModules.length) {
     safeInfo.modules = buildModulesLinkedList(safeInfoModules)

--- a/src/logic/safe/utils/safeInformation.ts
+++ b/src/logic/safe/utils/safeInformation.ts
@@ -17,7 +17,7 @@ export type SafeInfo = {
   threshold: number
   implementation: AddressInfo
   owners: AddressValue[]
-  modules: AddressValue[]
+  modules: AddressValue[] | null
   fallbackHandler: AddressInfo
   version: string
 }


### PR DESCRIPTION
## What it solves
Fixes #2440.

## How this PR fixes it
Falls back to an empty array if modules are null.
This was the only place I could find. The module list component was already checking for null.

## How to test it
* Create a new safe
* Go to settings > modules
* Everything should work as before
