### PR TITLE
Catch tx errors

### DIFF
--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -26,6 +26,8 @@ enum ErrorCodes {
   _800 = '800: Safe creation tx failed',
   _801 = '801: Failed to send a tx with a spending limit',
   _802 = '802: Error submitting a transaction, safeAddress not found',
+  _803 = '803: Error creating a transaction',
+  _804 = '804: Error processing a transaction',
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',
 }

--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -24,6 +24,8 @@ enum ErrorCodes {
   _701 = '701: Failed to save a localStorage item',
   _702 = '702: Failed to remove a localStorage item',
   _800 = '800: Safe creation tx failed',
+  _801 = '801: Failed to send a tx with a spending limit',
+  _802 = '802: Error submitting a transaction, safeAddress not found',
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',
 }

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -77,13 +77,8 @@ export const createTransaction = (
     dispatch(push(`${SAFELIST_ADDRESS}/${safeAddress}/transactions`))
   }
 
-  try {
-    const ready = await onboardUser()
-    if (!ready) return
-  } catch (err) {
-    logError(Errors._803, err.message)
-    return
-  }
+  const ready = await onboardUser()
+  if (!ready) return
 
   const { account: from, hardwareWallet, smartContractWallet } = providerSelector(state)
   const safeInstance = getGnosisSafeInstanceAt(safeAddress)
@@ -181,18 +176,19 @@ export const createTransaction = (
     dispatch(closeSnackbarAction({ key: beforeExecutionKey }))
     dispatch(enqueueSnackbar({ key: err.code, ...notification }))
 
-    let errMsg = err.message
+    logError(Errors._803, err.message)
+
     if (err.code !== METAMASK_REJECT_CONFIRM_TX_ERROR_CODE) {
       const executeDataUsedSignatures = safeInstance.methods
         .execTransaction(to, valueInWei, txData, operation, 0, 0, 0, ZERO_ADDRESS, ZERO_ADDRESS, sigs)
         .encodeABI()
       try {
-        const resp = await getErrorMessage(safeInstance.options.address, 0, executeDataUsedSignatures, from)
-        errMsg = resp || errMsg
-      } catch (e) {}
+        const errMsg = await getErrorMessage(safeInstance.options.address, 0, executeDataUsedSignatures, from)
+        logError(Errors._803, errMsg)
+      } catch (e) {
+        logError(Errors._803, e.message)
+      }
     }
-
-    logError(Errors._803, errMsg)
   }
 
   return txHash

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -31,6 +31,7 @@ import { updateTransactionStatus } from 'src/logic/safe/store/actions/updateTran
 import { Confirmation } from 'src/logic/safe/store/models/types/confirmation'
 import { Operation } from 'src/logic/safe/store/models/types/gateway.d'
 import { isTxPendingError } from 'src/logic/wallets/getWeb3'
+import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
 interface ProcessTransactionArgs {
   approveAndExecute: boolean
@@ -163,7 +164,7 @@ export const processTransaction = ({
           console.error(e)
         }
       })
-      .on('error', (error) => {
+      .on('error', () => {
         dispatch(
           updateTransactionStatus({
             txStatus: 'PENDING_FAILED',
@@ -172,8 +173,6 @@ export const processTransaction = ({
             id: tx.id,
           }),
         )
-
-        console.error('Processing transaction error: ', error)
       })
       .then(async (receipt) => {
         dispatch(fetchTransactions(safeAddress))
@@ -204,11 +203,16 @@ export const processTransaction = ({
       }),
     )
 
+    let errMsg = err.message
     if (txHash) {
       const executeData = safeInstance.methods.approveHash(txHash).encodeABI()
-      const errMsg = await getErrorMessage(safeInstance.options.address, 0, executeData, from)
-      console.error(`Error executing the TX: ${errMsg}`)
+      try {
+        const resp = await getErrorMessage(safeInstance.options.address, 0, executeData, from)
+        errMsg = resp || errMsg
+      } catch (e) {}
     }
+
+    logError(Errors._804, errMsg)
   }
 
   return txHash

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -209,9 +209,9 @@ export const processTransaction = ({
       const executeData = safeInstance.methods.approveHash(txHash).encodeABI()
       try {
         const errMsg = await getErrorMessage(safeInstance.options.address, 0, executeData, from)
-        logError(Errors._803, errMsg)
+        logError(Errors._804, errMsg)
       } catch (e) {
-        logError(Errors._803, e.message)
+        logError(Errors._804, e.message)
       }
     }
   }

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -203,16 +203,17 @@ export const processTransaction = ({
       }),
     )
 
-    let errMsg = err.message
+    logError(Errors._804, err.message)
+
     if (txHash) {
       const executeData = safeInstance.methods.approveHash(txHash).encodeABI()
       try {
-        const resp = await getErrorMessage(safeInstance.options.address, 0, executeData, from)
-        errMsg = resp || errMsg
-      } catch (e) {}
+        const errMsg = await getErrorMessage(safeInstance.options.address, 0, executeData, from)
+        logError(Errors._803, errMsg)
+      } catch (e) {
+        logError(Errors._803, e.message)
+      }
     }
-
-    logError(Errors._804, errMsg)
   }
 
   return txHash


### PR DESCRIPTION
## What it solves
Fixes #2432.

## How this PR fixes it
Catches the "Signatures data too short" error, plus a few others.

## How to test it
* Set policy to > 1
* Create a tx and set the nonce to a lower number (of an existing tx)
* Check the console

## Any extra information
Plus added this extra messages for spending limit tx errors:
<img width="774" alt="Screenshot 2021-06-15 at 10 12 18" src="https://user-images.githubusercontent.com/381895/122019964-a0ccea00-cdc4-11eb-97c4-2f9e31a153cf.png">

