### PR TITLE
Rename development -> dev, master -> main

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-cla-document: 'https://github.com/gnosis/safe-react/blob/master/GNOSISCLA.md'
+          path-to-cla-document: 'https://github.com/gnosis/safe-react/blob/main/GNOSISCLA.md'
           branch: 'cla-signatures'
           allowlist: lukasschor,mikheevm,rmeissner,germartinez,fernandomg,Agupane,nicosampler,matextrem,gabitoesmiapodo,davidalbela,alongoni,Uxio0,dasanra,miguelmota,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh
           empty-commit-flag: false

--- a/.github/workflows/deploy-ewc.yml
+++ b/.github/workflows/deploy-ewc.yml
@@ -1,13 +1,13 @@
 name: Deploy to EWC network
 
-# Run on pushes to master or PRs to master
+# Run on pushes to main or PRs to main
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   # Launches build when release is published
   release:
       types: [published]
@@ -71,7 +71,7 @@ jobs:
       # Set production flag
       - name: Set production flag for release PR or tagged build
         run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'main'
 
       - name: Build ${{ env.REACT_APP_NETWORK }} app
         run: yarn build
@@ -109,12 +109,12 @@ jobs:
         env:
           REVIEW_FEATURE_URL: https://pr${{ github.event.number }}--${{ env.REPO_NAME_ALPHANUMERIC }}.review.gnosisdev.com
 
-      # Script to deploy to development environment
-      # EWC build is never created in development branch
+      # Script to deploy to the dev environment
+      # EWC build is never created on the dev branch
 
       # Script to deploy to staging environment
       - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: aws s3 sync build s3://${{ env.STAGING_BUCKET_NAME }}/current/app --delete
 
       # Script to upload release files
@@ -141,7 +141,7 @@ jobs:
 
       # Upload Sentry source maps when sending to staging or production
       - run: yarn sentry-upload-sourcemaps
-        if: success() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+        if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG}}

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -1,12 +1,12 @@
 name: Deploy to Mainnet network
 
-# Run on pushes to master or PRs
+# Run on pushes to main or PRs
 on:
   # Pull request hook without any config. Launches for every pull request
   pull_request:
   push:
     branches:
-      - master
+      - main
   # Launches build when release is published
   release:
       types: [published]
@@ -70,7 +70,7 @@ jobs:
       # Set production flag
       - name: Set production flag for release PR or tagged build
         run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'main'
 
       - name: Build ${{ env.REACT_APP_NETWORK }} app
         run: yarn build
@@ -111,12 +111,12 @@ jobs:
         env:
           REVIEW_FEATURE_URL: https://pr${{ github.event.number }}--${{ env.REPO_NAME_ALPHANUMERIC }}.review.gnosisdev.com
 
-      # Script to deploy to development environment
-      # Mainnet build is never created in development branch
+      # Script to deploy to the dev environment
+      # Mainnet build is never created on the dev branch
 
        # Script to deploy to staging environment
       - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master' # Or refs/heads/main
+        if: github.ref == 'refs/heads/main' # Or refs/heads/main
         run: aws s3 sync build s3://${{ env.STAGING_BUCKET_NAME }}/current/app --delete
 
       # Script to upload release files
@@ -143,7 +143,7 @@ jobs:
 
       # Upload Sentry source maps when sending to staging or production
       - run: yarn sentry-upload-sourcemaps
-        if: success() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+        if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG}}

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -4,6 +4,10 @@ name: Deploy to Mainnet network
 on:
   # Pull request hook without any config. Launches for every pull request
   pull_request:
+    branches:
+      - main
+      - 'release/**'
+      - 'mainnet/**'
   push:
     branches:
       - main

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - main
-      - 'release/**'
-      - 'mainnet/**'
   push:
     branches:
       - main

--- a/.github/workflows/deploy-rinkeby.yml
+++ b/.github/workflows/deploy-rinkeby.yml
@@ -1,14 +1,14 @@
 name: Deploy to Rinkeby network
 
-# Run on pushes to dev/master or PR
+# Run on pushes to dev/main or PR
 on:
   # Pull request hook without any config. Launches for every pull request
   pull_request:
-  # Launches for pushes to master or development
+  # Launches for pushes to main or dev
   push:
     branches:
-      - master
-      - development
+      - main
+      - dev
   # Launches build when release is published
   release:
       types: [published]
@@ -73,7 +73,7 @@ jobs:
         # Set production flag
       - name: Set production flag for release PR or tagged build
         run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'main'
 
       - name: Build ${{ env.REACT_APP_NETWORK }} app ${{ env.REACT_APP_ENV }}
         run: yarn build
@@ -112,16 +112,16 @@ jobs:
         env:
           REVIEW_FEATURE_URL: https://pr${{ github.event.number }}--${{ env.REPO_NAME_ALPHANUMERIC }}.review.gnosisdev.com
 
-      # Script to deploy to development environment
-      - name: 'Deploy to S3: Develop'
-        if: github.ref == 'refs/heads/development'
+      # Script to deploy to the dev environment
+      - name: 'Deploy to S3: Dev'
+        if: github.ref == 'refs/heads/dev'
         run: aws s3 sync build s3://${{ secrets.AWS_DEV_BUCKET_NAME }}/app --delete
 
       # Script to deploy to staging environment
       - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: aws s3 sync build s3://${{ env.STAGING_BUCKET_NAME }}/current/app --delete
-      
+
       # Script to upload release files
       - name: 'Upload release build files for production'
         if: startsWith(github.ref, 'refs/tags/v')
@@ -146,7 +146,7 @@ jobs:
 
       # Upload Sentry source maps when sending to staging or production
       - run: yarn sentry-upload-sourcemaps
-        if: success() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+        if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG}}

--- a/.github/workflows/deploy-volta.yml
+++ b/.github/workflows/deploy-volta.yml
@@ -1,13 +1,13 @@
 name: Deploy to Volta network
 
-# Run on pushes to master or PRs to master
+# Run on pushes to main or PRs to main
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   # Launches build when release is published
   release:
       types: [published]
@@ -71,7 +71,7 @@ jobs:
       # Set production flag
       - name: Set production flag for release PR or tagged build
         run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'main'
 
       - name: Build ${{ env.REACT_APP_NETWORK }} app
         run: yarn build
@@ -109,12 +109,12 @@ jobs:
         env:
           REVIEW_FEATURE_URL: https://pr${{ github.event.number }}--${{ env.REPO_NAME_ALPHANUMERIC }}.review.gnosisdev.com
 
-      # Script to deploy to development environment
-      # Volta build is never created in development branch
+      # Script to deploy to the dev environment
+      # Volta build is never created on the dev branch
 
       # Script to deploy to staging environment
       - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: aws s3 sync build s3://${{ env.STAGING_BUCKET_NAME }}/current/app --delete
 
       # Script to upload release files
@@ -140,7 +140,7 @@ jobs:
 
       # Upload Sentry source maps when sending to staging or production
       - run: yarn sentry-upload-sourcemaps
-        if: success() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+        if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG}}

--- a/.github/workflows/deploy-xdai.yml
+++ b/.github/workflows/deploy-xdai.yml
@@ -1,13 +1,13 @@
 name: Deploy to xDai network
 
-# Run on pushes to master or PRs to master
+# Run on pushes to main or PRs to main
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   # Launches build when release is published
   release:
       types: [published]
@@ -71,7 +71,7 @@ jobs:
       # Set production flag
       - name: Set production flag for release PR or tagged build
         run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'master'
+        if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'main'
 
       - name: Build ${{ env.REACT_APP_NETWORK }} app
         run: yarn build
@@ -109,14 +109,14 @@ jobs:
         env:
           REVIEW_FEATURE_URL: https://pr${{ github.event.number }}--${{ env.REPO_NAME_ALPHANUMERIC }}.review.gnosisdev.com
 
-      # Script to deploy to development environment
-      # xDai build is never created in development branch
+      # Script to deploy to the dev environment
+      # xDai build is never created on the dev branch
 
       # Script to deploy to staging environment
       - name: 'Deploy to S3: Staging'
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: aws s3 sync build s3://${{ env.STAGING_BUCKET_NAME }}/current/app --delete
-      
+
       # Script to upload release files
       - name: 'Upload release build files for production'
         if: startsWith(github.ref, 'refs/tags/v')
@@ -141,7 +141,7 @@ jobs:
 
      # Upload Sentry source maps when sending to staging or production
       - run: yarn sentry-upload-sourcemaps
-        if: success() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+        if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG}}

--- a/.github/workflows/release-mainnet-desktop.yml
+++ b/.github/workflows/release-mainnet-desktop.yml
@@ -1,7 +1,7 @@
 name: Build/Release Mainnet desktop app
 
 # this will help you specify where to run
-on: 
+on:
   workflow_dispatch
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
-      - development
+      - main
+      - dev
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ yarn lint:fix
 The code is deployed to a testing website automatically on each push via a GitHub Action.
 The GitHub Action will create a new subdomain and post the link as a comment in the PR.
 
-When pushing to the `master` branch, the code will be automatically deployed to [staging](https://safe-team-rinkeby.staging.gnosisdev.com/).
+When pushing to the `main` branch, the code will be automatically deployed to [staging](https://safe-team-rinkeby.staging.gnosisdev.com/).
 
 ### Production
 Deployment to production is done manually. Please see the [release procedure](docs/release-procedure.md) notes for details.

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -9,8 +9,8 @@ We prepare at least one release every sprint. Sprints are two weeks long.
 ### QA
 * The QA team do regression testing on this branch
 * If issues are found, bugfixes are merged into this branch
-* Once the QA is done, we push the branch to `master`
-* Master is automatically deployed to staging – some extra QA can be done there if needed
+* Once the QA is done, we push the branch to `main`
+* `Main` is automatically deployed to staging – some extra QA can be done there if needed
 
 ### Tag & release
 * A version tag must be created and pushed.
@@ -20,4 +20,4 @@ git push --tags
 ```
 * Devops are notified on Slack to deploy the tag to production
 * A [GitHub release](https://github.com/gnosis/safe-react/releases) is created
-* Master is back-merged into the main `development` branch
+* `Main` is back-merged into the `dev` branch

--- a/scripts/github/deploy_pull_request.sh
+++ b/scripts/github/deploy_pull_request.sh
@@ -9,7 +9,7 @@ function deploy_pull_request {
 
   # App build path
   APP_PATH="./build"
-  
+
   # Deploy pull request
   aws s3 sync $APP_PATH s3://${REVIEW_BUCKET_NAME}/${REVIEW_FEATURE_FOLDER}/${REACT_APP_NETWORK}/app --delete
 }

--- a/scripts/github/prepare_production_deployment.sh
+++ b/scripts/github/prepare_production_deployment.sh
@@ -9,7 +9,7 @@ if [ -n "$VERSION_TAG" ] && [ -n "$PROD_DEPLOYMENT_HOOK_TOKEN" ] && [ -n "$PROD_
 then
   curl --silent --output /dev/null --write-out "%{http_code}" -X POST \
      -F token="$PROD_DEPLOYMENT_HOOK_TOKEN" \
-     -F ref=master \
+     -F ref=main \
      -F "variables[TRIGGER_RELEASE_COMMIT_TAG]=$VERSION_TAG" \
       $PROD_DEPLOYMENT_HOOK_URL
 else


### PR DESCRIPTION
* Replaced the branch names in deployment scripts
* Updated the docs

As per the discussion with @francovenica, I've also disabled the automatic mainnet deployment on each PR.
@francovenica almost never uses it. He'd like to keep the option to explicitly deploy on mainnet, though.
The deployment to mainnet will happen only on PRs created against the main branch now.