### PR TITLE
Added data test ids needed to fix add remove owner e2e test

### DIFF
--- a/src/components/ButtonHelper/index.tsx
+++ b/src/components/ButtonHelper/index.tsx
@@ -15,11 +15,12 @@ const UnStyledButton = styled.button`
 type Props = {
   onClick?: () => void
   children: ReactElement
+  dataTestId?: string
 }
 
-const ButtonHelper = ({ onClick = () => undefined, children }: Props): React.ReactElement => {
+const ButtonHelper = ({ onClick = () => undefined, children, dataTestId }: Props): React.ReactElement => {
   return (
-    <UnStyledButton onClick={onClick} type={'button'}>
+    <UnStyledButton onClick={onClick} type={'button'} data-testid={dataTestId}>
       {children}
     </UnStyledButton>
   )

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
@@ -180,7 +180,7 @@ export const ReviewAddOwner = ({ onClickBack, onClose, onSubmit, values }: Revie
                   </Paragraph>
                 </Row>
                 <Hairline />
-                <Row className={classes.selectedOwner}>
+                <Row className={classes.selectedOwner} data-testid="add-owner-review">
                   <Col align="center" xs={12}>
                     <EthHashInfo
                       hash={values.ownerAddress}

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
@@ -201,7 +201,7 @@ export const ReviewRemoveOwnerModal = ({
                   </Paragraph>
                 </Row>
                 <Hairline />
-                <Row className={classes.selectedOwner}>
+                <Row className={classes.selectedOwner} data-testid="remove-owner-review">
                   <Col align="center" xs={12}>
                     <EthHashInfo
                       hash={owner.address}

--- a/src/routes/safe/components/Settings/ManageOwners/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/index.tsx
@@ -121,16 +121,16 @@ const ManageOwners = ({ granted, owners }: Props): ReactElement => {
                   ))}
                   <TableCell component="td">
                     <Row align="end" className={classes.actions}>
-                      <ButtonHelper onClick={onShow('EditOwner', row)} data-testid={RENAME_OWNER_BTN_TEST_ID}>
+                      <ButtonHelper onClick={onShow('EditOwner', row)} dataTestId={RENAME_OWNER_BTN_TEST_ID}>
                         <Icon size="sm" type="edit" color="icon" tooltip="Edit owner" />
                       </ButtonHelper>
                       {granted && (
                         <>
-                          <ButtonHelper onClick={onShow('ReplaceOwner', row)} data-testid={REPLACE_OWNER_BTN_TEST_ID}>
+                          <ButtonHelper onClick={onShow('ReplaceOwner', row)} dataTestId={REPLACE_OWNER_BTN_TEST_ID}>
                             <Icon size="sm" type="replaceOwner" color="icon" tooltip="Replace owner" />
                           </ButtonHelper>
                           {ownerData.length > 1 && (
-                            <ButtonHelper onClick={onShow('RemoveOwner', row)} data-testid={REMOVE_OWNER_BTN_TEST_ID}>
+                            <ButtonHelper onClick={onShow('RemoveOwner', row)} dataTestId={REMOVE_OWNER_BTN_TEST_ID}>
                               <Icon size="sm" type="delete" color="error" tooltip="Remove owner" />
                             </ButtonHelper>
                           )}


### PR DESCRIPTION
## What it solves

Fixes https://github.com/gnosis/safe-react-e2e-tests/issues/8

## How this PR fixes it

Adds the data test ids needed to fix the add-remove-owner e2e tests

## How to test it

Use this PR to run the add-remove-owner e2e test
