### PR TITLE
Add a help link in Load Safe

### DIFF
--- a/src/routes/load/components/DetailsForm/index.tsx
+++ b/src/routes/load/components/DetailsForm/index.tsx
@@ -86,6 +86,17 @@ const DetailsForm = ({ errors, form }: DetailsFormProps): ReactElement => {
           Your connected wallet does not have to be the owner of this Safe. In this case, the interface will provide you
           a read-only view.
         </Paragraph>
+
+        <Paragraph color="primary" size="md" className={classes.links}>
+          Don&apos;t have the address of the Safe you created?{' '}
+          <a
+            href="https://help.gnosis-safe.io/en/articles/4971293-i-don-t-remember-my-safe-address-where-can-i-find-it"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            This article explains how to find it.
+          </a>
+        </Paragraph>
       </Block>
       <Block className={classes.root}>
         <Col xs={11}>


### PR DESCRIPTION
## What it solves
Resolves #2450.

## How this PR fixes it
Adds a paragraph with a help link.

## How to test it
- Go to Add existing safe
- Click on the help link

## Any extra information
<img width="847" alt="Screenshot 2021-06-17 at 13 31 00" src="https://user-images.githubusercontent.com/381895/122388870-964f5380-cf70-11eb-878a-a0c1cab97f9a.png">
