### PR TITLE
Add a margin for token icons

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/TokenSelectField/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/TokenSelectField/index.tsx
@@ -32,8 +32,8 @@ const SelectedToken = ({ assetAddress, assets }: SelectedTokenProps): React.Reac
     <MenuItem className={classes.container}>
       {asset && asset.numberOfTokens ? (
         <>
-          <ListItemIcon className={classes.tokenImage}>
-            <Img alt={asset.name} height={28} onError={setImageToPlaceholder} src={asset.image} />
+          <ListItemIcon>
+            <Img className={classes.tokenImage} alt={asset.name} onError={setImageToPlaceholder} src={asset.image} />
           </ListItemIcon>
           <ListItemText
             className={classes.tokenData}
@@ -59,6 +59,7 @@ type TokenSelectFieldProps = {
 
 const TokenSelectField = ({ assets, initialValue }: TokenSelectFieldProps): React.ReactElement => {
   const classes = useTokenSelectFieldStyles()
+  const tokenClasses = useSelectedTokenStyles()
   const assetsAddresses = Object.keys(assets)
 
   return (
@@ -76,8 +77,13 @@ const TokenSelectField = ({ assets, initialValue }: TokenSelectFieldProps): Reac
 
         return (
           <MenuItem key={asset.slug} value={assetAddress}>
-            <ListItemIcon className={classes.tokenImage}>
-              <Img alt={asset.name} height={28} onError={setImageToPlaceholder} src={asset.image} />
+            <ListItemIcon>
+              <Img
+                className={tokenClasses.tokenImage}
+                alt={asset.name}
+                onError={setImageToPlaceholder}
+                src={asset.image}
+              />
             </ListItemIcon>
             <ListItemText
               primary={asset.name}

--- a/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/TokenSelectField/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/TokenSelectField/style.ts
@@ -13,7 +13,10 @@ export const selectedTokenStyles = createStyles({
     lineHeight: '14px',
   },
   tokenImage: {
+    display: 'block',
     marginRight: sm,
+    height: 28,
+    width: 'auto',
   },
 })
 

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.tsx
@@ -28,8 +28,8 @@ const SelectedToken = ({ tokenAddress, tokens }: SelectTokenProps): ReactElement
     <MenuItem className={classes.container}>
       {token ? (
         <>
-          <ListItemIcon className={classes.tokenImage}>
-            <Img alt={token.name} height={28} onError={setImageToPlaceholder} src={token.logoUri} />
+          <ListItemIcon>
+            <Img className={classes.tokenImage} alt={token.name} onError={setImageToPlaceholder} src={token.logoUri} />
           </ListItemIcon>
           <ListItemText
             className={classes.tokenData}
@@ -54,6 +54,7 @@ interface TokenSelectFieldProps {
 
 const TokenSelectField = ({ initialValue, isValid = true, tokens }: TokenSelectFieldProps): ReactElement => {
   const classes = useSelectStyles()
+  const tokenClasses = useSelectedTokenStyles()
 
   return (
     <Field
@@ -69,7 +70,12 @@ const TokenSelectField = ({ initialValue, isValid = true, tokens }: TokenSelectF
       {tokens.map((token) => (
         <MenuItem key={token.address} value={token.address}>
           <ListItemIcon>
-            <Img alt={token.name} height={28} onError={setImageToPlaceholder} src={token.logoUri} />
+            <Img
+              className={tokenClasses.tokenImage}
+              alt={token.name}
+              onError={setImageToPlaceholder}
+              src={token.logoUri}
+            />
           </ListItemIcon>
           <ListItemText
             primary={token.name}

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/style.ts
@@ -15,7 +15,10 @@ export const useSelectedTokenStyles = makeStyles(
       lineHeight: '14px',
     },
     tokenImage: {
+      display: 'block',
       marginRight: sm,
+      height: 28,
+      width: 'auto',
     },
   }),
 )


### PR DESCRIPTION
## What it solves
Fixes #2267.

## How this PR fixes it
Adds a class name to the img.

## How to test it
- Send funds
- Open the token menu

## Any extra information
<img width="536" alt="Screenshot 2021-06-17 at 14 50 17" src="https://user-images.githubusercontent.com/381895/122399906-838e4c00-cf7b-11eb-9d02-fb247fe822d4.png">