### PR TITLE
(Bugfix)Spending Limit UI

### DIFF
--- a/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/index.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/index.tsx
@@ -46,7 +46,7 @@ export const LimitsTable = ({ data }: SpendingLimitTableProps): ReactElement => 
 
   return (
     <>
-      <TableContainer style={{ minHeight: '420px' }}>
+      <TableContainer style={{ minHeight: '440px' }}>
         <Table
           columns={columns}
           data={data}

--- a/src/routes/safe/components/Settings/SpendingLimit/style.ts
+++ b/src/routes/safe/components/Settings/SpendingLimit/style.ts
@@ -54,7 +54,6 @@ export const useStyles = makeStyles(
     },
     buttonRow: {
       padding: lg,
-      position: 'absolute',
       left: 0,
       bottom: 0,
       boxSizing: 'border-box',


### PR DESCRIPTION
## What it solves
Closes #2459
## How this PR fixes it
Increasing the min-height of the table, the pagination isn't overlapped by a line. 
## How to test it


## Any extra information
![image](https://user-images.githubusercontent.com/622217/122616485-d0981e00-d060-11eb-87bd-da6fdda749e9.png)
![image](https://user-images.githubusercontent.com/622217/122625624-9472b680-d07c-11eb-8226-b53328eb9c20.png)
