### PR TITLE
[L2] Add gweiFactor to gas price oracle

### DIFF
--- a/docs/networks.md
+++ b/docs/networks.md
@@ -200,6 +200,7 @@ const baseConfig: EnvironmentSettings = {
   gasPriceOracle: {
     url: '',
     gasParameter: '',
+    gweiFactor: '',
   },
   rpcServiceUrl: '',
   networkExplorerName: '',

--- a/src/config/networks/energy_web_chain.ts
+++ b/src/config/networks/energy_web_chain.ts
@@ -11,6 +11,7 @@ const baseConfig: EnvironmentSettings = {
   gasPriceOracle: {
     url: 'https://station.energyweb.org',
     gasParameter: 'standard',
+    gweiFactor: '1e9'
   },
   gasPrice: 1e6,
   rpcServiceUrl: 'https://rpc.energyweb.org',

--- a/src/config/networks/local.ts
+++ b/src/config/networks/local.ts
@@ -10,6 +10,7 @@ const baseConfig: EnvironmentSettings = {
   gasPriceOracle: {
     url: 'https://ethgasstation.info/json/ethgasAPI.json',
     gasParameter: 'average',
+    gweiFactor: '1e8'
   },
   rpcServiceUrl: 'http://localhost:4447',
   networkExplorerName: 'Etherscan',

--- a/src/config/networks/mainnet.ts
+++ b/src/config/networks/mainnet.ts
@@ -10,6 +10,7 @@ const baseConfig: EnvironmentSettings = {
   gasPriceOracle: {
     url: 'https://ethgasstation.info/json/ethgasAPI.json?api-key=${ETHGASSTATION_API_KEY}',
     gasParameter: 'average',
+    gweiFactor: '1e8'
   },
   rpcServiceUrl: 'https://mainnet.infura.io:443/v3',
   networkExplorerName: 'Etherscan',

--- a/src/config/networks/network.d.ts
+++ b/src/config/networks/network.d.ts
@@ -69,6 +69,9 @@ export type GasPriceOracle = {
   // Different gas api providers can use a different name to reflect different gas levels based on tx speed
   // For example in ethGasStation for ETHEREUM_MAINNET = safeLow | average | fast
   gasParameter: string
+  // Some providers may not use the most common standard, gwei to return the gas price value
+  // This is the case of Ethgasstation that returns price as gwei x 10.
+  gweiFactor: string
 }
 
 type GasPrice =

--- a/src/config/networks/rinkeby.ts
+++ b/src/config/networks/rinkeby.ts
@@ -10,6 +10,7 @@ const baseConfig: EnvironmentSettings = {
   gasPriceOracle: {
     url: `https://ethgasstation.info/json/ethgasAPI.json?api-key=${ETHGASSTATION_API_KEY}`,
     gasParameter: 'average',
+    gweiFactor: '1e8'
   },
   rpcServiceUrl: 'https://rinkeby.infura.io:443/v3',
   networkExplorerName: 'Etherscan',

--- a/src/config/networks/volta.ts
+++ b/src/config/networks/volta.ts
@@ -9,6 +9,7 @@ const baseConfig: EnvironmentSettings = {
   gasPriceOracle: {
     url: 'https://station.energyweb.org',
     gasParameter: 'standard',
+    gweiFactor: '1e9'
   },
   rpcServiceUrl: 'https://volta-rpc.energyweb.org',
   networkExplorerName: 'Volta explorer',

--- a/src/logic/wallets/ethTransactions.ts
+++ b/src/logic/wallets/ethTransactions.ts
@@ -14,12 +14,12 @@ export const calculateGasPrice = async (): Promise<string> => {
     // Fixed gas price in configuration. xDai uses this approach
     return new BigNumber(gasPrice).toString()
   } else if (gasPriceOracle) {
-    const { url, gasParameter } = gasPriceOracle
+    const { url, gasParameter, gweiFactor } = gasPriceOracle
 
     // Fetch from gas price provider
     const { data } = await axios.get(url)
 
-    return new BigNumber(data[gasParameter]).multipliedBy(1e8).toString()
+    return new BigNumber(data[gasParameter]).multipliedBy(gweiFactor).toString()
   } else {
     const errorMsg = 'gasPrice or gasPriceOracle not set in config'
     return Promise.reject(errorMsg)


### PR DESCRIPTION
## What it solves
Some gas price oracles are not using the most standard way to return the gas price (gwei), for example eth gas station is returning "gwei x 10"

## How this PR fixes it
We set `gweiFactor` as a config parameter in order to know the required unit to get the gas price value in `wei`

## How to test it
This is necessary to add compatibility to the gas provider from BSC that is setting the units in gwei and there for we are getting 10x lower gas price values.
To test in this PR just check that gas values still fit to mainnet ones. Once merged to BSC PR check that value for BSC is not returned as low gas price value
