### PR TITLE
Fix Apple Silicon (M1) compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
-    "electron": "^9.4.0",
+    "electron": "^11.0.0",
     "electron-builder": "22.10.5",
     "electron-notarize": "1.0.0",
     "eslint": "^7.26.0",


### PR DESCRIPTION
## What it solves
Resolves Apple Silicon (M1) incompatibility of Electron 9.x.x

## How this PR fixes it
Upgrade dependency to Electron 11.x.x
