### PR TITLE
🔥 Fix "Cannot read property'toLowerCase' of undefined" in autocomplete

### DIFF
--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -30,11 +30,9 @@ export const isValidAddressBookName = (addressBookName: string): boolean => {
  */
 export const filterContractAddressBookEntries = async (addressBook: AddressBookState): Promise<AddressBookEntry[]> => {
   const abFlags = await Promise.all(
-    addressBook.map(
-      async ({ address }: AddressBookEntry): Promise<boolean> => {
-        return (await mustBeEthereumContractAddress(address)) === undefined
-      },
-    ),
+    addressBook.map(async ({ address }: AddressBookEntry): Promise<boolean> => {
+      return (await mustBeEthereumContractAddress(address)) === undefined
+    }),
   )
 
   return addressBook.filter((_, index) => abFlags[index])

--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -52,9 +52,9 @@ export const filterAddressEntries = (
   { inputValue }: { inputValue: string },
 ): AddressBookEntry[] =>
   addressBookEntries.filter(({ address, name }) => {
-    const inputLowerCase = inputValue.toLowerCase()
-    const foundName = name.toLowerCase().includes(inputLowerCase)
-    const foundAddress = address?.toLowerCase().includes(inputLowerCase)
+    const inputLowerCase = (inputValue || '').toLowerCase()
+    const foundName = (name || '').toLowerCase().includes(inputLowerCase)
+    const foundAddress = (address || '').toLowerCase().includes(inputLowerCase)
 
     return foundName || foundAddress
   })

--- a/src/logic/addressBook/utils/v2-migration.ts
+++ b/src/logic/addressBook/utils/v2-migration.ts
@@ -106,7 +106,7 @@ const migrateAddressBook = ({ states, namespace, namespaceSeparator }: StorageCo
   const migratedAddressBook = (parsedAddressBook as Omit<AddressBookEntry, 'chainId'>[])
     // exclude those addresses with invalid names and addresses
     .filter((item) => {
-      return isValidAddressBookName(item.name) && getWeb3().utils.isAddress(item.address)
+      return item.name && isValidAddressBookName(item.name) && getWeb3().utils.isAddress(item.address)
     })
     .map(({ address, ...entry }) =>
       makeAddressBookEntry({


### PR DESCRIPTION
## What it solves
Resolves a customer support report.

> I'm trying to interact with a contract that had ownership transferred to a gnosis multisig safe. When going to new transaction -> contract interaction -> paste contract address, I get this error. Is this a known issue and if so, does it affect mainnet or only testnet?

> This is the contract address: 0xee589ec00c4320f24fcb2a49d1d5f8f256fbb0f5
This is the console output on chrome

![image](https://user-images.githubusercontent.com/381895/123261026-8a2a3f80-d4f6-11eb-8844-ee4c7cde6d71.png)

## How this PR fixes it
I don't know the root cause of the bug but it seems that some Address Book entries are created without a name property.
The Autocomplete code assumes there's aways a name and it's a string. I've added a fallback for it.

Update: the root cause might be that [we aren't checking if name exists](https://github.com/gnosis/safe-react/pull/2484/files#diff-3be536ee86eb7568410fb632994c257ce40d70d8b9c67f0c889b35c6fe2cbbd3L109) when migrating to the new AB format. Added a fix for that, too.

## How to test it
* Artificially delete the name property from one of the AB entries (by directly manipulating the AB localStorage value and refreshing the page).
* Paste the address of that entry in the Contract interaction form.
