### PR TITLE
Hide switch button when not MetaMask

### DIFF
--- a/src/components/AppLayout/Header/components/ProviderDetails/UserDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/UserDetails.tsx
@@ -99,7 +99,7 @@ type Props = {
   connected: boolean
   network: ETHEREUM_NETWORK
   onDisconnect: () => void
-  onNetworkChange: () => unknown
+  onNetworkChange?: () => unknown
   openDashboard?: (() => void | null) | boolean
   provider?: string
   userAddress: string
@@ -171,7 +171,7 @@ export const UserDetails = ({
           </Button>
         </Row>
       )}
-      {network !== desiredNetwork && (
+      {network !== desiredNetwork && onNetworkChange && (
         <Row className={classes.buttonRow}>
           <Button fullWidth onClick={onNetworkChange} size="medium" variant="outlined" color="primary">
             <Paragraph noMargin size="lg">

--- a/src/components/AppLayout/Header/index.tsx
+++ b/src/components/AppLayout/Header/index.tsx
@@ -14,7 +14,7 @@ import {
   userAccountSelector,
 } from 'src/logic/wallets/store/selectors'
 import { removeProvider } from 'src/logic/wallets/store/actions'
-import { switchNetwork } from 'src/logic/wallets/utils/network'
+import { canSwitchNetwork, switchNetwork } from 'src/logic/wallets/utils/network'
 import { getNetworkId } from 'src/config'
 import { onboard } from 'src/components/ConnectButton'
 import { loadLastUsedProvider } from 'src/logic/wallets/store/middlewares/providerWatcher'
@@ -26,6 +26,7 @@ const HeaderComponent = (): React.ReactElement => {
   const loaded = useSelector(loadedSelector)
   const available = useSelector(availableSelector)
   const dispatch = useDispatch()
+  const showSwitchButton = canSwitchNetwork()
 
   useEffect(() => {
     const tryToConnectToLastUsedProvider = async () => {
@@ -77,7 +78,7 @@ const HeaderComponent = (): React.ReactElement => {
         connected={available}
         network={network}
         onDisconnect={onDisconnect}
-        onNetworkChange={onNetworkChange}
+        onNetworkChange={showSwitchButton ? onNetworkChange : undefined}
         openDashboard={openDashboard()}
         provider={provider}
         userAddress={userAddress}

--- a/src/logic/wallets/__tests__/network.test.ts
+++ b/src/logic/wallets/__tests__/network.test.ts
@@ -1,5 +1,5 @@
 import { Wallet } from 'bnc-onboard/dist/src/interfaces'
-import { switchNetwork, shouldSwitchNetwork } from 'src/logic/wallets/utils/network'
+import { switchNetwork, shouldSwitchNetwork, canSwitchNetwork } from 'src/logic/wallets/utils/network'
 
 class CodedError extends Error {
   public code: number
@@ -99,6 +99,26 @@ describe('src/logic/wallets/utils/network', () => {
       }
 
       expect(shouldSwitchNetwork(wallet as Wallet)).toBe(false)
+    })
+  })
+
+  describe('canSwitchNetwork', () => {
+    it('should return true when swithcing is supported', () => {
+      const wallet = {
+        provider: {
+          isMetaMask: true,
+        },
+      }
+
+      expect(canSwitchNetwork(wallet as Wallet)).toBe(true)
+    })
+
+    it('should return false when swithcing is not supported', () => {
+      const wallet = {
+        provider: undefined,
+      }
+
+      expect(canSwitchNetwork(wallet as Wallet)).toBe(false)
     })
   })
 })

--- a/src/logic/wallets/utils/network.ts
+++ b/src/logic/wallets/utils/network.ts
@@ -83,3 +83,7 @@ export const shouldSwitchNetwork = (wallet = onboard.getState()?.wallet): boolea
   const currentNetwork = wallet?.provider?.networkVersion
   return currentNetwork ? desiredNetwork !== currentNetwork : false
 }
+
+export const canSwitchNetwork = (wallet = onboard.getState()?.wallet): boolean => {
+  return wallet?.provider?.isMetaMask || false
+}


### PR DESCRIPTION
## What it solves
An addendum to #2477. Resolves the [defect](https://github.com/gnosis/safe-react/pull/2477#issuecomment-868475392) found by @liliya-soroka.

When the wallet isn't MetaMask (and it's the only wallet we know to support chain switching), don't show the Switch Network button.

## How this PR fixes it
Checks if the wallet is MetaMask.

## How to test it
Connect with some other wallet, the button shouldn't be there.