### PR TITLE
Bug: No safe name displayed after creation

### DIFF
--- a/src/routes/opening/utils/getSafeAddressFromLogs.ts
+++ b/src/routes/opening/utils/getSafeAddressFromLogs.ts
@@ -17,7 +17,7 @@ export const getNewSafeAddressFromLogs = (logs: Log[]): string => {
   const proxyCreationEvent = abiDecoder.decodeLogs(logs).find(({ name }) => name === 'ProxyCreation')
 
   // We extract the proxy creation information from the event parameters
-  const proxyInformation = proxyCreationEvent.events.find(({ name }) => name === 'proxy')
+  const proxyInformation = proxyCreationEvent?.events?.find(({ name }) => name === 'proxy')
 
-  return checksumAddress(proxyInformation.value || '')
+  return checksumAddress(proxyInformation?.value || '')
 }

--- a/src/routes/opening/utils/getSafeAddressFromLogs.ts
+++ b/src/routes/opening/utils/getSafeAddressFromLogs.ts
@@ -1,6 +1,7 @@
 import abiDecoder from 'abi-decoder'
 import { getProxyFactoryDeployment } from '@gnosis.pm/safe-deployments'
 import { Log } from 'web3-core'
+import { checksumAddress } from 'src/utils/checksumAddress'
 
 import { LATEST_SAFE_VERSION } from 'src/utils/constants'
 
@@ -18,5 +19,5 @@ export const getNewSafeAddressFromLogs = (logs: Log[]): string => {
   // We extract the proxy creation information from the event parameters
   const proxyInformation = proxyCreationEvent.events.find(({ name }) => name === 'proxy')
 
-  return proxyInformation.value
+  return checksumAddress(proxyInformation.value || '')
 }


### PR DESCRIPTION
## What it solves
Resolves #2493 
`abi-decoder` package returns a lowercase address and it's used in the address-book entry: https://github.com/ConsenSys/abi-decoder/blob/a9ed4923433ad32069e2ea963d683ed2ff49fa07/index.js#L111.

## How this PR fixes it
By checksumming address returned from abi-decoder

## How to test it
Create a safe on this branch, it should have a name displayed right after creation

