### PR TITLE
Display the list of owned safes

### DIFF
--- a/src/components/Collapse/index.tsx
+++ b/src/components/Collapse/index.tsx
@@ -15,6 +15,10 @@ const HeaderWrapper = styled.div`
   padding: 15px 0 3px;
   cursor: pointer;
   user-select: none;
+
+  & > * {
+    margin-right: 5px;
+  }
 `
 
 const TitleWrapper = styled.div``

--- a/src/components/Collapse/index.tsx
+++ b/src/components/Collapse/index.tsx
@@ -5,9 +5,17 @@ import ExpandMore from '@material-ui/icons/ExpandMore'
 import React from 'react'
 import styled from 'styled-components'
 
-const Wrapper = styled.div``
+const Wrapper = styled.div`
+  width: 100%;
+`
 
-const HeaderWrapper = styled.div``
+const HeaderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 15px 0 3px;
+  cursor: pointer;
+  user-select: none;
+`
 
 const TitleWrapper = styled.div``
 
@@ -20,7 +28,6 @@ interface CollapseProps {
   title: React.ReactElement | string
   description?: React.ReactElement | string
   collapseClassName?: string
-  headerWrapperClassName?: string
 }
 
 const Collapse: React.FC<CollapseProps> = ({
@@ -28,7 +35,6 @@ const Collapse: React.FC<CollapseProps> = ({
   description = null,
   title,
   collapseClassName,
-  headerWrapperClassName,
 }): React.ReactElement => {
   const [open, setOpen] = React.useState(false)
 
@@ -38,7 +44,7 @@ const Collapse: React.FC<CollapseProps> = ({
 
   return (
     <Wrapper>
-      <HeaderWrapper className={headerWrapperClassName} onClick={handleClick}>
+      <HeaderWrapper onClick={handleClick}>
         <TitleWrapper>{title}</TitleWrapper>
         <Header>
           <IconButton disableRipple size="small">

--- a/src/components/Collapse/index.tsx
+++ b/src/components/Collapse/index.tsx
@@ -32,6 +32,7 @@ interface CollapseProps {
   title: React.ReactElement | string
   description?: React.ReactElement | string
   collapseClassName?: string
+  defaultExpanded?: boolean
 }
 
 const Collapse: React.FC<CollapseProps> = ({
@@ -39,8 +40,9 @@ const Collapse: React.FC<CollapseProps> = ({
   description = null,
   title,
   collapseClassName,
+  defaultExpanded = false,
 }): React.ReactElement => {
-  const [open, setOpen] = React.useState(false)
+  const [open, setOpen] = React.useState(defaultExpanded)
 
   const handleClick = () => {
     setOpen(!open)

--- a/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
@@ -1,30 +1,39 @@
 import React, { ReactElement } from 'react'
-import { makeStyles } from '@material-ui/core/styles'
-import { EthHashInfo } from '@gnosis.pm/safe-react-components'
+import styled from 'styled-components'
+import { EthHashInfo, Text } from '@gnosis.pm/safe-react-components'
+import Link from 'src/components/layout/Link'
+import { SAFELIST_ADDRESS, LOAD_ADDRESS } from 'src/routes/routes'
 
-const useStyles = makeStyles({
-  wrapper: {
-    width: '100%',
-    padding: '5px 0',
-    opacity: '0.3',
-    transition: 'opacity 200ms ease-in',
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 0;
+  margin-right: 28px;
+  border-bottom: 1px solid #e8e7e6;
 
-    '&:hover': {
-      opacity: '1',
-    },
-  },
-})
+  & > a:last-child {
+    text-decoration: underline;
+  }
+`
 
 type Props = {
   address: string
+  onClick: () => unknown
 }
 
-export const UnsavedAddress = ({ address }: Props): ReactElement => {
-  const classes = useStyles()
-
+export const UnsavedAddress = ({ address, onClick }: Props): ReactElement => {
   return (
-    <div className={classes.wrapper}>
-      <EthHashInfo hash={address} showAvatar shortenHash={12} />
-    </div>
+    <Wrapper>
+      <Link to={`${SAFELIST_ADDRESS}/${address}/balances`} onClick={onClick}>
+        <EthHashInfo hash={address} showAvatar shortenHash={8} />
+      </Link>
+
+      <Link to={`${LOAD_ADDRESS}/${address}`} onClick={onClick}>
+        <Text size="sm" color="primary">
+          Add Safe
+        </Text>
+      </Link>
+    </Wrapper>
   )
 }

--- a/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
@@ -1,0 +1,30 @@
+import React, { ReactElement } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import { EthHashInfo } from '@gnosis.pm/safe-react-components'
+
+const useStyles = makeStyles({
+  wrapper: {
+    width: '100%',
+    padding: '5px 0',
+    opacity: '0.3',
+    transition: 'opacity 200ms ease-in',
+
+    '&:hover': {
+      opacity: '1',
+    },
+  },
+})
+
+type Props = {
+  address: string
+}
+
+export const UnsavedAddress = ({ address }: Props): ReactElement => {
+  const classes = useStyles()
+
+  return (
+    <div className={classes.wrapper}>
+      <EthHashInfo hash={address} showAvatar shortenHash={12} />
+    </div>
+  )
+}

--- a/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
@@ -26,7 +26,7 @@ export const UnsavedAddress = ({ address, onClick }: Props): ReactElement => {
   return (
     <Wrapper>
       <Link to={`${SAFELIST_ADDRESS}/${address}/balances`} onClick={onClick}>
-        <EthHashInfo hash={address} showAvatar shortenHash={8} />
+        <EthHashInfo hash={address} showAvatar shortenHash={4} />
       </Link>
 
       <Link to={`${LOAD_ADDRESS}/${address}`} onClick={onClick}>

--- a/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
@@ -1,18 +1,23 @@
 import React, { ReactElement } from 'react'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { EthHashInfo, Text } from '@gnosis.pm/safe-react-components'
 import Link from 'src/components/layout/Link'
 import { SAFELIST_ADDRESS, LOAD_ADDRESS } from 'src/routes/routes'
+import { addressBookName } from 'src/logic/addressBook/store/selectors'
 
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
   padding: 5px 0;
   margin-right: 28px;
   border-bottom: 1px solid #e8e7e6;
 
-  & > a:last-child {
+  & > a:first-of-type {
+    flex: 1;
+  }
+
+  & > a:last-of-type {
     text-decoration: underline;
   }
 `
@@ -20,13 +25,18 @@ const Wrapper = styled.div`
 type Props = {
   address: string
   onClick: () => unknown
+  children: ReactElement
 }
 
-export const UnsavedAddress = ({ address, onClick }: Props): ReactElement => {
+export const UnsavedAddress = ({ address, onClick, children }: Props): ReactElement => {
+  const name = useSelector((state) => addressBookName(state, { address }))
+
   return (
     <Wrapper>
+      {children}
+
       <Link to={`${SAFELIST_ADDRESS}/${address}/balances`} onClick={onClick}>
-        <EthHashInfo hash={address} showAvatar shortenHash={4} />
+        <EthHashInfo hash={address} name={name} showAvatar shortenHash={4} />
       </Link>
 
       <Link to={`${LOAD_ADDRESS}/${address}`} onClick={onClick}>

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -60,6 +60,14 @@ export const SafeList = ({
   otherSafes,
 }: Props): React.ReactElement => {
   const classes = useStyles()
+  const ownedSafesExpanded = otherSafes.some((address) => address === currentSafeAddress)
+
+  const getLink = (address: string): React.ReactElement =>
+    sameAddress(currentSafeAddress, address) ? (
+      <StyledIcon type="check" size="md" color="primary" />
+    ) : (
+      <div className={classes.noIcon}>placeholder</div>
+    )
 
   return (
     <MuiList className={classes.list}>
@@ -71,12 +79,7 @@ export const SafeList = ({
             to={`${SAFELIST_ADDRESS}/${safe.address}/balances`}
           >
             <ListItem classes={{ root: classes.listItemRoot }}>
-              {sameAddress(currentSafeAddress, safe.address) ? (
-                <StyledIcon type="check" size="md" color="primary" />
-              ) : (
-                <div className={classes.noIcon}>placeholder</div>
-              )}
-
+              {getLink(safe.address)}
               <AddressWrapper safe={safe} defaultSafeAddress={defaultSafeAddress} />
             </ListItem>
           </Link>
@@ -88,9 +91,11 @@ export const SafeList = ({
         <ListItem classes={{ root: classes.listItemRoot }}>
           <div className={classes.noIcon}>placeholder</div>
 
-          <Collapse title="Owned Safes">
+          <Collapse title={`Owned Safes (${otherSafes.length})`} defaultExpanded={ownedSafesExpanded}>
             {otherSafes.map((address) => (
-              <UnsavedAddress address={address} key={address} onClick={onSafeClick} />
+              <UnsavedAddress address={address} key={address} onClick={onSafeClick}>
+                {getLink(address)}
+              </UnsavedAddress>
             ))}
           </Collapse>
         </ListItem>

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 import { DefaultSafe } from 'src/logic/safe/store/reducer/types/safe'
 import Hairline from 'src/components/layout/Hairline'
 import Link from 'src/components/layout/Link'
+import Collapse from 'src/components/Collapse'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { SAFELIST_ADDRESS } from 'src/routes/routes'
 import { AddressWrapper } from 'src/components/SafeListSidebar/SafeList/AddressWrapper'
@@ -51,38 +52,6 @@ type Props = {
   onSafeClick: () => void
 }
 
-type WrapperProps = {
-  address: string
-  onSafeClick: Props['onSafeClick']
-  currentAddress: Props['currentSafeAddress']
-  children: React.ReactNode
-}
-
-const ListItemWrapper = ({ address, currentAddress, onSafeClick, children }: WrapperProps) => {
-  const classes = useStyles()
-
-  return (
-    <>
-      <Link
-        data-testid={SIDEBAR_SAFELIST_ROW_TESTID}
-        onClick={onSafeClick}
-        to={`${SAFELIST_ADDRESS}/${address}/balances`}
-      >
-        <ListItem classes={{ root: classes.listItemRoot }}>
-          {sameAddress(currentAddress, address) ? (
-            <StyledIcon type="check" size="md" color="primary" />
-          ) : (
-            <div className={classes.noIcon}>placeholder</div>
-          )}
-
-          {children}
-        </ListItem>
-      </Link>
-      <Hairline />
-    </>
-  )
-}
-
 export const SafeList = ({
   currentSafeAddress,
   defaultSafeAddress,
@@ -95,21 +64,37 @@ export const SafeList = ({
   return (
     <MuiList className={classes.list}>
       {safes.map((safe) => (
-        <ListItemWrapper
-          address={safe.address}
-          currentAddress={currentSafeAddress}
-          onSafeClick={onSafeClick}
-          key={safe.address}
-        >
-          <AddressWrapper safe={safe} defaultSafeAddress={defaultSafeAddress} />
-        </ListItemWrapper>
+        <React.Fragment key={safe.address}>
+          <Link
+            data-testid={SIDEBAR_SAFELIST_ROW_TESTID}
+            onClick={onSafeClick}
+            to={`${SAFELIST_ADDRESS}/${safe.address}/balances`}
+          >
+            <ListItem classes={{ root: classes.listItemRoot }}>
+              {sameAddress(currentSafeAddress, safe.address) ? (
+                <StyledIcon type="check" size="md" color="primary" />
+              ) : (
+                <div className={classes.noIcon}>placeholder</div>
+              )}
+
+              <AddressWrapper safe={safe} defaultSafeAddress={defaultSafeAddress} />
+            </ListItem>
+          </Link>
+          <Hairline />
+        </React.Fragment>
       ))}
 
-      {otherSafes.map((address) => (
-        <ListItemWrapper address={address} currentAddress={currentSafeAddress} onSafeClick={onSafeClick} key={address}>
-          <UnsavedAddress address={address} />
-        </ListItemWrapper>
-      ))}
+      {otherSafes.length > 0 && (
+        <ListItem classes={{ root: classes.listItemRoot }}>
+          <div className={classes.noIcon}>placeholder</div>
+
+          <Collapse title="Owned Safes">
+            {otherSafes.map((address) => (
+              <UnsavedAddress address={address} key={address} onClick={onSafeClick} />
+            ))}
+          </Collapse>
+        </ListItem>
+      )}
     </MuiList>
   )
 }

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -11,6 +11,7 @@ import Link from 'src/components/layout/Link'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { SAFELIST_ADDRESS } from 'src/routes/routes'
 import { AddressWrapper } from 'src/components/SafeListSidebar/SafeList/AddressWrapper'
+import { UnsavedAddress } from 'src/components/SafeListSidebar/SafeList/UnsavedAddress'
 import { SafeRecordWithNames } from 'src/logic/safe/store/selectors'
 
 export const SIDEBAR_SAFELIST_ROW_TESTID = 'SIDEBAR_SAFELIST_ROW_TESTID'
@@ -46,32 +47,68 @@ type Props = {
   currentSafeAddress: string | undefined
   defaultSafeAddress: DefaultSafe
   safes: SafeRecordWithNames[]
+  otherSafes: string[]
   onSafeClick: () => void
 }
 
-export const SafeList = ({ currentSafeAddress, defaultSafeAddress, onSafeClick, safes }: Props): React.ReactElement => {
+type WrapperProps = {
+  address: string
+  onSafeClick: Props['onSafeClick']
+  currentAddress: Props['currentSafeAddress']
+  children: React.ReactNode
+}
+
+const ListItemWrapper = ({ address, currentAddress, onSafeClick, children }: WrapperProps) => {
+  const classes = useStyles()
+
+  return (
+    <>
+      <Link
+        data-testid={SIDEBAR_SAFELIST_ROW_TESTID}
+        onClick={onSafeClick}
+        to={`${SAFELIST_ADDRESS}/${address}/balances`}
+      >
+        <ListItem classes={{ root: classes.listItemRoot }}>
+          {sameAddress(currentAddress, address) ? (
+            <StyledIcon type="check" size="md" color="primary" />
+          ) : (
+            <div className={classes.noIcon}>placeholder</div>
+          )}
+
+          {children}
+        </ListItem>
+      </Link>
+      <Hairline />
+    </>
+  )
+}
+
+export const SafeList = ({
+  currentSafeAddress,
+  defaultSafeAddress,
+  onSafeClick,
+  safes,
+  otherSafes,
+}: Props): React.ReactElement => {
   const classes = useStyles()
 
   return (
     <MuiList className={classes.list}>
       {safes.map((safe) => (
-        <React.Fragment key={safe.address}>
-          <Link
-            data-testid={SIDEBAR_SAFELIST_ROW_TESTID}
-            onClick={onSafeClick}
-            to={`${SAFELIST_ADDRESS}/${safe.address}/balances`}
-          >
-            <ListItem classes={{ root: classes.listItemRoot }}>
-              {sameAddress(currentSafeAddress, safe.address) ? (
-                <StyledIcon type="check" size="md" color="primary" />
-              ) : (
-                <div className={classes.noIcon}>placeholder</div>
-              )}
-              <AddressWrapper safe={safe} defaultSafeAddress={defaultSafeAddress} />
-            </ListItem>
-          </Link>
-          <Hairline />
-        </React.Fragment>
+        <ListItemWrapper
+          address={safe.address}
+          currentAddress={currentSafeAddress}
+          onSafeClick={onSafeClick}
+          key={safe.address}
+        >
+          <AddressWrapper safe={safe} defaultSafeAddress={defaultSafeAddress} />
+        </ListItemWrapper>
+      ))}
+
+      {otherSafes.map((address) => (
+        <ListItemWrapper address={address} currentAddress={currentSafeAddress} onSafeClick={onSafeClick} key={address}>
+          <UnsavedAddress address={address} />
+        </ListItemWrapper>
       ))}
     </MuiList>
   )

--- a/src/components/SafeListSidebar/index.tsx
+++ b/src/components/SafeListSidebar/index.tsx
@@ -18,6 +18,7 @@ import { WELCOME_ADDRESS } from 'src/routes/routes'
 import { useAnalytics, SAFE_NAVIGATION_EVENT } from 'src/utils/googleAnalytics'
 
 import { safeAddressFromUrl, defaultSafe as defaultSafeSelector } from 'src/logic/safe/store/selectors'
+import useOwnerSafes from 'src/logic/safe/hooks/useOwnerSafes'
 
 export const SafeListSidebarContext = React.createContext({
   isOpen: false,
@@ -40,6 +41,7 @@ export const SafeListSidebar = ({ children }: Props): ReactElement => {
   const [isOpen, setIsOpen] = useState(false)
   const [filter, setFilter] = useState('')
   const safes = useSelector(sortedSafeListSelector).filter((safe) => !safe.loadedViaUrl)
+  const ownerSafes = useOwnerSafes()
   const defaultSafe = useSelector(defaultSafeSelector)
   const safeAddress = useSelector(safeAddressFromUrl)
 
@@ -75,6 +77,11 @@ export const SafeListSidebar = ({ children }: Props): ReactElement => {
   }
 
   const filteredSafes = useMemo(() => filterBy(filter, safes), [safes, filter])
+  const filteredOwnerSafes = useMemo(
+    () => ownerSafes.filter((address) => new RegExp(filter, 'i').test(address)),
+    [ownerSafes, filter],
+  )
+
   useEffect(() => {
     setTimeout(() => {
       setFilter('')
@@ -123,6 +130,7 @@ export const SafeListSidebar = ({ children }: Props): ReactElement => {
           defaultSafeAddress={defaultSafe}
           onSafeClick={toggleSidebar}
           safes={filteredSafes}
+          otherSafes={filteredOwnerSafes}
         />
       </Drawer>
       {children}

--- a/src/logic/addressBook/store/selectors/index.ts
+++ b/src/logic/addressBook/store/selectors/index.ts
@@ -42,6 +42,13 @@ export const addressBookAsMap = createSelector([addressBookState], (addressBook)
   return addressBookMap
 })
 
+const getNameByAddress = (addressBook, address: string, chainId: number): string => {
+  if (!isValidAddress(address)) {
+    return ''
+  }
+  return addressBook?.[chainId]?.[checksumAddress(address)]?.name || ''
+}
+
 type GetNameParams = Overwrite<Partial<AddressBookEntry>, { address: string }>
 
 export const addressBookEntryName = createSelector(
@@ -53,11 +60,20 @@ export const addressBookEntryName = createSelector(
     }),
   ],
   (addressBook, { address, chainId }) => {
-    if (isValidAddress(address)) {
-      return addressBook?.[chainId]?.[checksumAddress(address)]?.name ?? ADDRESS_BOOK_DEFAULT_NAME
-    }
+    return getNameByAddress(addressBook, address, chainId) || ADDRESS_BOOK_DEFAULT_NAME
+  },
+)
 
-    return ADDRESS_BOOK_DEFAULT_NAME
+export const addressBookName = createSelector(
+  [
+    addressBookAsMap,
+    (_, { address, chainId = networkId }: GetNameParams): { address: string; chainId: number } => ({
+      address,
+      chainId,
+    }),
+  ],
+  (addressBook, { address, chainId }) => {
+    return getNameByAddress(addressBook, address, chainId)
   },
 )
 

--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -20,6 +20,7 @@ enum ErrorCodes {
   _607 = '607: Error fetching available currencies',
   _608 = '608: No next page',
   _609 = '609: Failed to retrieve SpendingLimits module information',
+  _610 = '610: Error fetching safes by owner',
   _700 = '700: Failed to load a localStorage item',
   _701 = '701: Failed to save a localStorage item',
   _702 = '702: Failed to remove a localStorage item',

--- a/src/logic/safe/api/fetchSafesByOwner.ts
+++ b/src/logic/safe/api/fetchSafesByOwner.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+import { getTxServiceUrl } from 'src/config'
+
+export const fetchSafesByOwner = async (ownerAddress: string): Promise<string[]> => {
+  const url = `${getTxServiceUrl()}/owners/${ownerAddress}`
+  const res = await axios.get<{ safes: string[] }>(url)
+  return res.data.safes
+}

--- a/src/logic/safe/api/fetchSafesByOwner.ts
+++ b/src/logic/safe/api/fetchSafesByOwner.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { getTxServiceUrl } from 'src/config'
 
 export const fetchSafesByOwner = async (ownerAddress: string): Promise<string[]> => {
-  const url = `${getTxServiceUrl()}/owners/${ownerAddress}`
+  const url = `${getTxServiceUrl()}/owners/${ownerAddress}/safes`
   const res = await axios.get<{ safes: string[] }>(url)
   return res.data.safes
 }

--- a/src/logic/safe/hooks/useOwnerSafes.ts
+++ b/src/logic/safe/hooks/useOwnerSafes.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { sameAddress } from 'src/logic/wallets/ethAddresses'
+import { safesAsList } from 'src/logic/safe/store/selectors'
+import { userAccountSelector } from 'src/logic/wallets/store/selectors'
+import { fetchSafesByOwner } from 'src/logic/safe/api/fetchSafesByOwner'
+import { Errors, logError } from 'src/logic/exceptions/CodedException'
+import { IS_PRODUCTION } from 'src/utils/constants'
+
+const useOwnerSafes = (): string[] => {
+  const connectedWalletAddress = useSelector(userAccountSelector)
+  const savedSafes = useSelector(safesAsList)
+  const [ownerSafes, setOwnerSafes] = useState<string[]>([])
+  const [filteredSafes, setFilteredSafes] = useState<string[]>([])
+
+  useEffect(() => {
+    if (IS_PRODUCTION || !connectedWalletAddress) {
+      return
+    }
+
+    const load = async () => {
+      try {
+        const safes = await fetchSafesByOwner(connectedWalletAddress)
+        setOwnerSafes(safes)
+      } catch (err) {
+        logError(Errors._610, err.message)
+      }
+    }
+    load()
+  }, [connectedWalletAddress])
+
+  useMemo(() => {
+    const unsavedSafes = ownerSafes.filter((address) => !savedSafes.some((item) => sameAddress(address, item.address)))
+    setFilteredSafes(unsavedSafes)
+  }, [ownerSafes, savedSafes])
+
+  return filteredSafes
+}
+
+export default useOwnerSafes

--- a/src/logic/safe/hooks/useOwnerSafes.ts
+++ b/src/logic/safe/hooks/useOwnerSafes.ts
@@ -5,7 +5,6 @@ import { safesAsList } from 'src/logic/safe/store/selectors'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { fetchSafesByOwner } from 'src/logic/safe/api/fetchSafesByOwner'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
-import { IS_PRODUCTION } from 'src/utils/constants'
 
 const useOwnerSafes = (): string[] => {
   const connectedWalletAddress = useSelector(userAccountSelector)
@@ -14,7 +13,7 @@ const useOwnerSafes = (): string[] => {
   const [filteredSafes, setFilteredSafes] = useState<string[]>([])
 
   useEffect(() => {
-    if (IS_PRODUCTION || !connectedWalletAddress) {
+    if (!connectedWalletAddress) {
       return
     }
 

--- a/src/logic/safe/hooks/useOwnerSafes.ts
+++ b/src/logic/safe/hooks/useOwnerSafes.ts
@@ -13,6 +13,8 @@ const useOwnerSafes = (): string[] => {
   const [filteredSafes, setFilteredSafes] = useState<string[]>([])
 
   useEffect(() => {
+    setOwnerSafes([])
+
     if (!connectedWalletAddress) {
       return
     }

--- a/src/logic/safe/hooks/useOwnerSafes.ts
+++ b/src/logic/safe/hooks/useOwnerSafes.ts
@@ -29,7 +29,9 @@ const useOwnerSafes = (): string[] => {
   }, [connectedWalletAddress])
 
   useMemo(() => {
-    const unsavedSafes = ownerSafes.filter((address) => !savedSafes.some((item) => sameAddress(address, item.address)))
+    const unsavedSafes = ownerSafes.filter((address) => {
+      return !savedSafes.some((item) => sameAddress(address, item.address) && !item.loadedViaUrl)
+    })
     setFilteredSafes(unsavedSafes)
   }, [ownerSafes, savedSafes])
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -78,7 +78,7 @@ const Routes = (): React.ReactElement => {
       <Route component={Welcome} exact path={WELCOME_ADDRESS} />
       <Route component={Open} exact path={OPEN_ADDRESS} />
       <Route component={Safe} path={SAFE_ADDRESS} />
-      <Route component={Load} exact path={LOAD_ADDRESS} />
+      <Route component={Load} path={`${LOAD_ADDRESS}/:safeAddress?`} />
       <Redirect to="/" />
     </Switch>
   )

--- a/src/routes/load/components/DetailsForm/index.tsx
+++ b/src/routes/load/components/DetailsForm/index.tsx
@@ -4,6 +4,7 @@ import CheckCircle from '@material-ui/icons/CheckCircle'
 import React, { ReactElement, ReactNode } from 'react'
 import { FormApi } from 'final-form'
 import { useParams } from 'react-router'
+import { useSelector } from 'react-redux'
 
 import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
 import OpenPaper from 'src/components/Stepper/OpenPaper'
@@ -24,6 +25,7 @@ import Paragraph from 'src/components/layout/Paragraph'
 import { FIELD_LOAD_ADDRESS, FIELD_LOAD_NAME } from 'src/routes/load/components/fields'
 import { secondary } from 'src/theme/variables'
 import { getSafeInfo } from 'src/logic/safe/utils/safeInformation'
+import { addressBookName } from 'src/logic/addressBook/store/selectors'
 
 const useStyles = makeStyles({
   root: {
@@ -72,6 +74,7 @@ interface DetailsFormProps {
 const DetailsForm = ({ errors, form }: DetailsFormProps): ReactElement => {
   const classes = useStyles()
   const { safeAddress } = useParams<{ safeAddress?: string }>()
+  const safeName = useSelector((state) => (safeAddress ? addressBookName(state, { address: safeAddress }) : ''))
 
   const handleScan = (value: string, closeQrModal: () => void): void => {
     form.mutators.setValue(FIELD_LOAD_ADDRESS, value)
@@ -103,6 +106,7 @@ const DetailsForm = ({ errors, form }: DetailsFormProps): ReactElement => {
       <Block className={classes.root}>
         <Col xs={11}>
           <Field
+            defaultValue={safeName}
             component={TextField}
             name={FIELD_LOAD_NAME}
             placeholder="Name of the Safe*"

--- a/src/routes/load/components/DetailsForm/index.tsx
+++ b/src/routes/load/components/DetailsForm/index.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import CheckCircle from '@material-ui/icons/CheckCircle'
 import React, { ReactElement, ReactNode } from 'react'
 import { FormApi } from 'final-form'
+import { useParams } from 'react-router'
 
 import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
 import OpenPaper from 'src/components/Stepper/OpenPaper'
@@ -70,6 +71,7 @@ interface DetailsFormProps {
 
 const DetailsForm = ({ errors, form }: DetailsFormProps): ReactElement => {
   const classes = useStyles()
+  const { safeAddress } = useParams<{ safeAddress?: string }>()
 
   const handleScan = (value: string, closeQrModal: () => void): void => {
     form.mutators.setValue(FIELD_LOAD_ADDRESS, value)
@@ -114,6 +116,7 @@ const DetailsForm = ({ errors, form }: DetailsFormProps): ReactElement => {
       <Block className={classes.root} margin="lg">
         <Col xs={11}>
           <AddressInput
+            defaultValue={safeAddress}
             fieldMutator={(val) => {
               form.mutators.setValue(FIELD_LOAD_ADDRESS, val)
             }}

--- a/src/routes/load/container/Load.tsx
+++ b/src/routes/load/container/Load.tsx
@@ -17,6 +17,7 @@ import { checksumAddress } from 'src/utils/checksumAddress'
 import { isValidAddress } from 'src/utils/isValidAddress'
 import { providerNameSelector, userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { addOrUpdateSafe } from 'src/logic/safe/store/actions/addOrUpdateSafe'
+import { useParams } from 'react-router'
 
 export const loadSafe = async (safeAddress: string, addSafe: (safe: SafeRecordProps) => void): Promise<void> => {
   const safeProps = await buildSafe(safeAddress)
@@ -51,6 +52,7 @@ const Load = (): ReactElement => {
   const dispatch = useDispatch()
   const provider = useSelector(providerNameSelector)
   const userAddress = useSelector(userAccountSelector)
+  const { safeAddress } = useParams<{ safeAddress?: string }>()
 
   const addSafeHandler = async (safe: SafeRecordProps) => {
     await dispatch(addOrUpdateSafe(safe))
@@ -93,7 +95,7 @@ const Load = (): ReactElement => {
 
   return (
     <Page>
-      <Layout onLoadSafeSubmit={onLoadSafeSubmit} userAddress={userAddress} provider={provider} />
+      <Layout onLoadSafeSubmit={onLoadSafeSubmit} userAddress={userAddress} provider={provider} key={safeAddress} />
     </Page>
   )
 }


### PR DESCRIPTION
## What it solves
When testing the safe interface, oftentimes you clear the localStorage and lose all your safes.

Related to #510.

## How this PR fixes it
Your safes can be still retrieved via an endpoint, so I've made a little custom hook that fetches safes by their owner.

## How to test it
Connect your wallet and see your unsaved safes in the sidebar. Should not be visible on production.

## Screenshots
<img width="832" alt="Screenshot 2021-06-29 at 12 09 45" src="https://user-images.githubusercontent.com/381895/123779865-e6180e00-d8d2-11eb-9a21-87b5fd917ebb.png">

