### PR TITLE
Text ellipsis for sApp description

### DIFF
--- a/src/routes/safe/components/Apps/components/AppCard/index.tsx
+++ b/src/routes/safe/components/Apps/components/AppCard/index.tsx
@@ -42,8 +42,13 @@ const AppName = styled(Title)`
 `
 
 const AppDescription = styled(Text)`
-  height: 71px;
   text-align: center;
+  height: 72px;
+  line-height: 24px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 `
 
 export const setAppImageFallback = (error: SyntheticEvent<HTMLImageElement, Event>): void => {


### PR DESCRIPTION
## What it solves
Resolves #2478

## How this PR fixes it
By adding an ellipsis to the description. We show 3 lines (max) and add a ellipsis at the end.

## How to test it
1. Go to the admin panel -> safe apps
2. add a new app with a very long description

## Screenshots
![image](https://user-images.githubusercontent.com/622217/123987808-de716b80-d99d-11eb-827a-82dcdf90e29a.png)
