### PR TITLE
Add centralized routing source

### DIFF
--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, useRouteMatch } from 'react-router-dom'
 
@@ -43,128 +43,110 @@ const useSidebarItems = (): ListItemType[] => {
     path: `${SAFELIST_ADDRESS}/:safeAddress/:safeAction/:safeSubaction?`,
   }) as SafeRouteWithAction
 
+  const makeEntryItem = useCallback(
+    ({ label, disabled, badge, iconType, route, subItems }) => {
+      return {
+        label,
+        badge,
+        disabled,
+        icon: <ListIcon type={iconType} />,
+        selected: isSelected({ route, matchSafeWithAction }),
+        href: generatePath(route, { safeAddress }),
+        subItems,
+      }
+    },
+    [matchSafeWithAction, safeAddress],
+  )
+
   return useMemo((): ListItemType[] => {
     if (!matchSafe || !matchSafeWithAddress || !featuresEnabled) {
       return []
     }
 
-    const settingsItem = {
-      label: 'Settings',
-      icon: <ListIcon type="settings" />,
-      href: generatePath(SAFE_ROUTES.SETTINGS_DETAILS, {
-        safeAddress,
+    const assetsSubItems = [
+      makeEntryItem({
+        label: 'Coins',
+        iconType: 'assets',
+        route: SAFE_ROUTES.ASSETS_BALANCES,
       }),
-      subItems: [
-        {
-          label: 'Safe Details',
-          badge: needsUpdate && granted,
-          icon: <ListIcon type="info" />,
-          selected: isSelected({ route: SAFE_ROUTES.SETTINGS_DETAILS, matchSafeWithAction }),
-          href: generatePath(SAFE_ROUTES.SETTINGS_DETAILS, {
-            safeAddress,
-          }),
-        },
-        {
-          label: 'Owners',
-          icon: <ListIcon type="owners" />,
-          selected: isSelected({ route: SAFE_ROUTES.SETTINGS_OWNERS, matchSafeWithAction }),
-          href: generatePath(SAFE_ROUTES.SETTINGS_OWNERS, {
-            safeAddress,
-          }),
-        },
-        {
-          label: 'Policies',
-          icon: <ListIcon type="requiredConfirmations" />,
-          selected: isSelected({ route: SAFE_ROUTES.SETTINGS_POLICIES, matchSafeWithAction }),
-          href: generatePath(SAFE_ROUTES.SETTINGS_POLICIES, {
-            safeAddress,
-          }),
-        },
-        {
-          disabled: !isSpendingLimitEnabled,
-          label: 'Spending Limit',
-          icon: <ListIcon type="fuelIndicator" />,
-          selected: isSelected({ route: SAFE_ROUTES.SETTINGS_SPENDING_LIMIT, matchSafeWithAction }),
-          href: generatePath(SAFE_ROUTES.SETTINGS_SPENDING_LIMIT, {
-            safeAddress,
-          }),
-        },
-        {
-          label: 'Advanced',
-          icon: <ListIcon type="settingsTool" />,
-          selected: isSelected({ route: SAFE_ROUTES.SETTINGS_ADVANCED, matchSafeWithAction }),
-          href: generatePath(SAFE_ROUTES.SETTINGS_ADVANCED, {
-            safeAddress,
-          }),
-        },
-      ],
-    }
+      makeEntryItem({
+        disabled: !isCollectiblesEnabled,
+        label: 'Collectibles',
+        iconType: 'collectibles',
+        route: SAFE_ROUTES.ASSETS_COLLECTIBLES,
+      }),
+    ]
+
+    const settingsSubItems = [
+      makeEntryItem({
+        label: 'Safe Details',
+        badge: needsUpdate && granted,
+        iconType: 'info',
+        route: SAFE_ROUTES.SETTINGS_DETAILS,
+      }),
+      makeEntryItem({
+        label: 'Owners',
+        iconType: 'owners',
+        route: SAFE_ROUTES.SETTINGS_OWNERS,
+      }),
+      makeEntryItem({
+        label: 'Policies',
+        iconType: 'requiredConfirmations',
+        route: SAFE_ROUTES.SETTINGS_POLICIES,
+      }),
+      makeEntryItem({
+        disabled: !isSpendingLimitEnabled,
+        label: 'Spending Limit',
+        iconType: 'fuelIndicator',
+        route: SAFE_ROUTES.SETTINGS_SPENDING_LIMIT,
+      }),
+      makeEntryItem({
+        label: 'Advanced',
+        iconType: 'settingsTool',
+        route: SAFE_ROUTES.SETTINGS_ADVANCED,
+      }),
+    ]
 
     return [
-      {
+      makeEntryItem({
         label: 'ASSETS',
-        icon: <ListIcon type="assets" />,
-        href: generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-          safeAddress,
-        }),
-        subItems: [
-          {
-            label: 'Coins',
-            icon: <ListIcon type="assets" />,
-            selected: isSelected({ route: SAFE_ROUTES.ASSETS_BALANCES, matchSafeWithAction }),
-            href: generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-              safeAddress,
-            }),
-          },
-          {
-            disabled: !isCollectiblesEnabled,
-            label: 'Collectibles',
-            icon: <ListIcon type="collectibles" />,
-            selected: isSelected({ route: SAFE_ROUTES.ASSETS_COLLECTIBLES, matchSafeWithAction }),
-            href: generatePath(SAFE_ROUTES.ASSETS_COLLECTIBLES, {
-              safeAddress,
-            }),
-          },
-        ],
-      },
-      {
+        iconType: 'assets',
+        route: SAFE_ROUTES.ASSETS_BALANCES,
+        subItems: assetsSubItems,
+      }),
+      makeEntryItem({
         label: 'TRANSACTIONS',
-        icon: <ListIcon type="transactionsInactive" />,
-        selected: isSelected({ route: SAFE_ROUTES.TRANSACTIONS, matchSafeWithAction }),
-        href: generatePath(SAFE_ROUTES.TRANSACTIONS, {
-          safeAddress,
-        }),
-      },
-      {
+        iconType: 'transactionsInactive',
+        route: SAFE_ROUTES.TRANSACTIONS,
+      }),
+      makeEntryItem({
         label: 'ADDRESS BOOK',
-        icon: <ListIcon type="addressBook" />,
-        selected: isSelected({ route: SAFE_ROUTES.ADDRESS_BOOK, matchSafeWithAction }),
-        href: generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
-          safeAddress,
-        }),
-      },
-      {
-        label: 'Apps',
+        iconType: 'addressBook',
+        route: SAFE_ROUTES.ADDRESS_BOOK,
+      }),
+      makeEntryItem({
         disabled: !safeAppsEnabled,
-        icon: <ListIcon type="apps" />,
-        selected: isSelected({ route: SAFE_ROUTES.APPS, matchSafeWithAction }),
-        href: generatePath(SAFE_ROUTES.APPS, {
-          safeAddress,
-        }),
-      },
-      settingsItem,
+        label: 'Apps',
+        iconType: 'apps',
+        route: SAFE_ROUTES.APPS,
+      }),
+      makeEntryItem({
+        label: 'Settings',
+        iconType: 'settings',
+        route: SAFE_ROUTES.SETTINGS_DETAILS,
+        subItems: settingsSubItems,
+      }),
     ]
   }, [
-    safeAddress,
+    featuresEnabled,
     granted,
     isCollectiblesEnabled,
     isSpendingLimitEnabled,
+    makeEntryItem,
     matchSafe,
-    matchSafeWithAction,
     matchSafeWithAddress,
     needsUpdate,
     safeAppsEnabled,
-    featuresEnabled,
   ])
 }
 

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -1,21 +1,33 @@
 import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { useRouteMatch } from 'react-router-dom'
+import { generatePath, useRouteMatch } from 'react-router-dom'
 
 import { isFeatureEnabled } from 'src/config'
 import { ListItemType } from 'src/components/List'
 import ListIcon from 'src/components/List/ListIcon'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFELIST_ADDRESS, SAFE_ROUTES } from 'src/routes/routes'
 import { FEATURES } from 'src/config/networks/network.d'
 import { currentSafeFeaturesEnabled, currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
+
+type isSelectedProps = {
+  route: string
+  safeAction: string
+  safeSubaction?: string
+}
+
+const isSelected = ({ route, safeAction, safeSubaction }: isSelectedProps) => {
+  const [, , , action, subAction] = route.split('/')
+
+  return safeAction === action && (safeSubaction ? safeSubaction === subAction : true)
+}
 
 const useSidebarItems = (): ListItemType[] => {
   const featuresEnabled = useSelector(currentSafeFeaturesEnabled)
   const safeAppsEnabled = isFeatureEnabled(FEATURES.SAFE_APPS)
   const isCollectiblesEnabled = isFeatureEnabled(FEATURES.ERC721)
   const isSpendingLimitEnabled = isFeatureEnabled(FEATURES.SPENDING_LIMIT)
-  const { needsUpdate } = useSelector(currentSafeWithNames)
+  const { address, needsUpdate } = useSelector(currentSafeWithNames)
   const granted = useSelector(grantedSelector)
 
   const matchSafe = useRouteMatch({ path: `${SAFELIST_ADDRESS}`, strict: false })
@@ -37,40 +49,52 @@ const useSidebarItems = (): ListItemType[] => {
     const settingsItem = {
       label: 'Settings',
       icon: <ListIcon type="settings" />,
-      selected: safeAction === 'settings',
-      href: `${matchSafeWithAddress?.url}/settings/details`,
+      selected: isSelected({ route: SAFE_ROUTES.DETAILS, safeAction }),
+      href: generatePath(SAFE_ROUTES.DETAILS, {
+        address,
+      }),
       subItems: [
         {
           label: 'Safe Details',
           badge: needsUpdate && granted,
           icon: <ListIcon type="info" />,
-          selected: safeAction === 'settings' && safeSubaction === 'details',
-          href: `${matchSafeWithAddress?.url}/settings/details`,
+          selected: isSelected({ route: SAFE_ROUTES.DETAILS, safeAction, safeSubaction }),
+          href: generatePath(SAFE_ROUTES.DETAILS, {
+            address,
+          }),
         },
         {
           label: 'Owners',
           icon: <ListIcon type="owners" />,
-          selected: safeAction === 'settings' && safeSubaction === 'owners',
-          href: `${matchSafeWithAddress?.url}/settings/owners`,
+          selected: isSelected({ route: SAFE_ROUTES.OWNERS, safeAction, safeSubaction }),
+          href: generatePath(SAFE_ROUTES.OWNERS, {
+            address,
+          }),
         },
         {
           label: 'Policies',
           icon: <ListIcon type="requiredConfirmations" />,
-          selected: safeAction === 'settings' && safeSubaction === 'policies',
-          href: `${matchSafeWithAddress?.url}/settings/policies`,
+          selected: isSelected({ route: SAFE_ROUTES.POLICIES, safeAction, safeSubaction }),
+          href: generatePath(SAFE_ROUTES.POLICIES, {
+            address,
+          }),
         },
         {
           disabled: !isSpendingLimitEnabled,
           label: 'Spending Limit',
           icon: <ListIcon type="fuelIndicator" />,
-          selected: safeAction === 'settings' && safeSubaction === 'spending-limit',
-          href: `${matchSafeWithAddress?.url}/settings/spending-limit`,
+          selected: isSelected({ route: SAFE_ROUTES.SPENDING_LIMIT, safeAction, safeSubaction }),
+          href: generatePath(SAFE_ROUTES.SPENDING_LIMIT, {
+            address,
+          }),
         },
         {
           label: 'Advanced',
           icon: <ListIcon type="settingsTool" />,
-          selected: safeAction === 'settings' && safeSubaction === 'advanced',
-          href: `${matchSafeWithAddress?.url}/settings/advanced`,
+          selected: isSelected({ route: SAFE_ROUTES.ADVANCED, safeAction, safeSubaction }),
+          href: generatePath(SAFE_ROUTES.ADVANCED, {
+            address,
+          }),
         },
       ],
     }
@@ -119,6 +143,7 @@ const useSidebarItems = (): ListItemType[] => {
       settingsItem,
     ]
   }, [
+    address,
     granted,
     isCollectiblesEnabled,
     isSpendingLimitEnabled,

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -23,7 +23,7 @@ type IsSelectedProps = {
 const isSelected = ({ route, matchSafeWithAction }: IsSelectedProps): boolean => {
   const currentRoute = matchSafeWithAction.url
   const expectedRoute = generatePath(route, {
-    address: matchSafeWithAction.params.safeAddress,
+    safeAddress: matchSafeWithAction.params.safeAddress,
   })
 
   return currentRoute === expectedRoute

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -38,7 +38,6 @@ const useSidebarItems = (): ListItemType[] => {
   const granted = useSelector(grantedSelector)
 
   const matchSafe = useRouteMatch({ path: `${SAFELIST_ADDRESS}`, strict: false })
-  const matchSafeWithAddress = useRouteMatch<{ safeAddress: string }>({ path: `${SAFELIST_ADDRESS}/:safeAddress` })
   const matchSafeWithAction = useRouteMatch({
     path: `${SAFELIST_ADDRESS}/:safeAddress/:safeAction/:safeSubaction?`,
   }) as SafeRouteWithAction
@@ -59,7 +58,7 @@ const useSidebarItems = (): ListItemType[] => {
   )
 
   return useMemo((): ListItemType[] => {
-    if (!matchSafe || !matchSafeWithAddress || !featuresEnabled) {
+    if (!matchSafe || !matchSafeWithAction || !featuresEnabled) {
       return []
     }
 
@@ -144,7 +143,7 @@ const useSidebarItems = (): ListItemType[] => {
     isSpendingLimitEnabled,
     makeEntryItem,
     matchSafe,
-    matchSafeWithAddress,
+    matchSafeWithAction,
     needsUpdate,
     safeAppsEnabled,
   ])

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -34,7 +34,7 @@ const useSidebarItems = (): ListItemType[] => {
   const safeAppsEnabled = isFeatureEnabled(FEATURES.SAFE_APPS)
   const isCollectiblesEnabled = isFeatureEnabled(FEATURES.ERC721)
   const isSpendingLimitEnabled = isFeatureEnabled(FEATURES.SPENDING_LIMIT)
-  const { address, needsUpdate } = useSelector(currentSafeWithNames)
+  const { address: safeAddress, needsUpdate } = useSelector(currentSafeWithNames)
   const granted = useSelector(grantedSelector)
 
   const matchSafe = useRouteMatch({ path: `${SAFELIST_ADDRESS}`, strict: false })
@@ -52,7 +52,7 @@ const useSidebarItems = (): ListItemType[] => {
       label: 'Settings',
       icon: <ListIcon type="settings" />,
       href: generatePath(SAFE_ROUTES.SETTINGS_DETAILS, {
-        address,
+        safeAddress,
       }),
       subItems: [
         {
@@ -61,7 +61,7 @@ const useSidebarItems = (): ListItemType[] => {
           icon: <ListIcon type="info" />,
           selected: isSelected({ route: SAFE_ROUTES.SETTINGS_DETAILS, matchSafeWithAction }),
           href: generatePath(SAFE_ROUTES.SETTINGS_DETAILS, {
-            address,
+            safeAddress,
           }),
         },
         {
@@ -69,7 +69,7 @@ const useSidebarItems = (): ListItemType[] => {
           icon: <ListIcon type="owners" />,
           selected: isSelected({ route: SAFE_ROUTES.SETTINGS_OWNERS, matchSafeWithAction }),
           href: generatePath(SAFE_ROUTES.SETTINGS_OWNERS, {
-            address,
+            safeAddress,
           }),
         },
         {
@@ -77,7 +77,7 @@ const useSidebarItems = (): ListItemType[] => {
           icon: <ListIcon type="requiredConfirmations" />,
           selected: isSelected({ route: SAFE_ROUTES.SETTINGS_POLICIES, matchSafeWithAction }),
           href: generatePath(SAFE_ROUTES.SETTINGS_POLICIES, {
-            address,
+            safeAddress,
           }),
         },
         {
@@ -86,7 +86,7 @@ const useSidebarItems = (): ListItemType[] => {
           icon: <ListIcon type="fuelIndicator" />,
           selected: isSelected({ route: SAFE_ROUTES.SETTINGS_SPENDING_LIMIT, matchSafeWithAction }),
           href: generatePath(SAFE_ROUTES.SETTINGS_SPENDING_LIMIT, {
-            address,
+            safeAddress,
           }),
         },
         {
@@ -94,7 +94,7 @@ const useSidebarItems = (): ListItemType[] => {
           icon: <ListIcon type="settingsTool" />,
           selected: isSelected({ route: SAFE_ROUTES.SETTINGS_ADVANCED, matchSafeWithAction }),
           href: generatePath(SAFE_ROUTES.SETTINGS_ADVANCED, {
-            address,
+            safeAddress,
           }),
         },
       ],
@@ -105,7 +105,7 @@ const useSidebarItems = (): ListItemType[] => {
         label: 'ASSETS',
         icon: <ListIcon type="assets" />,
         href: generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-          address,
+          safeAddress,
         }),
         subItems: [
           {
@@ -113,7 +113,7 @@ const useSidebarItems = (): ListItemType[] => {
             icon: <ListIcon type="assets" />,
             selected: isSelected({ route: SAFE_ROUTES.ASSETS_BALANCES, matchSafeWithAction }),
             href: generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-              address,
+              safeAddress,
             }),
           },
           {
@@ -122,7 +122,7 @@ const useSidebarItems = (): ListItemType[] => {
             icon: <ListIcon type="collectibles" />,
             selected: isSelected({ route: SAFE_ROUTES.ASSETS_COLLECTIBLES, matchSafeWithAction }),
             href: generatePath(SAFE_ROUTES.ASSETS_COLLECTIBLES, {
-              address,
+              safeAddress,
             }),
           },
         ],
@@ -132,7 +132,7 @@ const useSidebarItems = (): ListItemType[] => {
         icon: <ListIcon type="transactionsInactive" />,
         selected: isSelected({ route: SAFE_ROUTES.TRANSACTIONS, matchSafeWithAction }),
         href: generatePath(SAFE_ROUTES.TRANSACTIONS, {
-          address,
+          safeAddress,
         }),
       },
       {
@@ -140,7 +140,7 @@ const useSidebarItems = (): ListItemType[] => {
         icon: <ListIcon type="addressBook" />,
         selected: isSelected({ route: SAFE_ROUTES.ADDRESS_BOOK, matchSafeWithAction }),
         href: generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
-          address,
+          safeAddress,
         }),
       },
       {
@@ -149,13 +149,13 @@ const useSidebarItems = (): ListItemType[] => {
         icon: <ListIcon type="apps" />,
         selected: isSelected({ route: SAFE_ROUTES.APPS, matchSafeWithAction }),
         href: generatePath(SAFE_ROUTES.APPS, {
-          address,
+          safeAddress,
         }),
       },
       settingsItem,
     ]
   }, [
-    address,
+    safeAddress,
     granted,
     isCollectiblesEnabled,
     isSpendingLimitEnabled,

--- a/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
@@ -39,7 +39,7 @@ export const UnsavedAddress = ({ address, onClick, children }: Props): ReactElem
 
       <Link
         to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-          address,
+          safeAddress: address,
         })}
         onClick={onClick}
       >

--- a/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/UnsavedAddress.tsx
@@ -1,9 +1,11 @@
 import React, { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
+import { generatePath } from 'react-router-dom'
 import styled from 'styled-components'
 import { EthHashInfo, Text } from '@gnosis.pm/safe-react-components'
+
 import Link from 'src/components/layout/Link'
-import { SAFELIST_ADDRESS, LOAD_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES, LOAD_ADDRESS } from 'src/routes/routes'
 import { addressBookName } from 'src/logic/addressBook/store/selectors'
 
 const Wrapper = styled.div`
@@ -35,7 +37,12 @@ export const UnsavedAddress = ({ address, onClick, children }: Props): ReactElem
     <Wrapper>
       {children}
 
-      <Link to={`${SAFELIST_ADDRESS}/${address}/balances`} onClick={onClick}>
+      <Link
+        to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+          address,
+        })}
+        onClick={onClick}
+      >
         <EthHashInfo hash={address} name={name} showAvatar shortenHash={4} />
       </Link>
 

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -2,7 +2,8 @@ import MuiList from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import { makeStyles } from '@material-ui/core/styles'
 import { Icon } from '@gnosis.pm/safe-react-components'
-import * as React from 'react'
+import React from 'react'
+import { generatePath } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { DefaultSafe } from 'src/logic/safe/store/reducer/types/safe'
@@ -10,7 +11,7 @@ import Hairline from 'src/components/layout/Hairline'
 import Link from 'src/components/layout/Link'
 import Collapse from 'src/components/Collapse'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import { AddressWrapper } from 'src/components/SafeListSidebar/SafeList/AddressWrapper'
 import { UnsavedAddress } from 'src/components/SafeListSidebar/SafeList/UnsavedAddress'
 import { SafeRecordWithNames } from 'src/logic/safe/store/selectors'
@@ -76,7 +77,9 @@ export const SafeList = ({
           <Link
             data-testid={SIDEBAR_SAFELIST_ROW_TESTID}
             onClick={onSafeClick}
-            to={`${SAFELIST_ADDRESS}/${safe.address}/balances`}
+            to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+              address: safe.address,
+            })}
           >
             <ListItem classes={{ root: classes.listItemRoot }}>
               {getLink(safe.address)}

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -78,7 +78,7 @@ export const SafeList = ({
             data-testid={SIDEBAR_SAFELIST_ROW_TESTID}
             onClick={onSafeClick}
             to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-              address: safe.address,
+              safeAddress: safe.address,
             })}
           >
             <ListItem classes={{ root: classes.listItemRoot }}>

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -80,7 +80,7 @@ export const createTransaction =
       dispatch(
         push(
           generatePath(SAFE_ROUTES.TRANSACTIONS, {
-            address: safeAddress,
+            safeAddress,
           }),
         ),
       )

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -1,4 +1,5 @@
 import { push } from 'connected-react-router'
+import { generatePath } from 'react-router-dom'
 import { AnyAction } from 'redux'
 import { ThunkAction } from 'redux-thunk'
 
@@ -18,7 +19,7 @@ import { currentSafeCurrentVersion } from 'src/logic/safe/store/selectors'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { providerSelector } from 'src/logic/wallets/store/selectors'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
 import closeSnackbarAction from 'src/logic/notifications/store/actions/closeSnackbar'
 import { generateSafeTxHash } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
@@ -76,7 +77,13 @@ export const createTransaction =
     const state = getState()
 
     if (navigateToTransactionsTab) {
-      dispatch(push(`${SAFELIST_ADDRESS}/${safeAddress}/transactions`))
+      dispatch(
+        push(
+          generatePath(SAFE_ROUTES.TRANSACTIONS, {
+            address: safeAddress,
+          }),
+        ),
+      )
     }
 
     const ready = await onboardUser()

--- a/src/logic/safe/store/middleware/notificationsMiddleware.ts
+++ b/src/logic/safe/store/middleware/notificationsMiddleware.ts
@@ -70,7 +70,7 @@ const onNotificationClicked = (dispatch, notificationKey, safeAddress) => () => 
   dispatch(
     push(
       generatePath(SAFE_ROUTES.TRANSACTIONS, {
-        address: safeAddress,
+        safeAddress,
       }),
     ),
   )

--- a/src/logic/safe/store/middleware/notificationsMiddleware.ts
+++ b/src/logic/safe/store/middleware/notificationsMiddleware.ts
@@ -1,4 +1,5 @@
 import { push } from 'connected-react-router'
+import { generatePath } from 'react-router-dom'
 import { Action } from 'redux-actions'
 
 import { NOTIFICATIONS, enhanceSnackbarForAction } from 'src/logic/notifications'
@@ -20,6 +21,7 @@ import { safeAddressFromUrl, safesAsMap } from 'src/logic/safe/store/selectors'
 import { isTransactionSummary, TransactionGatewayResult } from 'src/logic/safe/store/models/types/gateway.d'
 import { loadFromStorage, saveToStorage } from 'src/utils/storage'
 import { ADD_OR_UPDATE_SAFE } from '../actions/addOrUpdateSafe'
+import { SAFE_ROUTES } from 'src/routes/routes'
 
 const watchedActions = [ADD_OR_UPDATE_SAFE, ADD_QUEUED_TRANSACTIONS, ADD_HISTORY_TRANSACTIONS]
 
@@ -65,7 +67,13 @@ const sendAwaitingTransactionNotification = async (
 
 const onNotificationClicked = (dispatch, notificationKey, safeAddress) => () => {
   dispatch(closeSnackbarAction({ key: notificationKey }))
-  dispatch(push(`/safes/${safeAddress}/transactions`))
+  dispatch(
+    push(
+      generatePath(SAFE_ROUTES.TRANSACTIONS, {
+        address: safeAddress,
+      }),
+    ),
+  )
 }
 
 const notificationsMiddleware = (store) => (next) => async (action) => {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { Loader } from '@gnosis.pm/safe-react-components'
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
@@ -9,20 +10,16 @@ import {
   SAFE_PARAM_ADDRESS,
   SAFE_ROUTES,
   WELCOME_ADDRESS,
-} from './routes'
+} from 'src/routes/routes'
 
-import { Loader } from '@gnosis.pm/safe-react-components'
-import { defaultSafe as defaultSafeSelector } from 'src/logic/safe/store/selectors'
-import { useAnalytics } from 'src/utils/googleAnalytics'
-import { DEFAULT_SAFE_INITIAL_STATE } from 'src/logic/safe/store/reducer/safe'
 import { LoadingContainer } from 'src/components/LoaderContainer'
+import { defaultSafe as defaultSafeSelector } from 'src/logic/safe/store/selectors'
+import { DEFAULT_SAFE_INITIAL_STATE } from 'src/logic/safe/store/reducer/safe'
+import { useAnalytics } from 'src/utils/googleAnalytics'
 
 const Welcome = React.lazy(() => import('./welcome/container'))
-
 const Open = React.lazy(() => import('./open/container/Open'))
-
 const Safe = React.lazy(() => import('./safe/container'))
-
 const Load = React.lazy(() => import('./load/container/Load'))
 
 const SAFE_ADDRESS = `${SAFELIST_ADDRESS}/:${SAFE_PARAM_ADDRESS}`

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -76,7 +76,7 @@ const Routes = (): React.ReactElement => {
             return (
               <Redirect
                 to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-                  address: defaultSafe,
+                  safeAddress: defaultSafe,
                 })}
               />
             )

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,15 @@
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
-import { Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
+import { generatePath, Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
 
-import { LOAD_ADDRESS, OPEN_ADDRESS, SAFELIST_ADDRESS, SAFE_PARAM_ADDRESS, WELCOME_ADDRESS } from './routes'
+import {
+  LOAD_ADDRESS,
+  OPEN_ADDRESS,
+  SAFELIST_ADDRESS,
+  SAFE_PARAM_ADDRESS,
+  SAFE_ROUTES,
+  WELCOME_ADDRESS,
+} from './routes'
 
 import { Loader } from '@gnosis.pm/safe-react-components'
 import { defaultSafe as defaultSafeSelector } from 'src/logic/safe/store/selectors'
@@ -69,7 +76,13 @@ const Routes = (): React.ReactElement => {
           }
 
           if (defaultSafe) {
-            return <Redirect to={`${SAFELIST_ADDRESS}/${defaultSafe}/balances`} />
+            return (
+              <Redirect
+                to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+                  address: defaultSafe,
+                })}
+              />
+            )
           }
 
           return <Redirect to={WELCOME_ADDRESS} />

--- a/src/routes/load/container/Load.tsx
+++ b/src/routes/load/container/Load.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { generatePath, useParams } from 'react-router-dom'
 
 import Layout from 'src/routes/load/components/Layout'
 import { AddressBookEntry, makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
@@ -9,7 +10,7 @@ import { FIELD_LOAD_ADDRESS } from 'src/routes/load/components/fields'
 import Page from 'src/components/layout/Page'
 import { saveSafes, loadStoredSafes } from 'src/logic/safe/utils'
 import { getAccountsFrom, getNamesFrom } from 'src/routes/open/utils/safeDataExtractor'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import { buildSafe } from 'src/logic/safe/store/actions/fetchSafe'
 import { history } from 'src/store'
 import { SafeRecordProps } from 'src/logic/safe/store/models/safe'
@@ -17,7 +18,6 @@ import { checksumAddress } from 'src/utils/checksumAddress'
 import { isValidAddress } from 'src/utils/isValidAddress'
 import { providerNameSelector, userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { addOrUpdateSafe } from 'src/logic/safe/store/actions/addOrUpdateSafe'
-import { useParams } from 'react-router'
 
 export const loadSafe = async (safeAddress: string, addSafe: (safe: SafeRecordProps) => void): Promise<void> => {
   const safeProps = await buildSafe(safeAddress)
@@ -86,8 +86,11 @@ const Load = (): ReactElement => {
       safeAddress = checksumAddress(safeAddress)
       await loadSafe(safeAddress, addSafeHandler)
 
-      const url = `${SAFELIST_ADDRESS}/${safeAddress}/balances`
-      history.push(url)
+      history.push(
+        generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+          address: safeAddress,
+        }),
+      )
     } catch (error) {
       console.error('Error while loading the Safe', error)
     }

--- a/src/routes/load/container/Load.tsx
+++ b/src/routes/load/container/Load.tsx
@@ -88,7 +88,7 @@ const Load = (): ReactElement => {
 
       history.push(
         generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-          address: safeAddress,
+          safeAddress,
         }),
       )
     } catch (error) {

--- a/src/routes/open/container/Open.tsx
+++ b/src/routes/open/container/Open.tsx
@@ -210,7 +210,7 @@ const Open = (): ReactElement => {
     await removeFromStorage(SAFE_PENDING_CREATION_STORAGE_KEY)
     const url = {
       pathname: generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-        address: safeProps.address,
+        safeAddress: safeProps.address,
       }),
       state: {
         name,

--- a/src/routes/open/container/Open.tsx
+++ b/src/routes/open/container/Open.tsx
@@ -3,7 +3,7 @@ import { backOff } from 'exponential-backoff'
 import queryString from 'query-string'
 import React, { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useLocation } from 'react-router-dom'
+import { generatePath, useLocation } from 'react-router-dom'
 import { TransactionReceipt } from 'web3-core'
 
 import { SafeDeployment } from 'src/routes/opening'
@@ -19,7 +19,7 @@ import {
   getSafeNameFrom,
   getThresholdFrom,
 } from 'src/routes/open/utils/safeDataExtractor'
-import { SAFELIST_ADDRESS, WELCOME_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES, WELCOME_ADDRESS } from 'src/routes/routes'
 import { buildSafe } from 'src/logic/safe/store/actions/fetchSafe'
 import { history } from 'src/store'
 import { loadFromStorage, removeFromStorage, saveToStorage } from 'src/utils/storage'
@@ -209,7 +209,9 @@ const Open = (): ReactElement => {
 
     await removeFromStorage(SAFE_PENDING_CREATION_STORAGE_KEY)
     const url = {
-      pathname: `${SAFELIST_ADDRESS}/${safeProps.address}/balances`,
+      pathname: generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+        address: safeProps.address,
+      }),
       state: {
         name,
         tx: pendingCreation?.txHash,

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -3,3 +3,11 @@ export const SAFELIST_ADDRESS = '/safes'
 export const OPEN_ADDRESS = '/open'
 export const LOAD_ADDRESS = '/load'
 export const WELCOME_ADDRESS = '/welcome'
+
+export enum SAFE_ROUTES {
+  DETAILS = `/safes/:address/settings/details`,
+  OWNERS = `/safes/:address/settings/owners`,
+  POLICIES = `/safes/:address/settings/policies`,
+  SPENDING_LIMIT = `/safes/:address/settings/spending-limit`,
+  ADVANCED = `/safes/:address/settings/advanced`,
+}

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5,11 +5,13 @@ export const LOAD_ADDRESS = '/load'
 export const WELCOME_ADDRESS = '/welcome'
 
 export enum SAFE_ROUTES {
+  ASSETS_BASE_ROUTE = '/safes/:address/balances',
   ASSETS_BALANCES = '/safes/:address/balances',
   ASSETS_COLLECTIBLES = '/safes/:address/balances/collectibles',
   TRANSACTIONS = '/safes/:address/transactions',
   ADDRESS_BOOK = '/safes/:address/address-book',
   APPS = '/safes/:address/apps',
+  SETTINGS_BASE_ROUTE = '/safes/:address/settings',
   SETTINGS_DETAILS = '/safes/:address/settings/details',
   SETTINGS_OWNERS = '/safes/:address/settings/owners',
   SETTINGS_POLICIES = '/safes/:address/settings/policies',

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5,9 +5,14 @@ export const LOAD_ADDRESS = '/load'
 export const WELCOME_ADDRESS = '/welcome'
 
 export enum SAFE_ROUTES {
-  DETAILS = `/safes/:address/settings/details`,
-  OWNERS = `/safes/:address/settings/owners`,
-  POLICIES = `/safes/:address/settings/policies`,
-  SPENDING_LIMIT = `/safes/:address/settings/spending-limit`,
-  ADVANCED = `/safes/:address/settings/advanced`,
+  ASSETS_BALANCES = '/safes/:address/balances',
+  ASSETS_COLLECTIBLES = '/safes/:address/balances/collectibles',
+  TRANSACTIONS = '/safes/:address/transactions',
+  ADDRESS_BOOK = '/safes/:address/address-book',
+  APPS = '/safes/:address/apps',
+  SETTINGS_DETAILS = '/safes/:address/settings/details',
+  SETTINGS_OWNERS = '/safes/:address/settings/owners',
+  SETTINGS_POLICIES = '/safes/:address/settings/policies',
+  SETTINGS_SPENDING_LIMIT = '/safes/:address/settings/spending-limit',
+  SETTINGS_ADVANCED = '/safes/:address/settings/advanced',
 }

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5,16 +5,16 @@ export const LOAD_ADDRESS = '/load'
 export const WELCOME_ADDRESS = '/welcome'
 
 export enum SAFE_ROUTES {
-  ASSETS_BASE_ROUTE = '/safes/:address/balances',
-  ASSETS_BALANCES = '/safes/:address/balances',
-  ASSETS_COLLECTIBLES = '/safes/:address/balances/collectibles',
-  TRANSACTIONS = '/safes/:address/transactions',
-  ADDRESS_BOOK = '/safes/:address/address-book',
-  APPS = '/safes/:address/apps',
-  SETTINGS_BASE_ROUTE = '/safes/:address/settings',
-  SETTINGS_DETAILS = '/safes/:address/settings/details',
-  SETTINGS_OWNERS = '/safes/:address/settings/owners',
-  SETTINGS_POLICIES = '/safes/:address/settings/policies',
-  SETTINGS_SPENDING_LIMIT = '/safes/:address/settings/spending-limit',
-  SETTINGS_ADVANCED = '/safes/:address/settings/advanced',
+  ASSETS_BASE_ROUTE = '/safes/:safeAddress/balances',
+  ASSETS_BALANCES = '/safes/:safeAddress/balances',
+  ASSETS_COLLECTIBLES = '/safes/:safeAddress/balances/collectibles',
+  TRANSACTIONS = '/safes/:safeAddress/transactions',
+  ADDRESS_BOOK = '/safes/:safeAddress/address-book',
+  APPS = '/safes/:safeAddress/apps',
+  SETTINGS_BASE_ROUTE = '/safes/:safeAddress/settings',
+  SETTINGS_DETAILS = '/safes/:safeAddress/settings/details',
+  SETTINGS_OWNERS = '/safes/:safeAddress/settings/owners',
+  SETTINGS_POLICIES = '/safes/:safeAddress/settings/policies',
+  SETTINGS_SPENDING_LIMIT = '/safes/:safeAddress/settings/spending-limit',
+  SETTINGS_ADVANCED = '/safes/:safeAddress/settings/advanced',
 }

--- a/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
+++ b/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
@@ -6,11 +6,12 @@ import MoreHorizIcon from '@material-ui/icons/MoreHoriz'
 import { push } from 'connected-react-router'
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { generatePath } from 'react-router-dom'
 
 import { sameString } from 'src/utils/strings'
 import { ADDRESS_BOOK_DEFAULT_NAME } from 'src/logic/addressBook/model/addressBook'
 import { addressBookEntryName } from 'src/logic/addressBook/store/selectors'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import { safeAddressFromUrl } from 'src/logic/safe/store/selectors'
 import { xs } from 'src/theme/variables'
 import { grantedSelector } from 'src/routes/safe/container/selector'
@@ -61,7 +62,13 @@ export const EllipsisTransactionDetails = ({
   const closeMenuHandler = () => setAnchorEl(null)
 
   const addOrEditEntryHandler = () => {
-    dispatch(push(`${SAFELIST_ADDRESS}/${currentSafeAddress}/address-book?entryAddress=${address}`))
+    dispatch(
+      push(
+        generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
+          address: currentSafeAddress,
+        }),
+      ),
+    )
     closeMenuHandler()
   }
 

--- a/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
+++ b/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
@@ -62,13 +62,11 @@ export const EllipsisTransactionDetails = ({
   const closeMenuHandler = () => setAnchorEl(null)
 
   const addOrEditEntryHandler = () => {
-    dispatch(
-      push(
-        generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
-          safeAddress: currentSafeAddress,
-        }),
-      ),
-    )
+    const addressBookPath = generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
+      safeAddress: currentSafeAddress,
+    })
+
+    dispatch(push(`${addressBookPath}?entryAddress=${address}`))
     closeMenuHandler()
   }
 

--- a/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
+++ b/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
@@ -65,7 +65,7 @@ export const EllipsisTransactionDetails = ({
     dispatch(
       push(
         generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
-          address: currentSafeAddress,
+          safeAddress: currentSafeAddress,
         }),
       ),
     )

--- a/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
@@ -82,7 +82,7 @@ interface AddAppProps {
 const AddApp = ({ appList, closeModal }: AddAppProps): ReactElement => {
   const safeAddress = useSelector(safeAddressFromUrl)
   const appsPath = generatePath(SAFE_ROUTES.APPS, {
-    address: safeAddress,
+    safeAddress,
   })
   const [appInfo, setAppInfo] = useState<SafeApp>(DEFAULT_APP_INFO)
   const [fetchError, setFetchError] = useState<string | undefined>()

--- a/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
@@ -1,5 +1,7 @@
 import { Icon, Link, Loader, Text, TextField } from '@gnosis.pm/safe-react-components'
 import React, { useState, ReactElement, useCallback, useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import { generatePath, useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { SafeApp, StoredSafeApp } from 'src/routes/safe/components/Apps/types'
@@ -12,9 +14,9 @@ import AppUrl, { AppInfoUpdater, appUrlResolver } from './AppUrl'
 import { FormButtons } from './FormButtons'
 import { APPS_STORAGE_KEY, getEmptySafeApp } from 'src/routes/safe/components/Apps/utils'
 import { loadFromStorage, saveToStorage } from 'src/utils/storage'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
-import { useHistory, useRouteMatch } from 'react-router-dom'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
+import { safeAddressFromUrl } from 'src/logic/safe/store/selectors'
 
 const FORM_ID = 'add-apps-form'
 
@@ -78,10 +80,13 @@ interface AddAppProps {
 }
 
 const AddApp = ({ appList, closeModal }: AddAppProps): ReactElement => {
+  const safeAddress = useSelector(safeAddressFromUrl)
+  const appsPath = generatePath(SAFE_ROUTES.APPS, {
+    address: safeAddress,
+  })
   const [appInfo, setAppInfo] = useState<SafeApp>(DEFAULT_APP_INFO)
   const [fetchError, setFetchError] = useState<string | undefined>()
   const history = useHistory()
-  const matchSafeWithAddress = useRouteMatch<{ safeAddress: string }>({ path: `${SAFELIST_ADDRESS}/:safeAddress` })
   const [isLoading, setIsLoading] = useState(false)
 
   const handleSubmit = useCallback(async () => {
@@ -92,9 +97,9 @@ const AddApp = ({ appList, closeModal }: AddAppProps): ReactElement => {
       ...persistedAppList.map(({ url, disabled }) => ({ url, disabled })),
     ]
     saveToStorage(APPS_STORAGE_KEY, newAppList)
-    const goToApp = `${matchSafeWithAddress?.url}/apps?appUrl=${encodeURI(appInfo.url)}`
+    const goToApp = `${appsPath}?appUrl=${encodeURI(appInfo.url)}`
     history.push(goToApp)
-  }, [appInfo.url, history, matchSafeWithAddress?.url])
+  }, [appInfo.url, history, appsPath])
 
   useEffect(() => {
     if (isLoading) {

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -2,14 +2,14 @@ import React, { ReactElement, useState, useRef, useCallback, useEffect } from 'r
 import styled from 'styled-components'
 import { FixedIcon, Loader, Title, Card } from '@gnosis.pm/safe-react-components'
 import { GetBalanceParams, GetTxBySafeTxHashParams, MethodToResponse, RPCPayload } from '@gnosis.pm/safe-apps-sdk'
-import { useHistory } from 'react-router-dom'
+import { generatePath, useHistory } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { INTERFACE_MESSAGES, Transaction, RequestId, LowercaseNetworks } from '@gnosis.pm/safe-apps-sdk-v1'
 
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import { getNetworkId, getNetworkName, getTxServiceUrl } from 'src/config'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import { isSameURL } from 'src/utils/url'
 import { useAnalytics, SAFE_NAVIGATION_EVENT } from 'src/utils/googleAnalytics'
 import { LoadingContainer } from 'src/components/LoaderContainer/index'
@@ -94,7 +94,12 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
   const [appIsLoading, setAppIsLoading] = useState<boolean>(true)
   const [safeApp, setSafeApp] = useState<SafeApp | undefined>()
 
-  const redirectToBalance = () => history.push(`${SAFELIST_ADDRESS}/${safeAddress}/balances`)
+  const redirectToBalance = () =>
+    history.push(
+      generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+        address: safeAddress,
+      }),
+    )
   const timer = useRef<number>()
   const [appTimeout, setAppTimeout] = useState(false)
 

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -97,7 +97,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
   const redirectToBalance = () =>
     history.push(
       generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-        address: safeAddress,
+        safeAddress,
       }),
     )
   const timer = useRef<number>()

--- a/src/routes/safe/components/Apps/components/AppsList.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.tsx
@@ -1,15 +1,15 @@
-import React, { useState } from 'react'
-import styled, { css } from 'styled-components'
-import { useSelector } from 'react-redux'
 import { IconText, Loader, Menu, Text, Icon } from '@gnosis.pm/safe-react-components'
 import IconButton from '@material-ui/core/IconButton'
+import React, { useState } from 'react'
+import { useSelector } from 'react-redux'
+import { Link, generatePath } from 'react-router-dom'
+import styled, { css } from 'styled-components'
 
 import { Modal } from 'src/components/Modal'
 import { safeAddressFromUrl } from 'src/logic/safe/store/selectors'
 import AppCard from 'src/routes/safe/components/Apps/components/AppCard'
 import AddAppIcon from 'src/routes/safe/components/Apps/assets/addApp.svg'
-import { useRouteMatch, Link } from 'react-router-dom'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 
 import { useAppList } from '../hooks/useAppList'
 import { SAFE_APP_FETCH_STATUS, SafeApp } from '../types'
@@ -85,8 +85,10 @@ const isCustomApp = (appUrl: string, appsList: SafeApp[]) => {
 }
 
 const AppsList = (): React.ReactElement => {
-  const matchSafeWithAddress = useRouteMatch<{ safeAddress: string }>({ path: `${SAFELIST_ADDRESS}/:safeAddress` })
   const safeAddress = useSelector(safeAddressFromUrl)
+  const appsPath = generatePath(SAFE_ROUTES.APPS, {
+    address: safeAddress,
+  })
   const { appList, removeApp, isLoading } = useAppList()
   const [isAddAppModalOpen, setIsAddAppModalOpen] = useState<boolean>(false)
   const [appToRemove, setAppToRemove] = useState<SafeApp | null>(null)
@@ -115,7 +117,7 @@ const AppsList = (): React.ReactElement => {
             .filter((a) => a.fetchStatus !== SAFE_APP_FETCH_STATUS.ERROR)
             .map((a) => (
               <AppContainer key={a.url}>
-                <StyledLink key={a.url} to={`${matchSafeWithAddress?.url}/apps?appUrl=${encodeURI(a.url)}`}>
+                <StyledLink key={a.url} to={`${appsPath}?appUrl=${encodeURI(a.url)}`}>
                   <AppCard isLoading={isAppLoading(a)} iconUrl={a.iconUrl} name={a.name} description={a.description} />
                 </StyledLink>
                 {isCustomApp(a.url, appList) && (

--- a/src/routes/safe/components/Apps/components/AppsList.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.tsx
@@ -87,7 +87,7 @@ const isCustomApp = (appUrl: string, appsList: SafeApp[]) => {
 const AppsList = (): React.ReactElement => {
   const safeAddress = useSelector(safeAddressFromUrl)
   const appsPath = generatePath(SAFE_ROUTES.APPS, {
-    address: safeAddress,
+    safeAddress,
   })
   const { appList, removeApp, isLoading } = useAppList()
   const [isAddAppModalOpen, setIsAddAppModalOpen] = useState<boolean>(false)

--- a/src/routes/safe/components/Balances/index.tsx
+++ b/src/routes/safe/components/Balances/index.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core/styles'
 import React, { ReactElement, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
-import { Redirect, Route, Switch } from 'react-router-dom'
+import { generatePath, Redirect, Route, Switch } from 'react-router-dom'
 
 import ReceiveModal from 'src/components/App/ReceiveModal'
 import { styles } from './style'
@@ -10,7 +10,7 @@ import Modal from 'src/components/Modal'
 import Col from 'src/components/layout/Col'
 
 import Row from 'src/components/layout/Row'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import SendModal from 'src/routes/safe/components/Balances/SendModal'
 import { CurrencyDropdown } from 'src/routes/safe/components/CurrencyDropdown'
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
@@ -93,14 +93,24 @@ const Balances = (): ReactElement => {
       <Row align="center" className={controls}>
         <Switch>
           <Route
-            path={`${SAFELIST_ADDRESS}/${address}/balances/collectibles`}
+            path={generatePath(SAFE_ROUTES.ASSETS_COLLECTIBLES, {
+              address,
+            })}
             exact
             render={() => {
-              return !erc721Enabled ? <Redirect to={`${SAFELIST_ADDRESS}/${address}/balances`} /> : null
+              return !erc721Enabled ? (
+                <Redirect
+                  to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+                    address,
+                  })}
+                />
+              ) : null
             }}
           />
           <Route
-            path={`${SAFELIST_ADDRESS}/${address}/balances`}
+            path={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+              address,
+            })}
             exact
             render={() => {
               return (
@@ -114,7 +124,9 @@ const Balances = (): ReactElement => {
       </Row>
       <Switch>
         <Route
-          path={`${SAFELIST_ADDRESS}/${address}/balances/collectibles`}
+          path={generatePath(SAFE_ROUTES.ASSETS_COLLECTIBLES, {
+            address,
+          })}
           exact
           render={() => {
             if (erc721Enabled) {
@@ -124,7 +136,9 @@ const Balances = (): ReactElement => {
           }}
         />
         <Route
-          path={`${SAFELIST_ADDRESS}/${address}/balances`}
+          path={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+            address,
+          })}
           render={() => {
             return wrapInSuspense(<Coins showReceiveFunds={() => onShow('Receive')} showSendFunds={showSendFunds} />)
           }}

--- a/src/routes/safe/components/Balances/index.tsx
+++ b/src/routes/safe/components/Balances/index.tsx
@@ -44,9 +44,9 @@ const Balances = (): ReactElement => {
   const classes = useStyles()
   const [state, setState] = useState(INITIAL_STATE)
 
-  const { address, featuresEnabled, name: safeName } = useSelector(currentSafeWithNames)
+  const { address: safeAddress, featuresEnabled, name: safeName } = useSelector(currentSafeWithNames)
 
-  useFetchTokens(address)
+  useFetchTokens(safeAddress)
 
   useEffect(() => {
     const erc721Enabled = Boolean(featuresEnabled?.includes(FEATURES.ERC721))
@@ -94,14 +94,14 @@ const Balances = (): ReactElement => {
         <Switch>
           <Route
             path={generatePath(SAFE_ROUTES.ASSETS_COLLECTIBLES, {
-              address,
+              safeAddress,
             })}
             exact
             render={() => {
               return !erc721Enabled ? (
                 <Redirect
                   to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-                    address,
+                    safeAddress,
                   })}
                 />
               ) : null
@@ -109,7 +109,7 @@ const Balances = (): ReactElement => {
           />
           <Route
             path={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-              address,
+              safeAddress,
             })}
             exact
             render={() => {
@@ -125,7 +125,7 @@ const Balances = (): ReactElement => {
       <Switch>
         <Route
           path={generatePath(SAFE_ROUTES.ASSETS_COLLECTIBLES, {
-            address,
+            safeAddress,
           })}
           exact
           render={() => {
@@ -137,7 +137,7 @@ const Balances = (): ReactElement => {
         />
         <Route
           path={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-            address,
+            safeAddress,
           })}
           render={() => {
             return wrapInSuspense(<Coins showReceiveFunds={() => onShow('Receive')} showSendFunds={showSendFunds} />)
@@ -157,7 +157,7 @@ const Balances = (): ReactElement => {
         paperClassName="receive-modal"
         title="Receive Tokens"
       >
-        <ReceiveModal safeAddress={address} safeName={safeName} onClose={() => onHide('Receive')} />
+        <ReceiveModal safeAddress={safeAddress} safeName={safeName} onClose={() => onHide('Receive')} />
       </Modal>
     </>
   )

--- a/src/routes/safe/components/Settings/index.tsx
+++ b/src/routes/safe/components/Settings/index.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(styles)
 const Settings = (): React.ReactElement => {
   const classes = useStyles()
   const [state, setState] = useState(INITIAL_STATE)
-  const { address, owners, loadedViaUrl } = useSelector(currentSafeWithNames)
+  const { address: safeAddress, owners, loadedViaUrl } = useSelector(currentSafeWithNames)
   const granted = useSelector(grantedSelector)
 
   const onShow = (action) => () => {
@@ -70,35 +70,35 @@ const Settings = (): React.ReactElement => {
             <Switch>
               <Route
                 path={generatePath(SAFE_ROUTES.SETTINGS_DETAILS, {
-                  address,
+                  safeAddress,
                 })}
                 exact
                 render={() => <SafeDetails />}
               ></Route>
               <Route
                 path={generatePath(SAFE_ROUTES.SETTINGS_OWNERS, {
-                  address,
+                  safeAddress,
                 })}
                 exact
                 render={() => <ManageOwners granted={granted} owners={owners} />}
               ></Route>
               <Route
                 path={generatePath(SAFE_ROUTES.SETTINGS_POLICIES, {
-                  address,
+                  safeAddress,
                 })}
                 exact
                 render={() => <ThresholdSettings />}
               ></Route>
               <Route
                 path={generatePath(SAFE_ROUTES.SETTINGS_SPENDING_LIMIT, {
-                  address,
+                  safeAddress,
                 })}
                 exact
                 render={() => <SpendingLimitSettings />}
               ></Route>
               <Route
                 path={generatePath(SAFE_ROUTES.SETTINGS_ADVANCED, {
-                  address,
+                  safeAddress,
                 })}
                 exact
                 render={() => <Advanced />}

--- a/src/routes/safe/components/Settings/index.tsx
+++ b/src/routes/safe/components/Settings/index.tsx
@@ -69,35 +69,35 @@ const Settings = (): React.ReactElement => {
           <Block className={classes.container}>
             <Switch>
               <Route
-                path={generatePath(SAFE_ROUTES.DETAILS, {
+                path={generatePath(SAFE_ROUTES.SETTINGS_DETAILS, {
                   address,
                 })}
                 exact
                 render={() => <SafeDetails />}
               ></Route>
               <Route
-                path={generatePath(SAFE_ROUTES.OWNERS, {
+                path={generatePath(SAFE_ROUTES.SETTINGS_OWNERS, {
                   address,
                 })}
                 exact
                 render={() => <ManageOwners granted={granted} owners={owners} />}
               ></Route>
               <Route
-                path={generatePath(SAFE_ROUTES.POLICIES, {
+                path={generatePath(SAFE_ROUTES.SETTINGS_POLICIES, {
                   address,
                 })}
                 exact
                 render={() => <ThresholdSettings />}
               ></Route>
               <Route
-                path={generatePath(SAFE_ROUTES.SPENDING_LIMIT, {
+                path={generatePath(SAFE_ROUTES.SETTINGS_SPENDING_LIMIT, {
                   address,
                 })}
                 exact
                 render={() => <SpendingLimitSettings />}
               ></Route>
               <Route
-                path={generatePath(SAFE_ROUTES.ADVANCED, {
+                path={generatePath(SAFE_ROUTES.SETTINGS_ADVANCED, {
                   address,
                 })}
                 exact

--- a/src/routes/safe/components/Settings/index.tsx
+++ b/src/routes/safe/components/Settings/index.tsx
@@ -3,11 +3,11 @@ import { LoadingContainer } from 'src/components/LoaderContainer'
 import { makeStyles } from '@material-ui/core/styles'
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
-import { Route, Switch } from 'react-router-dom'
+import { generatePath, Route, Switch } from 'react-router-dom'
 
 import { styles } from './style'
 
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import Block from 'src/components/layout/Block'
 import ButtonLink from 'src/components/layout/ButtonLink'
 import Col from 'src/components/layout/Col'
@@ -69,27 +69,37 @@ const Settings = (): React.ReactElement => {
           <Block className={classes.container}>
             <Switch>
               <Route
-                path={`${SAFELIST_ADDRESS}/${address}/settings/details`}
+                path={generatePath(SAFE_ROUTES.DETAILS, {
+                  address,
+                })}
                 exact
                 render={() => <SafeDetails />}
               ></Route>
               <Route
-                path={`${SAFELIST_ADDRESS}/${address}/settings/owners`}
+                path={generatePath(SAFE_ROUTES.OWNERS, {
+                  address,
+                })}
                 exact
                 render={() => <ManageOwners granted={granted} owners={owners} />}
               ></Route>
               <Route
-                path={`${SAFELIST_ADDRESS}/${address}/settings/policies`}
+                path={generatePath(SAFE_ROUTES.POLICIES, {
+                  address,
+                })}
                 exact
                 render={() => <ThresholdSettings />}
               ></Route>
               <Route
-                path={`${SAFELIST_ADDRESS}/${address}/settings/spending-limit`}
+                path={generatePath(SAFE_ROUTES.SPENDING_LIMIT, {
+                  address,
+                })}
                 exact
                 render={() => <SpendingLimitSettings />}
               ></Route>
               <Route
-                path={`${SAFELIST_ADDRESS}/${address}/settings/advanced`}
+                path={generatePath(SAFE_ROUTES.ADVANCED, {
+                  address,
+                })}
                 exact
                 render={() => <Advanced />}
               ></Route>

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -27,10 +27,10 @@ const Container = (): React.ReactElement => {
   const safeAddress = useSelector(safeAddressFromUrl)
   const featuresEnabled = useSelector(currentSafeFeaturesEnabled)
   const balancesBaseRoute = generatePath(SAFE_ROUTES.ASSETS_BASE_ROUTE, {
-    address: safeAddress,
+    safeAddress,
   })
   const settingsBaseRoute = generatePath(SAFE_ROUTES.SETTINGS_BASE_ROUTE, {
-    address: safeAddress,
+    safeAddress,
   })
   const [modal, setModal] = useState({
     isOpen: false,
@@ -69,20 +69,20 @@ const Container = (): React.ReactElement => {
         <Route
           exact
           path={generatePath(SAFE_ROUTES.TRANSACTIONS, {
-            address: safeAddress,
+            safeAddress,
           })}
           render={() => wrapInSuspense(<TxList />, null)}
         />
         <Route
           exact
           path={generatePath(SAFE_ROUTES.APPS, {
-            address: safeAddress,
+            safeAddress,
           })}
           render={({ history }) => {
             if (!featuresEnabled.includes(FEATURES.SAFE_APPS)) {
               history.push(
                 generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-                  address: safeAddress,
+                  safeAddress,
                 }),
               )
             }
@@ -93,13 +93,13 @@ const Container = (): React.ReactElement => {
         <Route
           exact
           path={generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
-            address: safeAddress,
+            safeAddress,
           })}
           render={() => wrapInSuspense(<AddressBookTable />, null)}
         />
         <Redirect
           to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
-            address: safeAddress,
+            safeAddress,
           })}
         />
       </Switch>

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -1,11 +1,11 @@
 import { GenericModal, Loader } from '@gnosis.pm/safe-react-components'
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
-import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
+import { generatePath, Redirect, Route, Switch } from 'react-router-dom'
 
-import { currentSafeFeaturesEnabled } from 'src/logic/safe/store/selectors'
+import { currentSafeFeaturesEnabled, safeAddressFromUrl } from 'src/logic/safe/store/selectors'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
-import { SAFELIST_ADDRESS } from 'src/routes/routes'
+import { SAFE_ROUTES } from 'src/routes/routes'
 import { FEATURES } from 'src/config/networks/network.d'
 import { LoadingContainer } from 'src/components/LoaderContainer'
 
@@ -24,7 +24,14 @@ const TxList = React.lazy(() => import('src/routes/safe/components/Transactions/
 const AddressBookTable = React.lazy(() => import('src/routes/safe/components/AddressBook'))
 
 const Container = (): React.ReactElement => {
+  const safeAddress = useSelector(safeAddressFromUrl)
   const featuresEnabled = useSelector(currentSafeFeaturesEnabled)
+  const balancesBaseRoute = generatePath(SAFE_ROUTES.ASSETS_BASE_ROUTE, {
+    address: safeAddress,
+  })
+  const settingsBaseRoute = generatePath(SAFE_ROUTES.SETTINGS_BASE_ROUTE, {
+    address: safeAddress,
+  })
   const [modal, setModal] = useState({
     isOpen: false,
     title: null,
@@ -32,8 +39,6 @@ const Container = (): React.ReactElement => {
     footer: null,
     onClose: () => {},
   })
-
-  const matchSafeWithAddress = useRouteMatch({ path: `${SAFELIST_ADDRESS}/:safeAddress` })
 
   if (!featuresEnabled) {
     return (
@@ -60,37 +65,43 @@ const Container = (): React.ReactElement => {
   return (
     <>
       <Switch>
+        <Route exact path={`${balancesBaseRoute}/:assetType?`} render={() => wrapInSuspense(<Balances />, null)} />
         <Route
           exact
-          path={`${matchSafeWithAddress?.path}/balances/:assetType?`}
-          render={() => wrapInSuspense(<Balances />, null)}
-        />
-        <Route
-          exact
-          path={`${matchSafeWithAddress?.path}/transactions`}
+          path={generatePath(SAFE_ROUTES.TRANSACTIONS, {
+            address: safeAddress,
+          })}
           render={() => wrapInSuspense(<TxList />, null)}
         />
         <Route
           exact
-          path={`${matchSafeWithAddress?.path}/apps`}
+          path={generatePath(SAFE_ROUTES.APPS, {
+            address: safeAddress,
+          })}
           render={({ history }) => {
             if (!featuresEnabled.includes(FEATURES.SAFE_APPS)) {
-              history.push(`${matchSafeWithAddress?.url}/balances`)
+              history.push(
+                generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+                  address: safeAddress,
+                }),
+              )
             }
             return wrapInSuspense(<Apps />, null)
           }}
         />
+        <Route exact path={`${settingsBaseRoute}/:section`} render={() => wrapInSuspense(<Settings />, null)} />
         <Route
           exact
-          path={`${matchSafeWithAddress?.path}/settings/:section`}
-          render={() => wrapInSuspense(<Settings />, null)}
-        />
-        <Route
-          exact
-          path={`${matchSafeWithAddress?.path}/address-book`}
+          path={generatePath(SAFE_ROUTES.ADDRESS_BOOK, {
+            address: safeAddress,
+          })}
           render={() => wrapInSuspense(<AddressBookTable />, null)}
         />
-        <Redirect to={`${matchSafeWithAddress?.url}/balances`} />
+        <Redirect
+          to={generatePath(SAFE_ROUTES.ASSETS_BALANCES, {
+            address: safeAddress,
+          })}
+        />
       </Switch>
       {modal.isOpen && <GenericModal {...modal} onClose={closeGenericModal} />}
     </>


### PR DESCRIPTION
## What it solves
Resolves #2525 

## How this PR fixes it
This PR will set all routes to be created programmatically from an enum that we can handle in `routes` file

## How to test this
This is mostly a code semantic improvement. As bugs can happen this can be tested as minimum, just playing a bit around navigating through the app and seeing the expected behavior. No deep check should be necessary, when merging to dev, we will test this in any other PRs