### PR TITLE
Disable spellchecker in eth address field - re #2257

### DIFF
--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -50,6 +50,7 @@ const AddressInput = ({
       testId={testId}
       text={text}
       type="text"
+      spellCheck="false"
       validate={composeValidators(required, mustBeEthereumAddress, ...validators)}
     />
     <OnChange name={name}>

--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -23,6 +23,7 @@ export interface AddressInputProps {
   validators?: Validator[]
   defaultValue?: string
   disabled?: boolean
+  spellCheck?: boolean
   className?: string
 }
 
@@ -50,7 +51,7 @@ const AddressInput = ({
       testId={testId}
       text={text}
       type="text"
-      spellCheck="false"
+      spellCheck={false}
       validate={composeValidators(required, mustBeEthereumAddress, ...validators)}
     />
     <OnChange name={name}>

--- a/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
+++ b/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
@@ -224,9 +224,6 @@ const SafeOwnersForm = (props): React.ReactElement => {
                     }
                   }
                   name={addressName}
-                  type="text"
-                  autoCorrect={false}
-                  spellCheck={false}
                   placeholder="Owner Address*"
                   text="Owner Address"
                   testId={`create-safe-address-field-${index}`}

--- a/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
+++ b/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
@@ -203,7 +203,7 @@ const SafeOwnersForm = (props): React.ReactElement => {
                   testId={`create-safe-owner-name-field-${index}`}
                 />
               </Col>
-              <Col className={classes.ownerAddress} xs={7}>
+              <Col className={classes.ownerAddress} spellcheck="false" xs={7}>
                 <StyledAddressInput
                   fieldMutator={(newOwnerAddress) => {
                     const newOwnerName = addressBook.find((entry) => sameAddress(entry.address, newOwnerAddress))?.name

--- a/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
+++ b/src/routes/open/components/SafeOwnersConfirmationsForm/index.tsx
@@ -203,7 +203,7 @@ const SafeOwnersForm = (props): React.ReactElement => {
                   testId={`create-safe-owner-name-field-${index}`}
                 />
               </Col>
-              <Col className={classes.ownerAddress} spellcheck="false" xs={7}>
+              <Col className={classes.ownerAddress} xs={7}>
                 <StyledAddressInput
                   fieldMutator={(newOwnerAddress) => {
                     const newOwnerName = addressBook.find((entry) => sameAddress(entry.address, newOwnerAddress))?.name
@@ -224,6 +224,9 @@ const SafeOwnersForm = (props): React.ReactElement => {
                     }
                   }
                   name={addressName}
+                  type="text"
+                  autoCorrect={false}
+                  spellCheck={false}
                   placeholder="Owner Address*"
                   text="Owner Address"
                   testId={`create-safe-address-field-${index}`}


### PR DESCRIPTION
## What it solves
Browser was underlining the input text with a red wavy line. But an address isn't supposed to be spell-checked.

## Environment
Browser: Chrome

## How this PR fixes it
Disabled HTML spellcheck for safe address input element.

## Screenshots

Unfixed:
<img width="472" alt="unfixed" src="https://user-images.githubusercontent.com/36449086/126167370-cb3125b5-4361-4b86-8237-13f24ad52160.png">


Fixed:

![Screen Shot 2021-07-19 at 3 28 20 PM](https://user-images.githubusercontent.com/36449086/126167392-5b7f8881-9240-4b2b-9dbe-fca6a0fdb570.png)

