### PR TITLE
Chore: remove unused options from the configs

### DIFF
--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -45,15 +45,12 @@ describe('Config Services', () => {
     }))
     const { getTxServiceUrl, getGnosisSafeAppsUrl } = require('src/config')
     const TX_SERVICE_URL = mainnet.environment.dev?.txServiceUrl
-    const SAFE_APPS_URL = mainnet.environment.dev?.safeAppsUrl
 
     // When
     const txServiceUrl = getTxServiceUrl()
-    const safeAppsUrl = getGnosisSafeAppsUrl()
 
     // Then
     expect(TX_SERVICE_URL).toBe(txServiceUrl)
-    expect(SAFE_APPS_URL).toBe(safeAppsUrl)
   })
 
   it(`should load 'mainnet.staging' network config`, () => {
@@ -62,17 +59,14 @@ describe('Config Services', () => {
       NODE_ENV: 'production',
       NETWORK: 'MAINNET',
     }))
-    const { getTxServiceUrl, getGnosisSafeAppsUrl } = require('src/config')
+    const { getTxServiceUrl } = require('src/config')
     const TX_SERVICE_URL = mainnet.environment.staging?.txServiceUrl
-    const SAFE_APPS_URL = mainnet.environment.staging?.safeAppsUrl
 
     // When
     const txServiceUrl = getTxServiceUrl()
-    const safeAppsUrl = getGnosisSafeAppsUrl()
 
     // Then
     expect(TX_SERVICE_URL).toBe(txServiceUrl)
-    expect(SAFE_APPS_URL).toBe(safeAppsUrl)
   })
 
   it(`should load 'mainnet.production' network config`, () => {
@@ -84,15 +78,12 @@ describe('Config Services', () => {
     }))
     const { getTxServiceUrl, getGnosisSafeAppsUrl } = require('src/config')
     const TX_SERVICE_URL = mainnet.environment.production.txServiceUrl
-    const SAFE_APPS_URL = mainnet.environment.production.safeAppsUrl
 
     // When
     const txServiceUrl = getTxServiceUrl()
-    const safeAppsUrl = getGnosisSafeAppsUrl()
 
     // Then
     expect(TX_SERVICE_URL).toBe(txServiceUrl)
-    expect(SAFE_APPS_URL).toBe(safeAppsUrl)
   })
 
   it(`should load 'xdai.production' network config`, () => {
@@ -104,14 +95,11 @@ describe('Config Services', () => {
     }))
     const { getTxServiceUrl, getGnosisSafeAppsUrl } = require('src/config')
     const TX_SERVICE_URL = xdai.environment.production.txServiceUrl
-    const SAFE_APPS_URL = xdai.environment.production.safeAppsUrl
 
     // When
     const txServiceUrl = getTxServiceUrl()
-    const safeAppsUrl = getGnosisSafeAppsUrl()
     // Then
     expect(TX_SERVICE_URL).toBe(txServiceUrl)
-    expect(SAFE_APPS_URL).toBe(safeAppsUrl)
   })
 
   it(`should default to 'xdai.dev' network config if no environment is found`, () => {
@@ -122,14 +110,11 @@ describe('Config Services', () => {
     }))
     const { getTxServiceUrl, getGnosisSafeAppsUrl } = require('src/config')
     const TX_SERVICE_URL = xdai.environment.dev?.txServiceUrl
-    const SAFE_APPS_URL = xdai.environment.dev?.safeAppsUrl
 
     // When
     const txServiceUrl = getTxServiceUrl()
-    const safeAppsUrl = getGnosisSafeAppsUrl()
 
     // Then
     expect(TX_SERVICE_URL).toBe(txServiceUrl)
-    expect(SAFE_APPS_URL).toBe(safeAppsUrl)
   })
 })

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -93,10 +93,6 @@ export const getClientGatewayUrl = (): string => getConfig().clientGatewayUrl
 
 export const getTxServiceUrl = (): string => getConfig().txServiceUrl
 
-export const getRelayUrl = (): string | undefined => getConfig().relayApiUrl
-
-export const getGnosisSafeAppsUrl = (): string => getConfig().safeAppsUrl
-
 export const getGasPrice = (): number | undefined => getConfig()?.gasPrice
 
 export const getGasPriceOracle = (): GasPriceOracle | undefined => getConfig()?.gasPriceOracle

--- a/src/config/networks/bsc.ts
+++ b/src/config/networks/bsc.ts
@@ -5,7 +5,6 @@ const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.bsc.gnosis.io/v1',
   txServiceUrl: 'https://safe-transaction.bsc.gnosis.io/api/v1',
   safeUrl: 'https://bsc.gnosis-safe.io/app',
-  safeAppsUrl: 'https://safe-apps-bsc.staging.gnosisdev.com',
   gasPriceOracle: {
     url: 'https://bscgas.info/gas',
     gasParameter: 'standard',
@@ -29,7 +28,6 @@ const mainnet: NetworkConfig = {
     },
     production: {
       ...baseConfig,
-      safeAppsUrl: 'https://apps-bsc.gnosis-safe.io',
     },
   },
   network: {

--- a/src/config/networks/energy_web_chain.ts
+++ b/src/config/networks/energy_web_chain.ts
@@ -7,7 +7,6 @@ const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.ewc.gnosis.io/v1',
   txServiceUrl: 'https://safe-transaction.ewc.gnosis.io/api/v1',
   safeUrl: 'https://ewc.gnosis-safe.io/app',
-  safeAppsUrl: 'https://safe-apps-ewc.staging.gnosisdev.com',
   gasPriceOracle: {
     url: 'https://station.energyweb.org',
     gasParameter: 'standard',
@@ -32,7 +31,6 @@ const mainnet: NetworkConfig = {
     },
     production: {
       ...baseConfig,
-      safeAppsUrl: 'https://apps-ewc.gnosis-safe.io',
     },
   },
   network: {

--- a/src/config/networks/local.ts
+++ b/src/config/networks/local.ts
@@ -4,13 +4,11 @@ import { EnvironmentSettings, ETHEREUM_NETWORK, NetworkConfig } from 'src/config
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'http://localhost:8001/v1',
   txServiceUrl: 'http://localhost:8000/api/v1',
-  relayApiUrl: 'https://safe-relay.staging.gnosisdev.com/api/v1',
   safeUrl: 'http://localhost:3000/app',
-  safeAppsUrl: 'http://localhost:3002',
   gasPriceOracle: {
     url: 'https://ethgasstation.info/json/ethgasAPI.json',
     gasParameter: 'average',
-    gweiFactor: '1e8'
+    gweiFactor: '1e8',
   },
   rpcServiceUrl: 'http://localhost:4447',
   networkExplorerName: 'Etherscan',

--- a/src/config/networks/mainnet.ts
+++ b/src/config/networks/mainnet.ts
@@ -6,9 +6,8 @@ const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.mainnet.staging.gnosisdev.com/v1',
   txServiceUrl: 'https://safe-transaction.mainnet.staging.gnosisdev.com/api/v1',
   safeUrl: 'https://gnosis-safe.io/app',
-  safeAppsUrl: 'https://safe-apps.dev.gnosisdev.com',
   gasPriceOracle: {
-    url: 'https://ethgasstation.info/json/ethgasAPI.json?api-key=${ETHGASSTATION_API_KEY}',
+    url: `https://ethgasstation.info/json/ethgasAPI.json?api-key=${ETHGASSTATION_API_KEY}`,
     gasParameter: 'average',
     gweiFactor: '1e8',
   },
@@ -27,13 +26,11 @@ const mainnet: NetworkConfig = {
     staging: {
       ...baseConfig,
       safeUrl: 'https://safe-team-mainnet.staging.gnosisdev.com/app/',
-      safeAppsUrl: 'https://safe-apps.staging.gnosisdev.com',
     },
     production: {
       ...baseConfig,
       clientGatewayUrl: 'https://safe-client.mainnet.gnosis.io/v1',
       txServiceUrl: 'https://safe-transaction.mainnet.gnosis.io/api/v1',
-      safeAppsUrl: 'https://apps.gnosis-safe.io',
     },
   },
   network: {

--- a/src/config/networks/network.d.ts
+++ b/src/config/networks/network.d.ts
@@ -91,9 +91,6 @@ type GasPrice =
 export type EnvironmentSettings = GasPrice & {
   clientGatewayUrl: string
   txServiceUrl: string
-  // TODO: Shall we keep a reference to the relay?
-  relayApiUrl?: string
-  safeAppsUrl: string
   safeUrl: string
   rpcServiceUrl: string
   networkExplorerName: string

--- a/src/config/networks/polygon.ts
+++ b/src/config/networks/polygon.ts
@@ -5,7 +5,6 @@ const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client-polygon.staging.gnosisdev.com/v1',
   txServiceUrl: 'https://safe-transaction-polygon.staging.gnosisdev.com/api/v1',
   safeUrl: 'https://polygon.gnosis-safe.io/app',
-  safeAppsUrl: 'https://safe-apps-polygon.staging.gnosisdev.com',
   gasPriceOracle: {
     url: 'https://gasstation-mainnet.matic.network',
     gasParameter: 'standard',
@@ -31,7 +30,6 @@ const polygon: NetworkConfig = {
       ...baseConfig,
       clientGatewayUrl: 'https://safe-client.polygon.gnosis.io/v1',
       txServiceUrl: 'https://safe-transaction.polygon.gnosis.io/api/v1',
-      safeAppsUrl: 'https://apps-polygon.gnosis-safe.io',
     },
   },
   network: {

--- a/src/config/networks/rinkeby.ts
+++ b/src/config/networks/rinkeby.ts
@@ -6,7 +6,6 @@ const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.rinkeby.staging.gnosisdev.com/v1',
   txServiceUrl: 'https://safe-transaction.rinkeby.staging.gnosisdev.com/api/v1',
   safeUrl: 'https://rinkeby.gnosis-safe.io/app',
-  safeAppsUrl: 'https://safe-apps.dev.gnosisdev.com',
   gasPriceOracle: {
     url: `https://ethgasstation.info/json/ethgasAPI.json?api-key=${ETHGASSTATION_API_KEY}`,
     gasParameter: 'average',
@@ -27,13 +26,11 @@ const rinkeby: NetworkConfig = {
     staging: {
       ...baseConfig,
       safeUrl: 'https://safe-team-rinkeby.staging.gnosisdev.com/app/',
-      safeAppsUrl: 'https://safe-apps.staging.gnosisdev.com',
     },
     production: {
       ...baseConfig,
       clientGatewayUrl: 'https://safe-client.rinkeby.gnosis.io/v1',
       txServiceUrl: 'https://safe-transaction.rinkeby.gnosis.io/api/v1',
-      safeAppsUrl: 'https://apps.gnosis-safe.io',
     },
   },
   network: {

--- a/src/config/networks/volta.ts
+++ b/src/config/networks/volta.ts
@@ -5,7 +5,6 @@ const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.volta.gnosis.io/v1',
   txServiceUrl: 'https://safe-transaction.volta.gnosis.io/api/v1',
   safeUrl: 'https://volta.gnosis-safe.io/app',
-  safeAppsUrl: 'https://safe-apps-volta.staging.gnosisdev.com',
   gasPriceOracle: {
     url: 'https://station.energyweb.org',
     gasParameter: 'standard',
@@ -29,7 +28,6 @@ const mainnet: NetworkConfig = {
     },
     production: {
       ...baseConfig,
-      safeAppsUrl: 'https://apps-volta.gnosis-safe.io',
     },
   },
   network: {

--- a/src/config/networks/xdai.ts
+++ b/src/config/networks/xdai.ts
@@ -5,7 +5,6 @@ const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.xdai.gnosis.io/v1',
   txServiceUrl: 'https://safe-transaction.xdai.gnosis.io/api/v1',
   safeUrl: 'https://xdai.gnosis-safe.io/app',
-  safeAppsUrl: 'https://safe-apps-xdai.staging.gnosisdev.com',
   gasPrice: 1e9,
   rpcServiceUrl: 'https://dai.poa.network/',
   networkExplorerName: 'Blockscout',
@@ -25,7 +24,6 @@ const xDai: NetworkConfig = {
     },
     production: {
       ...baseConfig,
-      safeAppsUrl: 'https://apps-xdai.gnosis-safe.io',
     },
   },
   network: {


### PR DESCRIPTION
## What it solves
Remove unused configuration options: safe apps URL, safe relay service URL

## How this PR fixes it
Literally removes them and also fixes tests

## How to test it
Everything should work just fine as it used to
