### PR TITLE
Don't show required error when loading a safe

### DIFF
--- a/src/routes/load/components/DetailsForm/index.tsx
+++ b/src/routes/load/components/DetailsForm/index.tsx
@@ -74,7 +74,7 @@ interface DetailsFormProps {
 const DetailsForm = ({ errors, form }: DetailsFormProps): ReactElement => {
   const classes = useStyles()
   const { safeAddress } = useParams<{ safeAddress?: string }>()
-  const safeName = useSelector((state) => (safeAddress ? addressBookName(state, { address: safeAddress }) : ''))
+  const safeName = useSelector((state) => (safeAddress ? addressBookName(state, { address: safeAddress }) : undefined))
 
   const handleScan = (value: string, closeQrModal: () => void): void => {
     form.mutators.setValue(FIELD_LOAD_ADDRESS, value)


### PR DESCRIPTION
## What it solves
Resolves #2539

## How this PR fixes it

Initializes the safeName variable with undefined so the required check is not made

## How to test it

-Open Add existing safe

The required error should be ther
