### PR TITLE
Adds Binance Smart Chain and Polygon to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Besides the Ethereum Mainnet, the following networks are supported:
 
 - [Rinkeby Testnet](https://rinkeby.gnosis-safe.io/app/)
 - [xDai](https://xdai.gnosis-safe.io/app/)
+- [Polygon](https://polygon.gnosis-safe.io/app/)
+- [Binance Smart Chain](https://bsc.gnosis-safe.io/app/)
 - [Energy Web Chain](https://ewc.gnosis-safe.io/app/)
 - [Volta Testnet](https://volta.gnosis-safe.io/app/)
 


### PR DESCRIPTION
## What it solves
Recently Gnosis Safe added support for Binance Smart Chain and Polygon.
The readme did not have those listed yet, this pull request fixes that.

## How this PR fixes it
By adding both Polygon and Binance Smart Chain to the list.

## Screenshots
![image](https://user-images.githubusercontent.com/18427051/126718683-2031da49-81c6-443f-a618-b78b464a82d2.png)
