### PR TITLE
Fix import in Windows 10 + Chrome

### DIFF
--- a/src/routes/safe/components/AddressBook/__tests__/utils.test.ts
+++ b/src/routes/safe/components/AddressBook/__tests__/utils.test.ts
@@ -8,8 +8,14 @@ import {
 } from '../utils'
 
 describe('Address Book file validations', () => {
-  it('Should return wrong file extension error if file extension is not the allowed', () => {
+  it('Should return wrong file extension error if file type is not allowed', () => {
     const file = new File([''], 'file.txt', { type: 'text/plain' })
+    const result = validateFile(file)
+    expect(result).toBe(WRONG_FILE_EXTENSION_ERROR)
+  })
+
+  it('Should return wrong file extension error if file extension is not valid', () => {
+    const file = new File([''], 'file.txt', { type: IMPORT_SUPPORTED_FORMATS[0] })
     const result = validateFile(file)
     expect(result).toBe(WRONG_FILE_EXTENSION_ERROR)
   })

--- a/src/routes/safe/components/AddressBook/utils.ts
+++ b/src/routes/safe/components/AddressBook/utils.ts
@@ -5,15 +5,18 @@ export const WRONG_FILE_EXTENSION_ERROR = 'Only CSV files are allowed'
 export const FILE_SIZE_TOO_BIG_ERROR = 'The size of the file is over 1 MB'
 export const FILE_BYTES_LIMIT = 1000000
 export const IMPORT_SUPPORTED_FORMATS = [
+  '',
   'text/csv',
   'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ]
 
+const CSV_EXTENSION_REGEX = /([a-zA-Z0-9\s_\\.\-:])+(.csv|.ods|.xls|.xlsx)$/
+
 export type CsvDataType = { data: string[] }[]
 
 export const validateFile = (file: File): string | undefined => {
-  if (!IMPORT_SUPPORTED_FORMATS.includes(file.type)) {
+  if (!IMPORT_SUPPORTED_FORMATS.includes(file.type) || !CSV_EXTENSION_REGEX.test(file.name.toLowerCase())) {
     return WRONG_FILE_EXTENSION_ERROR
   }
 


### PR DESCRIPTION
## What it solves
Resolves #2578

## How this PR fixes it
It allows file type not to be defined but also includes a file extension validation in order to still do a minimum check that a valid file is being uploaded

## How to test it
It can only be tested using **Chrome** in **Windows 10**
If an office suite is installed it may be possible that the issue is not repeatable anymore. I can just confirm that it's possible with a clean Windows 10 or with LibreOffice installed
