### PR TITLE
Unnecessary gas estimates

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "immortal-db": "^1.1.0",
     "immutable": "^4.0.0-rc.12",
     "js-cookie": "^2.2.1",
+    "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/src/logic/contracts/getSafeCreationGasEstimate.tsx
+++ b/src/logic/contracts/getSafeCreationGasEstimate.tsx
@@ -3,6 +3,7 @@ import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
 import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
 import { getNetworkInfo } from 'src/config'
 import { calculateGasPrice } from 'src/logic/wallets/ethTransactions'
+import { throttle } from 'lodash'
 
 type getEstimateSafeCreationGasProps = {
   addresses: string[]
@@ -18,9 +19,9 @@ type SafeCreationEstimationResult = {
 }
 
 const { nativeCoin } = getNetworkInfo()
+export const DEFAULT_GAS = '< 0.001'
 
-// TODO rename and move file
-export const getEstimateSafeCreationGas = async ({
+const estimateSafeCreationGas = async ({
   addresses,
   numOwners,
   safeCreationSalt,
@@ -29,7 +30,7 @@ export const getEstimateSafeCreationGas = async ({
   if (!addresses.length || !numOwners || !userAccount) {
     return {
       gasEstimation: 0,
-      gasCostFormatted: '< 0.001',
+      gasCostFormatted: DEFAULT_GAS,
       gasLimit: 0,
     }
   }
@@ -44,3 +45,5 @@ export const getEstimateSafeCreationGas = async ({
     gasLimit: gasEstimation,
   }
 }
+
+export const getSafeCreationGasEstimate = throttle(estimateSafeCreationGas, 10000)


### PR DESCRIPTION
## What it solves
Resolves #2350 

## How this PR fixes it
Converted the hook that estimates gas into a function so it's not affected by re-renders. However i understand that there's another re-render that causes the estimation to be retrieved twice.
