### PR TITLE
Use explicit config to set L1 or L2 smart contract

### DIFF
--- a/src/config/networks/bsc.ts
+++ b/src/config/networks/bsc.ts
@@ -1,5 +1,5 @@
 import BnbLogo from 'src/config/assets/token_bnb.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, FEATURES, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, FEATURES, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
 
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.bsc.gnosis.io/v1',
@@ -39,6 +39,7 @@ const mainnet: NetworkConfig = {
     textColor: '#ffffff',
     label: 'BSC',
     isTestNet: false,
+    ethereumLayer: ETHEREUM_LAYER.L2,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'Binance Coin',

--- a/src/config/networks/energy_web_chain.ts
+++ b/src/config/networks/energy_web_chain.ts
@@ -1,5 +1,5 @@
 import EwcLogo from 'src/config/assets/token_ewc.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
 
 // @todo (agustin) we need to use fixed gasPrice because the oracle is not working right now and it's returning 0
 // once the oracle is fixed we need to remove the fixed value
@@ -42,6 +42,7 @@ const mainnet: NetworkConfig = {
     textColor: '#ffffff',
     label: 'EWC',
     isTestNet: false,
+    ethereumLayer: ETHEREUM_LAYER.L2,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'Energy web token',

--- a/src/config/networks/local.ts
+++ b/src/config/networks/local.ts
@@ -1,5 +1,5 @@
 import EtherLogo from 'src/config/assets/token_eth.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, NetworkConfig } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, NetworkConfig } from 'src/config/networks/network.d'
 
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'http://localhost:8001/v1',
@@ -36,6 +36,7 @@ const local: NetworkConfig = {
     textColor: '#ffffff',
     label: 'LocalRPC',
     isTestNet: true,
+    ethereumLayer: ETHEREUM_LAYER.L1,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'Ether',

--- a/src/config/networks/mainnet.ts
+++ b/src/config/networks/mainnet.ts
@@ -1,5 +1,5 @@
 import EtherLogo from 'src/config/assets/token_eth.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, NetworkConfig } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, NetworkConfig } from 'src/config/networks/network.d'
 import { ETHGASSTATION_API_KEY } from 'src/utils/constants'
 
 const baseConfig: EnvironmentSettings = {
@@ -47,6 +47,7 @@ const mainnet: NetworkConfig = {
     textColor: '#001428',
     label: 'Mainnet',
     isTestNet: false,
+    ethereumLayer: ETHEREUM_LAYER.L1,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'Ether',

--- a/src/config/networks/network.d.ts
+++ b/src/config/networks/network.d.ts
@@ -34,6 +34,11 @@ type Token = {
   logoUri?: string
 }
 
+export enum ETHEREUM_LAYER {
+  L1 = '1',
+  L2 = '2',
+}
+
 export enum ETHEREUM_NETWORK {
   UNKNOWN = 0,
   MAINNET = 1,
@@ -44,10 +49,10 @@ export enum ETHEREUM_NETWORK {
   KOVAN = 42,
   BSC = 56,
   XDAI = 100,
+  POLYGON = 137,
   ENERGY_WEB_CHAIN = 246,
   LOCAL = 4447,
   VOLTA = 73799,
-  POLYGON = 137,
 }
 
 export type NetworkSettings = {
@@ -57,6 +62,7 @@ export type NetworkSettings = {
   textColor: string
   label: string
   isTestNet: boolean
+  ethereumLayer: ETHEREUM_LAYER
   nativeCoin: Token
 }
 
@@ -105,7 +111,7 @@ type SafeEnvironments = {
   production: EnvironmentSettings
 }
 
-export type NetworkInfo = Omit<NetworkSettings, 'isTestNet' | 'nativeCoin'> & { safeUrl: string }
+export type NetworkInfo = Omit<NetworkSettings, 'isTestNet' | 'ethereumLayer' | 'nativeCoin'> & { safeUrl: string }
 
 export interface NetworkConfig {
   network: NetworkSettings

--- a/src/config/networks/polygon.ts
+++ b/src/config/networks/polygon.ts
@@ -1,5 +1,5 @@
 import maticLogo from 'src/config/assets/token_matic.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, FEATURES, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, FEATURES, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
 
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client-polygon.staging.gnosisdev.com/v1',
@@ -41,6 +41,7 @@ const polygon: NetworkConfig = {
     textColor: '#ffffff',
     label: 'Polygon',
     isTestNet: false,
+    ethereumLayer: ETHEREUM_LAYER.L2,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'MATIC',

--- a/src/config/networks/rinkeby.ts
+++ b/src/config/networks/rinkeby.ts
@@ -1,5 +1,5 @@
 import EtherLogo from 'src/config/assets/token_eth.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
 import { ETHGASSTATION_API_KEY } from 'src/utils/constants'
 
 const baseConfig: EnvironmentSettings = {
@@ -47,6 +47,7 @@ const rinkeby: NetworkConfig = {
     textColor: '#ffffff',
     label: 'Rinkeby',
     isTestNet: true,
+    ethereumLayer: ETHEREUM_LAYER.L1,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'Ether',

--- a/src/config/networks/volta.ts
+++ b/src/config/networks/volta.ts
@@ -1,5 +1,5 @@
 import EwcLogo from 'src/config/assets/token_ewc.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
 
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.volta.gnosis.io/v1',
@@ -39,6 +39,7 @@ const mainnet: NetworkConfig = {
     textColor: '#ffffff',
     label: 'Volta',
     isTestNet: true,
+    ethereumLayer: ETHEREUM_LAYER.L2,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'Volta Token',

--- a/src/config/networks/xdai.ts
+++ b/src/config/networks/xdai.ts
@@ -1,5 +1,5 @@
 import xDaiLogo from 'src/config/assets/token_xdai.svg'
-import { EnvironmentSettings, ETHEREUM_NETWORK, FEATURES, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
+import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, FEATURES, NetworkConfig, WALLETS } from 'src/config/networks/network.d'
 
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.xdai.gnosis.io/v1',
@@ -33,6 +33,7 @@ const xDai: NetworkConfig = {
     textColor: '#ffffff',
     label: 'xDai',
     isTestNet: false,
+    ethereumLayer: ETHEREUM_LAYER.L2,
     nativeCoin: {
       address: '0x0000000000000000000000000000000000000000',
       name: 'xDai',

--- a/src/logic/contracts/safeContracts.ts
+++ b/src/logic/contracts/safeContracts.ts
@@ -10,7 +10,8 @@ import Web3 from 'web3'
 import { AbiItem } from 'web3-utils'
 
 import { LATEST_SAFE_VERSION } from 'src/utils/constants'
-import { ETHEREUM_NETWORK } from 'src/config/networks/network.d'
+import { getNetworkConfigById, getNetworkId } from 'src/config'
+import { ETHEREUM_LAYER, ETHEREUM_NETWORK } from 'src/config/networks/network.d'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { calculateGasOf, EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { getWeb3, getNetworkIdFrom } from 'src/logic/wallets/getWeb3'
@@ -27,16 +28,18 @@ let safeMaster: GnosisSafe
 let fallbackHandler: FallbackManager
 let multiSend: MultiSend
 
-const getSafeContractDeployment = ({ networkId, safeVersion }: { networkId?: ETHEREUM_NETWORK, safeVersion: string }) => {
+const getSafeContractDeployment = ({ safeVersion }: { safeVersion: string }) => {
   // We check if version is prior to v1.0.0 as they are not supported but still we want to keep a minimum compatibility
   const useOldestContractVersion = semverSatisfies(safeVersion, '<1.0.0')
-  // If version is 1.3.0 we can use instance compatible with L2 for all networks
-  const useL2ContractVersion = semverSatisfies(safeVersion, '>=1.3.0')
+  // We have to check if network is L2
+  const networkId = getNetworkId()
+  const networkConfig = getNetworkConfigById(networkId)
+  const useL2ContractVersion = networkConfig?.network.ethereumLayer === ETHEREUM_LAYER.L2
   const getDeployment = useL2ContractVersion ? getSafeL2SingletonDeployment : getSafeSingletonDeployment
   return (
     getDeployment({
       version: safeVersion,
-      network: networkId?.toString(),
+      network: networkId.toString(),
     }) ||
     getDeployment({
       version: safeVersion,
@@ -54,7 +57,7 @@ const getSafeContractDeployment = ({ networkId, safeVersion }: { networkId?: ETH
  * @param {ETHEREUM_NETWORK} networkId
  */
 const getGnosisSafeContractInstance = (web3: Web3, networkId: ETHEREUM_NETWORK): GnosisSafe => {
-  const safeSingletonDeployment = getSafeContractDeployment({ networkId, safeVersion: LATEST_SAFE_VERSION })
+  const safeSingletonDeployment = getSafeContractDeployment({ safeVersion: LATEST_SAFE_VERSION })
 
   const contractAddress =
     safeSingletonDeployment?.networkAddresses[networkId] ?? safeSingletonDeployment?.defaultAddress


### PR DESCRIPTION
## What it solves
We were using L2 contract instance for all networks, but I was warned by @rmeissner  that on mainnet gas costs were much higher using this contract instance. So we are going to set explicitly L1 or L2 in config selecting the required smart contract for each case

## How this PR fixes it
It adds a config parameter setting which layer version is a network using

## How to test it
Should create L1 smart contract instances on rinkeby and mainnet. It can check which master copy is using to create smart contract

For upgrade step I can provide v1.1.1 or v1.0.0 safes if QA is not having more of them. They should check that also L1 master copy is used to upgrade in mainnet or rinkeby

