### PR TITLE
Fix: show QR code even if no safe name

### DIFF
--- a/src/components/App/ReceiveModal.tsx
+++ b/src/components/App/ReceiveModal.tsx
@@ -89,7 +89,7 @@ const ReceiveModal = ({ onClose, safeAddress, safeName }: Props): ReactElement =
       </Row>
       <Hairline />
       <Paragraph className={classes.networkInfo} noMargin size="lg" weight="bolder">
-        {networkInfo.label} Network only send {networkInfo.label} assets to this Safe.
+        {networkInfo.label} Network–only send {networkInfo.label} assets to this Safe.
       </Paragraph>
       <Paragraph className={classes.annotation} noMargin size="lg">
         This is the address of your Safe. Deposit funds by scanning the QR code or copying the address below. Only send{' '}

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -138,7 +138,7 @@ const App: React.FC = ({ children }) => {
             selectedToken={sendFunds.selectedToken}
           />
 
-          {safeAddress && safeName && (
+          {safeAddress && (
             <Modal
               description="Receive Tokens Form"
               handleClose={onReceiveHide}


### PR DESCRIPTION
## What it solves
Resolves #2593

## How this PR fixes it
Removes the safe name check when showing the QR code.

## How to test it
Open a safe w/o a name and click on the QR code button.

## Screenshots
<img width="582" alt="Screenshot 2021-08-12 at 11 06 48" src="https://user-images.githubusercontent.com/381895/129170535-171bbca8-0f15-4102-b484-a270b3ff9d88.png">

