### PR TITLE
Sentry: ignore wallet errors; set sample rate to 0.1

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,9 @@ Sentry.init({
   dsn: SENTRY_DSN,
   release: `safe-react@${process.env.REACT_APP_APP_VERSION}`,
   integrations: [new Integrations.BrowserTracing()],
-  sampleRate: 0.01,
+  sampleRate: 0.1,
+  // ignore MetaMask errors we don't control
+  ignoreErrors: ['Internal JSON-RPC error', 'JsonRpcEngine', 'Non-Error promise rejection captured with keys: code'],
 })
 
 const root = document.getElementById('root')


### PR DESCRIPTION
## What it solves
Resolves #2600.

Also increases the Sentry sample rate 10 times (from every 100th error to every 10th).

## How this PR fixes it
MM (and probably other wallet extensions) throw uncaught exceptions from their content script.
We cannot catch them in our code (apart from `window.onerror`), although we do catch the corresponding errors from web3. So there's no point logging these to Sentry.

## How to test it
No need to test, these errors are very random. We'll see if they stop appearing on Sentry.

## Screenshots
<img width="1157" alt="Screenshot 2021-08-12 at 12 06 04" src="https://user-images.githubusercontent.com/381895/129179011-7a40d126-5612-4107-8f9c-c2bcaa0ffbd7.png">
