### PR TITLE
Fix byte32[] decoding

### DIFF
--- a/src/components/DecodeTxs/__tests__/index.ts
+++ b/src/components/DecodeTxs/__tests__/index.ts
@@ -9,7 +9,15 @@ describe('DecodeTxs tests', () => {
     expect(getByteLength('0x000000ea,0x48656c6c6f2125')).toBe(11)
   })
 
+  it('should calculate the byte length of an hex array', () => {
+    expect(getByteLength(['0x000000ea', '0x48656c6c6f2125'])).toBe(11)
+  })
+
   it('should return 0 if passed a non-hex value', () => {
     expect(getByteLength('hello')).toBe(0)
+  })
+
+  it('should return 0 if passed a non-string', () => {
+    expect(getByteLength(123 as unknown as string)).toBe(0)
   })
 })

--- a/src/components/DecodeTxs/__tests__/index.ts
+++ b/src/components/DecodeTxs/__tests__/index.ts
@@ -1,0 +1,15 @@
+import { getByteLength } from '..'
+
+describe('DecodeTxs tests', () => {
+  it('should calculate the byte length of a single hex string', () => {
+    expect(getByteLength('0x000000ea')).toBe(4)
+  })
+
+  it('should calculate the byte length of multiple hex strings', () => {
+    expect(getByteLength('0x000000ea,0x48656c6c6f2125')).toBe(11)
+  })
+
+  it('should return 0 if passed a non-hex value', () => {
+    expect(getByteLength('hello')).toBe(0)
+  })
+})

--- a/src/components/DecodeTxs/index.tsx
+++ b/src/components/DecodeTxs/index.tsx
@@ -49,11 +49,13 @@ const ElementWrapper = styled.div`
   margin-bottom: 15px;
 `
 
-export const getByteLength = (data: string): number => {
-  const hexes = data.split(',')
+export const getByteLength = (data: string | string[]): number => {
   try {
+    if (!Array.isArray(data)) {
+      data = data.split(',')
+    }
     // Return the sum of the byte sizes of each hex string
-    return hexes.reduce((result, hex) => {
+    return data.reduce((result, hex) => {
       const bytes = web3.utils.hexToBytes(hex)
       return result + bytes.length
     }, 0)

--- a/src/components/DecodeTxs/index.tsx
+++ b/src/components/DecodeTxs/index.tsx
@@ -49,6 +49,19 @@ const ElementWrapper = styled.div`
   margin-bottom: 15px;
 `
 
+export const getByteLength = (data: string): number => {
+  const hexes = data.split(',')
+  try {
+    // Return the sum of the byte sizes of each hex string
+    return hexes.reduce((result, hex) => {
+      const bytes = web3.utils.hexToBytes(hex)
+      return result + bytes.length
+    }, 0)
+  } catch (err) {
+    return 0
+  }
+}
+
 export const BasicTxInfo = ({
   txRecipient,
   txData,
@@ -81,7 +94,7 @@ export const BasicTxInfo = ({
           Data (hex encoded):
         </Text>
         <FlexWrapper margin={5}>
-          <Text size="lg">{txData ? web3.utils.hexToBytes(txData).length : 0} bytes</Text>
+          <Text size="lg">{txData ? getByteLength(txData) : 0} bytes</Text>
           <CopyToClipboardBtn textToCopy={txData} />
         </FlexWrapper>
       </>
@@ -107,7 +120,7 @@ export const getParameterElement = (parameter: DecodedDataBasicParameter, index:
   if (parameter.type.startsWith('bytes')) {
     valueElement = (
       <FlexWrapper margin={5}>
-        <Text size="lg">{web3.utils.hexToBytes(parameter.value).length} bytes</Text>
+        <Text size="lg">{getByteLength(parameter.value)} bytes</Text>
         <CopyToClipboardBtn textToCopy={parameter.value} />
       </FlexWrapper>
     )


### PR DESCRIPTION
## What it solves
Resolves #2556 and #2613

## How this PR fixes it
Supports a joined list of hex strings. Swallows possible errors for any incompatible type.

## How to test it
* Open the Tx Builder app
* Use the test contract provided by Liliya in #2556
* Enter `["0x000000ea", "0x48656c6c6f2125"]` in the param value
* Send, review and decode

<img width="674" alt="Screenshot 2021-08-12 at 12 50 59" src="https://user-images.githubusercontent.com/381895/129184930-a69efe1e-e633-4dc5-9bbd-724556b304d3.png">

<img width="550" alt="Screenshot 2021-08-12 at 12 51 05" src="https://user-images.githubusercontent.com/381895/129184935-0c074369-a2c4-49da-92ba-79c9380159f3.png">

