### PR TITLE
Dockerize safe react project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/coverage

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-cla-document: 'https://github.com/gnosis/safe-react/blob/main/GNOSISCLA.md'
           branch: 'cla-signatures'
-          allowlist: lukasschor,mikheevm,rmeissner,germartinez,fernandomg,Agupane,nicosampler,matextrem,gabitoesmiapodo,davidalbela,alongoni,Uxio0,dasanra,miguelmota,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh
+          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:14
+
+RUN apt-get update && apt-get install -y libusb-1.0-0 libusb-1.0-0-dev libudev-dev
+
+WORKDIR /app
+
+COPY package.json ./
+
+COPY yarn.lock ./
+
+RUN yarn install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ yarn start-mainnet
 If you prefer to use Docker:
 
 ```
-yarn start:docker
+docker-compose build && docker-compose up
 ```
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -27,41 +27,57 @@ We use [yarn](https://yarnpkg.com) in our infrastructure, so we decided to go wi
 Please install yarn globally if you haven't already.
 
 ### Environment variables
+
 The app grabs environment variables from the `.env` file. Copy our template to your own local file:
+
 ```
 cp .env.example .env
 ```
 
 To execute transactions, you'll need to create an [Infura](https://infura.io) project and set the project ID in the `.env` you've just created:
+
 ```
 REACT_APP_INFURA_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
+
 Once done, you'll need to restart the app if it's already running.
 
 ### Installing and running
 
 Install dependencies for the project:
+
 ```
 yarn install
 ```
 
 To use the Rinkeby services:
+
 ```
 yarn start
 ```
 
 If you prefer using the Mainnet ones:
+
 ```
 yarn start-mainnet
 ```
 
+If you prefer to use Docker:
+
+```
+yarn start:docker
+```
+
 ### Building
+
 For Rinkeby:
+
 ```
 yarn build
 ```
 
 For Mainnet:
+
 ```
 yarn build-mainnet
 ```
@@ -69,6 +85,7 @@ yarn build-mainnet
 ## Running the tests
 
 To run the tests:
+
 ```
 yarn test
 ```
@@ -84,12 +101,14 @@ yarn lint:fix
 ## Deployment
 
 ### Dev & staging
+
 The code is deployed to a testing website automatically on each push via a GitHub Action.
 The GitHub Action will create a new subdomain and post the link as a comment in the PR.
 
 When pushing to the `main` branch, the code will be automatically deployed to [staging](https://safe-team-rinkeby.staging.gnosisdev.com/).
 
 ### Production
+
 Deployment to production is done manually. Please see the [release procedure](docs/release-procedure.md) notes for details.
 
 ## Configuring the app for running on different networks
@@ -98,9 +117,9 @@ Deployment to production is done manually. Please see the [release procedure](do
 
 ## Built With
 
-* [React](https://reactjs.org/) - A JS library for building user interfaces
-* [Material UI 4.X](https://material-ui.com/) - React components that implement Google's Material Design
-* [redux, immutable, reselect, final-form](https://redux.js.org/) - React ecosystem libraries
+- [React](https://reactjs.org/) - A JS library for building user interfaces
+- [Material UI 4.X](https://material-ui.com/) - React components that implement Google's Material Design
+- [redux, immutable, reselect, final-form](https://redux.js.org/) - React ecosystem libraries
 
 ![app diagram](https://user-images.githubusercontent.com/381895/121764528-e5e2e900-cb44-11eb-8643-483d41040349.png)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.2'
+
+services:
+  safe-react:
+    build: ./
+    volumes:
+      - /app/node_modules
+      - ./:/app
+    ports:
+      - 3000:3000

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "start-polygon": "REACT_APP_LATEST_SAFE_VERSION='1.3.0' REACT_APP_NETWORK=polygon yarn start",
     "start-bsc": "REACT_APP_LATEST_SAFE_VERSION='1.3.0' REACT_APP_NETWORK='bsc' yarn start",
     "start": "rescripts start",
+    "start:docker": "docker-compose build && docker-compose up",
     "test": "rescripts test --env=jsdom",
     "test:coverage": "yarn test --coverage --watchAll=false",
     "test:ci": "yarn test --ci --coverage --json --watchAll=false --testLocationInResults --runInBand",


### PR DESCRIPTION
## What it solves

The current listed version of electron (`9.0.0`) does not support the M1 chip (`darwin-arm64`).

There is another PR open to fix this: https://github.com/gnosis/safe-react/pull/2149

## How this PR fixes it

As an alternative, you can use docker to run the safe-react in a container.

## How to test it

[Install Docker](https://docs.docker.com/get-docker/) and  run `yarn start:docker`
