### PR TITLE
Hotfix v3.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/logic/contracts/safeContracts.ts
+++ b/src/logic/contracts/safeContracts.ts
@@ -34,7 +34,8 @@ const getSafeContractDeployment = ({ safeVersion }: { safeVersion: string }) => 
   // We have to check if network is L2
   const networkId = getNetworkId()
   const networkConfig = getNetworkConfigById(networkId)
-  const useL2ContractVersion = networkConfig?.network.ethereumLayer === ETHEREUM_LAYER.L2
+  // We had L1 contracts in three L2 networks, xDai, EWC and Volta so even if network is L2 we have to check that safe version is after v1.3.0
+  const useL2ContractVersion = networkConfig?.network.ethereumLayer === ETHEREUM_LAYER.L2 && semverSatisfies(safeVersion, '>=1.3.0')
   const getDeployment = useL2ContractVersion ? getSafeL2SingletonDeployment : getSafeSingletonDeployment
   return (
     getDeployment({


### PR DESCRIPTION
## What it solves
Resolves #
Issue with xDai, EWC and Volta that used L1 smart contracts while they are L2 networks and should be using those.

## How this PR fixes it
Check to use L1 or L2 instance is not taking into account that before version v1.3.0 there wasn't a L2 instance of the Safe smart contract. Just add a check to allow use L2 smart contract when we try to use on a L2 network and smart contract is >=1.3.0
