### PR TITLE
Fix material ui errors on dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.2",
     "material-ui-search-bar": "^1.0.0",
-    "notistack": "https://github.com/gnosis/notistack.git#v0.9.4",
+    "notistack": "https://github.com/gnosis/notistack.git#v0.9.5",
     "object-hash": "^2.1.1",
     "qrcode.react": "1.0.1",
     "query-string": "7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14826,14 +14826,14 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
   integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
-"notistack@https://github.com/gnosis/notistack.git#v0.9.4":
+"notistack@https://github.com/gnosis/notistack.git#v0.9.5":
   version "0.9.4"
-  resolved "https://github.com/gnosis/notistack.git#077aa51fd066f2c3198b2f5ce773f741e21f24df"
+  resolved "https://github.com/gnosis/notistack.git#a98ba68424bea6bad84a224e22e973d38decb35f"
   dependencies:
     classnames "^2.2.6"
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.7.2"
-    react-is "^16.9.0"
+    react-is "^17.0.2"
 
 npm-conf@^1.1.3:
   version "1.1.3"
@@ -17227,12 +17227,12 @@ react-intersection-observer@^8.32.0:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.32.0.tgz#47249332e12e8bb99ed35a10bb7dd10446445a7b"
   integrity sha512-RlC6FvS3MFShxTn4FHAy904bVjX5Nn4/eTjUkurW0fHK+M/fyQdXuyCy9+L7yjA+YMGogzzSJNc7M4UtfSKvtw==
 
-react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
+react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1:
+"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==


### PR DESCRIPTION
## What it solves
Fixes a lot of console errors on dev in the notistack package: https://github.com/gnosis/notistack

## How this PR fixes it
- Mainly by stopping passing props to a component that don't need/want it
- Use `root` instead of `container` material UI object for classnames
