### PR TITLE
Display all owned safes incl. added safes

### DIFF
--- a/src/components/SafeListSidebar/SafeList/OwnedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/OwnedAddress.tsx
@@ -19,18 +19,19 @@ const Wrapper = styled.div`
     flex: 1;
   }
 
-  & > a:last-of-type {
+  & > a:nth-of-type(2) {
     text-decoration: underline;
   }
 `
 
 type Props = {
   address: string
+  isAdded: boolean
   onClick: () => unknown
   children: ReactElement
 }
 
-export const UnsavedAddress = ({ address, onClick, children }: Props): ReactElement => {
+export const OwnedAddress = ({ address, isAdded, onClick, children }: Props): ReactElement => {
   const name = useSelector((state) => addressBookName(state, { address }))
 
   return (
@@ -46,11 +47,13 @@ export const UnsavedAddress = ({ address, onClick, children }: Props): ReactElem
         <EthHashInfo hash={address} name={name} showAvatar shortenHash={4} />
       </Link>
 
-      <Link to={`${LOAD_ADDRESS}/${address}`} onClick={onClick}>
-        <Text size="sm" color="primary">
-          Add Safe
-        </Text>
-      </Link>
+      {!isAdded && (
+        <Link to={`${LOAD_ADDRESS}/${address}`} onClick={onClick}>
+          <Text size="sm" color="primary">
+            Add Safe
+          </Text>
+        </Link>
+      )}
     </Wrapper>
   )
 }

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -13,7 +13,7 @@ import Collapse from 'src/components/Collapse'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { SAFE_ROUTES } from 'src/routes/routes'
 import { AddressWrapper } from 'src/components/SafeListSidebar/SafeList/AddressWrapper'
-import { UnsavedAddress } from 'src/components/SafeListSidebar/SafeList/UnsavedAddress'
+import { OwnedAddress } from 'src/components/SafeListSidebar/SafeList/OwnedAddress'
 import { SafeRecordWithNames } from 'src/logic/safe/store/selectors'
 
 export const SIDEBAR_SAFELIST_ROW_TESTID = 'SIDEBAR_SAFELIST_ROW_TESTID'
@@ -49,8 +49,12 @@ type Props = {
   currentSafeAddress: string | undefined
   defaultSafeAddress: DefaultSafe
   safes: SafeRecordWithNames[]
-  otherSafes: string[]
+  ownedSafes: string[]
   onSafeClick: () => void
+}
+
+const isAddressAdded = (addedSafes: SafeRecordWithNames[], address: string): boolean => {
+  return addedSafes.some((addr) => sameAddress(addr.address, address))
 }
 
 export const SafeList = ({
@@ -58,10 +62,12 @@ export const SafeList = ({
   defaultSafeAddress,
   onSafeClick,
   safes,
-  otherSafes,
+  ownedSafes,
 }: Props): React.ReactElement => {
   const classes = useStyles()
-  const ownedSafesExpanded = otherSafes.some((address) => address === currentSafeAddress)
+  const ownedSafesExpanded = ownedSafes.some((address) => {
+    return address === currentSafeAddress && !isAddressAdded(safes, address)
+  })
 
   const getLink = (address: string): React.ReactElement =>
     sameAddress(currentSafeAddress, address) ? (
@@ -90,15 +96,20 @@ export const SafeList = ({
         </React.Fragment>
       ))}
 
-      {otherSafes.length > 0 && (
+      {ownedSafes.length > 0 && (
         <ListItem classes={{ root: classes.listItemRoot }}>
           <div className={classes.noIcon}>placeholder</div>
 
-          <Collapse title={`Owned Safes (${otherSafes.length})`} defaultExpanded={ownedSafesExpanded}>
-            {otherSafes.map((address) => (
-              <UnsavedAddress address={address} key={address} onClick={onSafeClick}>
+          <Collapse title={`All owned Safes (${ownedSafes.length})`} defaultExpanded={ownedSafesExpanded}>
+            {ownedSafes.map((address: string) => (
+              <OwnedAddress
+                address={address}
+                key={address}
+                onClick={onSafeClick}
+                isAdded={isAddressAdded(safes, address)}
+              >
                 {getLink(address)}
-              </UnsavedAddress>
+              </OwnedAddress>
             ))}
           </Collapse>
         </ListItem>

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -54,7 +54,7 @@ type Props = {
 }
 
 const isAddressAdded = (addedSafes: SafeRecordWithNames[], address: string): boolean => {
-  return addedSafes.some((addr) => sameAddress(addr.address, address))
+  return addedSafes.some((safe) => sameAddress(safe.address, address))
 }
 
 export const SafeList = ({

--- a/src/components/SafeListSidebar/index.tsx
+++ b/src/components/SafeListSidebar/index.tsx
@@ -130,7 +130,7 @@ export const SafeListSidebar = ({ children }: Props): ReactElement => {
           defaultSafeAddress={defaultSafe}
           onSafeClick={toggleSidebar}
           safes={filteredSafes}
-          otherSafes={filteredOwnerSafes}
+          ownedSafes={filteredOwnerSafes}
         />
       </Drawer>
       {children}

--- a/src/logic/safe/hooks/useOwnerSafes.ts
+++ b/src/logic/safe/hooks/useOwnerSafes.ts
@@ -1,16 +1,12 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { sameAddress } from 'src/logic/wallets/ethAddresses'
-import { safesAsList } from 'src/logic/safe/store/selectors'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { fetchSafesByOwner } from 'src/logic/safe/api/fetchSafesByOwner'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
 const useOwnerSafes = (): string[] => {
   const connectedWalletAddress = useSelector(userAccountSelector)
-  const savedSafes = useSelector(safesAsList)
   const [ownerSafes, setOwnerSafes] = useState<string[]>([])
-  const [filteredSafes, setFilteredSafes] = useState<string[]>([])
 
   useEffect(() => {
     setOwnerSafes([])
@@ -30,14 +26,7 @@ const useOwnerSafes = (): string[] => {
     load()
   }, [connectedWalletAddress])
 
-  useMemo(() => {
-    const unsavedSafes = ownerSafes.filter((address) => {
-      return !savedSafes.some((item) => sameAddress(address, item.address) && !item.loadedViaUrl)
-    })
-    setFilteredSafes(unsavedSafes)
-  }, [ownerSafes, savedSafes])
-
-  return filteredSafes
+  return ownerSafes
 }
 
 export default useOwnerSafes


### PR DESCRIPTION
## What it solves
@koeppelmann suggested that it would be useful to display _all_ owned safes, even the ones that you already added.

## How this PR fixes it
Removes the filtering by added, renames some vars/modules to reflect the new semantics.

## How to test it
Open the sidebar and expand the `All owned Safes` list.

## Screenshots
<img width="419" alt="Screenshot 2021-08-17 at 16 15 10" src="https://user-images.githubusercontent.com/381895/129742855-9cd559d7-59f7-4c48-bb2f-b11bbcb93216.png">
