### PR TITLE
Dont use generatePath for safe routes if there`s no safeAddress

### DIFF
--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -58,7 +58,7 @@ const useSidebarItems = (): ListItemType[] => {
   )
 
   return useMemo((): ListItemType[] => {
-    if (!matchSafe || !matchSafeWithAction || !featuresEnabled) {
+    if (!matchSafe || !matchSafeWithAction || !featuresEnabled || !safeAddress) {
       return []
     }
 
@@ -145,6 +145,7 @@ const useSidebarItems = (): ListItemType[] => {
     matchSafe,
     matchSafeWithAction,
     needsUpdate,
+    safeAddress,
     safeAppsEnabled,
   ])
 }

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -28,12 +28,7 @@ const Container = (): React.ReactElement => {
   const featuresEnabled = useSelector(currentSafeFeaturesEnabled)
   const owners = useSelector(currentSafeOwners)
   const isSafeLoaded = owners.length > 0
-  const balancesBaseRoute = generatePath(SAFE_ROUTES.ASSETS_BASE_ROUTE, {
-    safeAddress,
-  })
-  const settingsBaseRoute = generatePath(SAFE_ROUTES.SETTINGS_BASE_ROUTE, {
-    safeAddress,
-  })
+
   const [modal, setModal] = useState({
     isOpen: false,
     title: null,
@@ -49,6 +44,13 @@ const Container = (): React.ReactElement => {
       </LoadingContainer>
     )
   }
+
+  const balancesBaseRoute = generatePath(SAFE_ROUTES.ASSETS_BASE_ROUTE, {
+    safeAddress,
+  })
+  const settingsBaseRoute = generatePath(SAFE_ROUTES.SETTINGS_BASE_ROUTE, {
+    safeAddress,
+  })
 
   const closeGenericModal = () => {
     if (modal.onClose) {


### PR DESCRIPTION
## What it solves
Resolves #2665 

## How this PR fixes it
The useSidebarItems hook and Container component were calling the generatePath hook with an empty address. We are now preventing the app from doing that.