### PR TITLE
Fix address book sync across multiple tabs

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -32,6 +32,7 @@ import { grantedSelector } from 'src/routes/safe/container/selector'
 
 import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
+import useAddressBookSync from 'src/logic/addressBook/hooks/useAddressBookSync'
 
 const notificationStyles = {
   success: {
@@ -80,6 +81,7 @@ const App: React.FC = ({ children }) => {
   // Temp information will be built from `addressFromUrl`
   const safeLoaded = useLoadSafe(safeAddress || addressFromUrl)
   useSafeScheduledUpdates(safeLoaded, safeAddress)
+  useAddressBookSync()
 
   const sendFunds = safeActionsState.sendFunds
   const formattedTotalBalance = currentSafeBalance ? formatAmountInUsFormat(currentSafeBalance.toString()) : ''

--- a/src/logic/addressBook/hooks/useAddressBookSync.ts
+++ b/src/logic/addressBook/hooks/useAddressBookSync.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { Dispatch } from 'src/logic/safe/store/actions/types.d'
+import { addressBookSync } from 'src/logic/addressBook/store/actions'
+import { ADDRESS_BOOK_REDUCER_ID } from 'src/logic/addressBook/store/reducer'
+import { AddressBookState } from '../model/addressBook'
+
+const useAddressBookSync = (): void => {
+  const dispatch = useDispatch<Dispatch>()
+
+  useEffect(() => {
+    const onStorageUpdate = (e: StorageEvent) => {
+      if (e.newValue && e.newValue !== e.oldValue && e.key?.endsWith(ADDRESS_BOOK_REDUCER_ID)) {
+        let newState: AddressBookState | null = null
+        try {
+          newState = JSON.parse(e.newValue) as AddressBookState
+        } catch (e) {
+          return
+        }
+        dispatch(addressBookSync(newState))
+      }
+    }
+
+    window.addEventListener('storage', onStorageUpdate)
+
+    return () => {
+      window.removeEventListener('storage', onStorageUpdate)
+    }
+  }, [dispatch])
+}
+
+export default useAddressBookSync

--- a/src/logic/addressBook/hooks/useAddressBookSync.ts
+++ b/src/logic/addressBook/hooks/useAddressBookSync.ts
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux'
 import { Dispatch } from 'src/logic/safe/store/actions/types.d'
 import { addressBookSync } from 'src/logic/addressBook/store/actions'
 import { ADDRESS_BOOK_REDUCER_ID } from 'src/logic/addressBook/store/reducer'
-import { AddressBookState } from '../model/addressBook'
+import { AddressBookState } from 'src/logic/addressBook/model/addressBook'
 
 const useAddressBookSync = (): void => {
   const dispatch = useDispatch<Dispatch>()
@@ -11,7 +11,7 @@ const useAddressBookSync = (): void => {
   useEffect(() => {
     const onStorageUpdate = (e: StorageEvent) => {
       if (e.newValue && e.newValue !== e.oldValue && e.key?.endsWith(ADDRESS_BOOK_REDUCER_ID)) {
-        let newState: AddressBookState | null = null
+        let newState: AddressBookState
         try {
           newState = JSON.parse(e.newValue) as AddressBookState
         } catch (e) {

--- a/src/logic/addressBook/store/actions/index.ts
+++ b/src/logic/addressBook/store/actions/index.ts
@@ -9,9 +9,11 @@ export enum ADDRESS_BOOK_ACTIONS {
   REMOVE = 'addressBook/remove',
   IMPORT = 'addressBook/import',
   SAFE_LOAD = 'addressBook/safeLoad',
+  SYNC = 'addressBook/sync',
 }
 
 export const addressBookAddOrUpdate = createAction<AddressBookEntry>(ADDRESS_BOOK_ACTIONS.ADD_OR_UPDATE)
 export const addressBookRemove = createAction<AddressBookEntry>(ADDRESS_BOOK_ACTIONS.REMOVE)
 export const addressBookSafeLoad = createAction<AddressBookState>(ADDRESS_BOOK_ACTIONS.SAFE_LOAD)
 export const addressBookImport = createAction<AddressBookState>(ADDRESS_BOOK_ACTIONS.IMPORT)
+export const addressBookSync = createAction<AddressBookState>(ADDRESS_BOOK_ACTIONS.SYNC)

--- a/src/logic/addressBook/store/reducer/index.ts
+++ b/src/logic/addressBook/store/reducer/index.ts
@@ -5,9 +5,9 @@ import { ADDRESS_BOOK_ACTIONS } from 'src/logic/addressBook/store/actions'
 import { getEntryIndex, isValidAddressBookName } from 'src/logic/addressBook/utils'
 import { AppReduxState } from 'src/store'
 
-type Payloads = AddressBookEntry | AddressBookState
-
 export const ADDRESS_BOOK_REDUCER_ID = 'addressBook'
+
+type Payloads = AddressBookEntry | AddressBookState
 
 const batchLoadEntries = (state, action: Action<AddressBookState>): AddressBookState => {
   const newState = [...state]

--- a/src/logic/addressBook/store/reducer/index.ts
+++ b/src/logic/addressBook/store/reducer/index.ts
@@ -5,9 +5,9 @@ import { ADDRESS_BOOK_ACTIONS } from 'src/logic/addressBook/store/actions'
 import { getEntryIndex, isValidAddressBookName } from 'src/logic/addressBook/utils'
 import { AppReduxState } from 'src/store'
 
-export const ADDRESS_BOOK_REDUCER_ID = 'addressBook'
-
 type Payloads = AddressBookEntry | AddressBookState
+
+export const ADDRESS_BOOK_REDUCER_ID = 'addressBook'
 
 const batchLoadEntries = (state, action: Action<AddressBookState>): AddressBookState => {
   const newState = [...state]
@@ -60,6 +60,7 @@ export default handleActions<AppReduxState['addressBook'], Payloads>(
     },
     [ADDRESS_BOOK_ACTIONS.SAFE_LOAD]: batchLoadEntries,
     [ADDRESS_BOOK_ACTIONS.IMPORT]: batchLoadEntries,
+    [ADDRESS_BOOK_ACTIONS.SYNC]: (_, action: Action<AddressBookState>): AddressBookState => action.payload,
   },
   [],
 )


### PR DESCRIPTION
## What it solves
Resolves #2646

## How this PR fixes it
Subscribes to the `storage` event and updates the Redux store on each localStorage write done outside of the current tab.

## How to test it
* Open two Safe tabs on the same URL
* Modify the address book in one of the tab (change the safe or one of the owners' name)
* The change should be immediately reflected in the other tab