### PR TITLE
[Hotfix v3.13.1] Create basic migration for addressbook chain id

### DIFF
--- a/src/logic/addressBook/store/selectors/index.ts
+++ b/src/logic/addressBook/store/selectors/index.ts
@@ -25,7 +25,7 @@ type AddressBookMap = {
 }
 
 type AddressBookMapByChain = {
-  [chainId: number]: AddressBookMap
+  [chainId: string]: AddressBookMap
 }
 
 export const addressBookAsMap = createSelector([addressBookState], (addressBook): AddressBookMapByChain => {
@@ -85,7 +85,7 @@ export const addressBookName = createSelector(
 export const currentNetworkAddressBook = createSelector(
   [addressBookState],
   (addressBook): AppReduxState['addressBook'] => {
-    return addressBook.filter(({ chainId }) => chainId === networkId)
+    return addressBook.filter(({ chainId }) => chainId.toString() === networkId)
   },
 )
 

--- a/src/logic/addressBook/utils/v2-migration.ts
+++ b/src/logic/addressBook/utils/v2-migration.ts
@@ -5,28 +5,11 @@ import { getNetworkName } from 'src/config'
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { Errors, trackError } from 'src/logic/exceptions/CodedException'
 import { getEntryIndex, isValidAddressBookName } from '.'
-import { ETHEREUM_NETWORK } from 'src/config/networks/network'
 
 interface StorageConfig {
   states: string[]
   namespace: string
   namespaceSeparator: string
-}
-
-const migrateChainId = ({ states, namespace, namespaceSeparator }: StorageConfig): void => {
-  const [state] = states
-  const addressBookKey = `${namespace}${namespaceSeparator}${state}`
-  const storedAddressBook = localStorage.getItem(addressBookKey)
-  let addressBookToStore: AddressBookState = storedAddressBook ? JSON.parse(storedAddressBook) : []
-
-  // TODO check if already migrated do not try again
-
-  addressBookToStore = addressBookToStore.map((entry) => {
-    return { ...entry, chainId: entry.chainId.toString() as ETHEREUM_NETWORK }
-  })
-
-  // store the mutated address book
-  localStorage.setItem(addressBookKey, JSON.stringify(addressBookToStore))
 }
 
 /**
@@ -143,7 +126,6 @@ const migrate = (storageConfig: StorageConfig): void => {
   try {
     migrateAddressBook(storageConfig)
     migrateSafeNames(storageConfig)
-    migrateChainId(storageConfig)
   } catch (e) {
     trackError(Errors._200, e.message)
   }


### PR DESCRIPTION
## What it solves
Resolves an issue where address book entries are not shown after changing chainId from number to string, because we have a strict comparison so string is not matching with number even they are the same value.

## How this PR fixes it
Consider that chainId value from address book has to always be casted to a string

## How to test it
Open the app in an environment where there is already an address book
You could load mixed values
You can store the following example in local storage and check that all values are still shown

```
[
{"address":"0x2b98ED26228aAaDf030BCA6184827490dE642c8f","name":"grateful-safe","chainId":4},{"address":"0x61a0c717d18232711bC788F19C9Cd56a43cc8872","name":"test1","chainId":"4"},{"address":"0xeB37f9Dc51FB74E8992A50cD23795fBA53e74a6A","name":"delighted-safe","chainId":4},{"address":"0x834C5e06f98cB129d142f0D99A9c617927f49F17","name":"thankful-safe","chainId":4},{"address":"0x6E45d69a383CECa3d54688e833Bd0e1388747e6B","name":"test3","chainId":"4"},{"address":"0xF6Fc48D4d7817F05A6229CF780Cf6f4a51835E49","name":"fabulous-safe","chainId":4},{"address":"0xC1652ceeFBC303Ec286933FdCea3F391d64ccd3C","name":"safe new","chainId":"4"}
]
```