### PR TITLE
Handle Intercom security issue

### DIFF
--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -15,6 +15,7 @@ import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/interco
 import AlertRedIcon from './assets/alert-red.svg'
 import IntercomIcon from './assets/intercom.png'
 import { useSafeAppUrl } from 'src/logic/hooks/useSafeAppUrl'
+import { CookieAttributes } from 'js-cookie'
 
 const isDesktop = process.env.REACT_APP_BUILD_FOR_DESKTOP
 
@@ -136,8 +137,10 @@ const CookiesBanner = (): ReactElement => {
             acceptedAnalytics,
             acceptedIntercom: acceptedAnalytics,
           }
-          const expDays = acceptedAnalytics ? 365 : 7
-          await saveCookie(COOKIES_KEY, newState, expDays)
+          const cookieConfig: CookieAttributes = {
+            expires: acceptedAnalytics ? 365 : 7,
+          }
+          await saveCookie(COOKIES_KEY, newState, cookieConfig)
           setLocalIntercom(newState.acceptedIntercom)
           setShowIntercom(newState.acceptedIntercom)
         } else {
@@ -161,7 +164,10 @@ const CookiesBanner = (): ReactElement => {
       acceptedAnalytics: !isDesktop,
       acceptedIntercom: true,
     }
-    await saveCookie(COOKIES_KEY, newState, 365)
+    const cookieConfig: CookieAttributes = {
+      expires: 365,
+    }
+    await saveCookie(COOKIES_KEY, newState, cookieConfig)
     setShowAnalytics(!isDesktop)
     setShowIntercom(true)
     dispatch.current(openCookieBanner({ cookieBannerOpen: false }))
@@ -173,8 +179,10 @@ const CookiesBanner = (): ReactElement => {
       acceptedAnalytics: localAnalytics,
       acceptedIntercom: localIntercom,
     }
-    const expDays = localAnalytics ? 365 : 7
-    await saveCookie(COOKIES_KEY, newState, expDays)
+    const cookieConfig: CookieAttributes = {
+      expires: localAnalytics ? 365 : 7,
+    }
+    await saveCookie(COOKIES_KEY, newState, cookieConfig)
     setShowAnalytics(localAnalytics)
     setShowIntercom(localIntercom)
 

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -112,6 +112,12 @@ const CookiesBanner = (): ReactElement => {
   const isSafeAppView = newAppUrl !== null
 
   useEffect(() => {
+    if (showIntercom && !isSafeAppView) {
+      loadIntercom()
+    }
+  }, [showIntercom, isSafeAppView])
+
+  useEffect(() => {
     if (intercomLoaded && isSafeAppView) {
       closeIntercom()
     }
@@ -180,10 +186,6 @@ const CookiesBanner = (): ReactElement => {
       closeIntercom()
     }
     dispatch.current(openCookieBanner({ cookieBannerOpen: false }))
-  }
-
-  if (showIntercom && !isSafeAppView) {
-    loadIntercom()
   }
 
   const CookiesBannerForm = (props: CookiesBannerFormProps) => {

--- a/src/logic/cookies/model/cookie.ts
+++ b/src/logic/cookies/model/cookie.ts
@@ -1,1 +1,2 @@
 export const COOKIES_KEY = 'COOKIES'
+export const COOKIES_KEY_INTERCOM = `${COOKIES_KEY}_INTERCOM`

--- a/src/logic/cookies/utils/index.ts
+++ b/src/logic/cookies/utils/index.ts
@@ -1,12 +1,12 @@
-import Cookies from 'js-cookie'
-
+import Cookies, { CookieAttributes } from 'js-cookie'
 import { getNetworkName } from 'src/config'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
-const PREFIX = `v1_${getNetworkName()}`
+const VERSION_PREFIX = 'v1_'
+const PREFIX = `${VERSION_PREFIX}${getNetworkName()}__`
 
 export const loadFromCookie = async (key: string, withoutPrefix = false): Promise<undefined | Record<string, any>> => {
-  const prefix = withoutPrefix ? '' : `${PREFIX}__`
+  const prefix = withoutPrefix ? '' : PREFIX
   try {
     const stringifiedValue = await Cookies.get(`${prefix}${key}`)
     if (stringifiedValue === null || stringifiedValue === undefined) {
@@ -20,11 +20,16 @@ export const loadFromCookie = async (key: string, withoutPrefix = false): Promis
   }
 }
 
-export const saveCookie = async (key: string, value: Record<string, any>, expirationDays: number): Promise<void> => {
+export const saveCookie = async (
+  key: string,
+  value: Record<string, any>,
+  options: CookieAttributes,
+  withoutPrefix = false,
+): Promise<void> => {
+  const prefix = withoutPrefix ? '' : PREFIX
   try {
     const stringifiedValue = JSON.stringify(value)
-    const expiration = expirationDays ? { expires: expirationDays } : undefined
-    await Cookies.set(`${PREFIX}__${key}`, stringifiedValue, expiration)
+    await Cookies.set(`${prefix}${key}`, stringifiedValue, options)
   } catch (err) {
     logError(Errors._701, `cookie ${key} – ${err.message}`)
   }

--- a/src/utils/intercom.ts
+++ b/src/utils/intercom.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import { CookieAttributes } from 'js-cookie'
 import { COOKIES_KEY_INTERCOM } from 'src/logic/cookies/model/cookie'
 import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
 import { INTERCOM_ID } from 'src/utils/constants'
@@ -12,8 +13,10 @@ const getIntercomUserId = async () => {
   if (!cookiesState) {
     const userId = crypto.randomBytes(32).toString('hex')
     const newCookieState = { userId }
-    const expirationDays = 365
-    await saveCookie(COOKIES_KEY_INTERCOM, newCookieState, expirationDays)
+    const cookieConfig: CookieAttributes = {
+      expires: 365,
+    }
+    await saveCookie(COOKIES_KEY_INTERCOM, newCookieState, cookieConfig)
     return userId
   }
   const { userId } = cookiesState

--- a/src/utils/intercom.ts
+++ b/src/utils/intercom.ts
@@ -1,11 +1,27 @@
+import crypto from 'crypto'
+import { COOKIES_KEY_INTERCOM } from 'src/logic/cookies/model/cookie'
+import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
 import { INTERCOM_ID } from 'src/utils/constants'
 
 let intercomLoaded = false
 
 export const isIntercomLoaded = () => intercomLoaded
 
+const getIntercomUserId = async () => {
+  const cookiesState = await loadFromCookie(COOKIES_KEY_INTERCOM)
+  if (!cookiesState) {
+    const userId = crypto.randomBytes(32).toString('hex')
+    const newCookieState = { userId }
+    const expirationDays = 365
+    await saveCookie(COOKIES_KEY_INTERCOM, newCookieState, expirationDays)
+    return userId
+  }
+  const { userId } = cookiesState
+  return userId
+}
+
 // eslint-disable-next-line consistent-return
-export const loadIntercom = (): void => {
+export const loadIntercom = async (): Promise<void> => {
   const APP_ID = INTERCOM_ID
   if (!APP_ID) {
     console.error('[Intercom] - In order to use Intercom you need to add an appID')
@@ -19,10 +35,12 @@ export const loadIntercom = (): void => {
   const x = d.getElementsByTagName('script')[0]
   x?.parentNode?.insertBefore(s, x)
 
+  const intercomUserId = await getIntercomUserId()
+
   s.onload = () => {
     ;(window as any).Intercom('boot', {
       app_id: APP_ID,
-      consent: true,
+      user_id: intercomUserId,
     })
     intercomLoaded = true
   }

--- a/src/utils/intercom.ts
+++ b/src/utils/intercom.ts
@@ -5,7 +5,7 @@ import { INTERCOM_ID } from 'src/utils/constants'
 
 let intercomLoaded = false
 
-export const isIntercomLoaded = () => intercomLoaded
+export const isIntercomLoaded = (): boolean => intercomLoaded
 
 const getIntercomUserId = async () => {
   const cookiesState = await loadFromCookie(COOKIES_KEY_INTERCOM)


### PR DESCRIPTION
## What it solves
Resolves #2565 

## How this PR fixes it
It adds the property `user_id` to the method that initializes Intercom: `Intercom('boot', { ... }`.
The property `consent` was removed as it is not present in the documentation.

The value of `user_id` is randomly generated and stored in the cookie `v1_<NETWORK>__COOKIES_INTERCOM` if the cookie does not exist. If the cookie already exists, the `user_id` is obtained from that cookie. The cookie lasts a year and a new cookie with a new `user_id` will be automatically created after that period of time. This cookie is created as long as the "Customer Support" option is selected in the cookie preferences.

Using `user_id` property on Intercom allows to identify the current user with that id and users are not asked for their email. Using a different `user_id` will match with a different conversation, meaning that each `user_id` is associated with only one conversation.

## How to test it

1. If "Customer support" is disabled in the cookie preferences no cookie is created.
2. If "Customer support" is enabled check that the cookie was created with a random `user_id`. If the cookie is manually deleted, it will be created again after refreshing the page with a new `user_id`.
3. Start a conversation on Intercom (and save somewhere the `user_id` in the current cookie).
4. Change manually the `user_id` inside the cookie.
5. Refresh the page.
6. Check that the existing conversation is not there.
7. Replace the `user_id` with the previous one.
8. Refresh the page.
9. Check that the initial conversation is there again.
