### PR TITLE
Removed act warnings in the unit tests console

### DIFF
--- a/src/routes/load/Load.test.tsx
+++ b/src/routes/load/Load.test.tsx
@@ -1,4 +1,3 @@
-import { act } from 'react-dom/test-utils'
 import { getClientGatewayUrl } from 'src/config'
 import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { mockedEndpoints } from 'src/setupTests'

--- a/src/routes/load/Load.test.tsx
+++ b/src/routes/load/Load.test.tsx
@@ -41,7 +41,7 @@ describe('<Load>', () => {
   })
 
   describe('First Step Load Safe', () => {
-    beforeEach(() => {
+    afterEach(() => {
       getENSAddressSpy.mockClear()
     })
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -68,19 +68,6 @@ Object.defineProperty(window, 'crypto', {
 
 const DEFAULT_ENV = { ...process.env }
 
-const originalError = console.error
-beforeAll(() => {
-  console.error = (...args) => {
-    if (/Warning.*not wrapped in act/.test(args[0])) {
-      return
-    }
-    if (/Code 101: Failed to resolve the address \(Given address \"notExistingENSDomain.eth\" /.test(args[0])) {
-      return
-    }
-    originalError.call(console, ...args)
-  }
-})
-
 function clearAllMockRequest() {
   Object.keys(mockedEndpoints).forEach((endpoint) => {
     mockedEndpoints[endpoint].mockClear()


### PR DESCRIPTION
## What it solves
Removed act warnings in the unit tests console

## How this PR fixes it

## How to test it

## Screenshots
