### PR TITLE
Fix: wrap web3Provider.eth.getCode in a try-catch

### DIFF
--- a/src/logic/wallets/__tests__/getWeb3.test.ts
+++ b/src/logic/wallets/__tests__/getWeb3.test.ts
@@ -1,4 +1,5 @@
-import { isTxPendingError } from 'src/logic/wallets/getWeb3'
+import Web3 from 'web3'
+import { isTxPendingError, isSmartContractWallet } from 'src/logic/wallets/getWeb3'
 
 describe('src/logic/wallets/getWeb3', () => {
   describe('isTxPendingError', () => {
@@ -10,6 +11,55 @@ describe('src/logic/wallets/getWeb3', () => {
     it('should return false for other error types', () => {
       const err = new Error('Transaction has been reverted by the EVM')
       expect(isTxPendingError(err)).toBe(false)
+    })
+  })
+
+  describe('isSmartContractWallet', () => {
+    const address = '0x66fb75feC6b40119e023564dF954c8794Cd876F0'
+
+    it('checks if an address is a contract', async () => {
+      const web3Provider = {
+        eth: {
+          getCode: jest.fn(() => Promise.resolve('Solidity code'))
+        }
+      } as unknown as Web3
+      const result = await isSmartContractWallet(web3Provider, address)
+      expect(web3Provider.eth.getCode).toHaveBeenCalledWith(address)
+      expect(result).toBe(true)
+    })
+
+    it('returns false for EoA addresses', async () => {
+      const web3Provider = {
+        eth: {
+          getCode: jest.fn(() => Promise.resolve('0x00000000000000000000'))
+        }
+      } as unknown as Web3
+      const result = await isSmartContractWallet(web3Provider, address)
+      expect(web3Provider.eth.getCode).toHaveBeenCalledWith(address)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for empty addresses', async () => {
+      const web3Provider = {
+        eth: {
+          getCode: jest.fn(() => Promise.resolve('Solidity code'))
+        }
+      } as unknown as Web3
+      const emptyAddress = ''
+      const result = await isSmartContractWallet(web3Provider, emptyAddress)
+      expect(web3Provider.eth.getCode).not.toHaveBeenCalled()
+      expect(result).toBe(false)
+    })
+
+    it('returns false if contract code cannot be fetched', async () => {
+      const web3Provider = {
+        eth: {
+          getCode: jest.fn(() => Promise.reject('No code'))
+        }
+      } as unknown as Web3
+      const result = await isSmartContractWallet(web3Provider, address)
+      expect(web3Provider.eth.getCode).toHaveBeenCalledWith(address)
+      expect(result).toBe(false)
     })
   })
 })

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -4,7 +4,6 @@ import { ContentHash } from 'web3-eth-ens'
 import { sameAddress } from './ethAddresses'
 import { EMPTY_DATA } from './ethTransactions'
 import { ProviderProps } from './store/model/provider'
-import { NODE_ENV } from 'src/utils/constants'
 import { getRpcServiceUrl } from 'src/config'
 import { isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { getAddressFromUnstoppableDomain } from './utils/unstoppableDomains'
@@ -49,11 +48,6 @@ export const resetWeb3 = (): void => {
 
 export const getAccountFrom = async (web3Provider: Web3): Promise<string | null> => {
   const accounts = await web3Provider.eth.getAccounts()
-
-  if (NODE_ENV === 'test' && window.testAccountIndex) {
-    return accounts[window.testAccountIndex]
-  }
-
   return accounts && accounts.length > 0 ? accounts[0] : null
 }
 
@@ -62,7 +56,10 @@ export const getNetworkIdFrom = (web3Provider: Web3): Promise<number> => web3Pro
 const isHardwareWallet = (walletName: string) =>
   sameAddress(WALLET_PROVIDER.LEDGER, walletName) || sameAddress(WALLET_PROVIDER.TREZOR, walletName)
 
-const isSmartContractWallet = async (web3Provider: Web3, account: string): Promise<boolean> => {
+export const isSmartContractWallet = async (web3Provider: Web3, account: string): Promise<boolean> => {
+  if (!account) {
+    return false
+  }
   let contractCode = ''
   try {
     contractCode = await web3Provider.eth.getCode(account)

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -63,8 +63,12 @@ const isHardwareWallet = (walletName: string) =>
   sameAddress(WALLET_PROVIDER.LEDGER, walletName) || sameAddress(WALLET_PROVIDER.TREZOR, walletName)
 
 const isSmartContractWallet = async (web3Provider: Web3, account: string): Promise<boolean> => {
-  const contractCode = await web3Provider.eth.getCode(account)
-
+  let contractCode = ''
+  try {
+    contractCode = await web3Provider.eth.getCode(account)
+  } catch (e) {
+    // ignore
+  }
   return !!contractCode && contractCode.replace(EMPTY_DATA, '').replace(/0/g, '') !== ''
 }
 

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -74,8 +74,7 @@ export const getProviderInfo = async (web3Instance: Web3, providerName = 'Wallet
   const network = await getNetworkIdFrom(web3Instance)
   const smartContractWallet = await isSmartContractWallet(web3Instance, account)
   const hardwareWallet = isHardwareWallet(providerName)
-
-  const available = account !== null
+  const available = Boolean(account)
 
   return {
     name: providerName,

--- a/src/types/definitions.d.ts
+++ b/src/types/definitions.d.ts
@@ -11,7 +11,6 @@ declare global {
       autoRefreshOnNetworkChange: boolean
       isMetaMask: boolean
     }
-    testAccountIndex?: string | number
   }
 }
 declare module '@openzeppelin/contracts/build/contracts/ERC721'


### PR DESCRIPTION
## What it solves
Resolves #2675

## How this PR fixes it
`web3Provider.eth.getCode` does checksum validation internally and can throw if the address is invalid. So I wrapped it in a try-catch.

## How to test it
The particular edge case when it throws is very hard to reproduce, so let's just verify that the wallet connection still works like before. Especially with WalletConnect and a Safe as a wallet.