### PR TITLE
Add gas estimation endpoint from gateway SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-deployments": "^1.0.0",
     "@gnosis.pm/safe-react-components": "^0.8.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "^2.2.2",
+    "@gnosis.pm/safe-react-gateway-sdk": "git://github.com/gnosis/safe-react-gateway-sdk.git#f76f2a4",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.3.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-deployments": "^1.0.0",
     "@gnosis.pm/safe-react-components": "^0.8.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "git://github.com/gnosis/safe-react-gateway-sdk.git#f76f2a4",
+    "@gnosis.pm/safe-react-gateway-sdk": "^2.3.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.3.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.0",

--- a/src/logic/safe/api/fetchSafeTxGasEstimation.ts
+++ b/src/logic/safe/api/fetchSafeTxGasEstimation.ts
@@ -3,10 +3,6 @@ import { postSafeGasEstimation, SafeTransactionEstimationRequest } from '@gnosis
 import { getClientGatewayUrl, getNetworkId } from 'src/config'
 import { checksumAddress } from 'src/utils/checksumAddress'
 
-export type GasEstimationResponse = {
-  safeTxGas: string
-}
-
 type FetchSafeTxGasEstimationProps = {
   safeAddress: string
 } & SafeTransactionEstimationRequest

--- a/src/logic/safe/api/fetchSafeTxGasEstimation.ts
+++ b/src/logic/safe/api/fetchSafeTxGasEstimation.ts
@@ -1,6 +1,6 @@
-import axios from 'axios'
+import { postSafeGasEstimation, SafeTransactionEstimationRequest } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import { getSafeServiceBaseUrl } from 'src/config'
+import { getClientGatewayUrl, getNetworkId } from 'src/config'
 import { checksumAddress } from 'src/utils/checksumAddress'
 
 export type GasEstimationResponse = {
@@ -9,14 +9,16 @@ export type GasEstimationResponse = {
 
 type FetchSafeTxGasEstimationProps = {
   safeAddress: string
-  to: string
-  value: string
-  data?: string
-  operation: number
-}
+} & SafeTransactionEstimationRequest
 
-export const fetchSafeTxGasEstimation = ({ safeAddress, ...body }: FetchSafeTxGasEstimationProps): Promise<string> => {
-  const url = `${getSafeServiceBaseUrl(checksumAddress(safeAddress))}/multisig-transactions/estimations/`
-
-  return axios.post(url, body).then(({ data }) => data.safeTxGas)
+export const fetchSafeTxGasEstimation = async ({
+  safeAddress,
+  ...body
+}: FetchSafeTxGasEstimationProps): Promise<string> => {
+  return postSafeGasEstimation(
+    getClientGatewayUrl(),
+    getNetworkId().toString(),
+    checksumAddress(safeAddress),
+    body,
+  ).then(({ safeTxGas }) => safeTxGas)
 }

--- a/src/logic/safe/api/fetchSafesByOwner.ts
+++ b/src/logic/safe/api/fetchSafesByOwner.ts
@@ -1,8 +1,10 @@
-import axios from 'axios'
-import { getTxServiceUrl } from 'src/config'
+import { getOwnedSafes } from '@gnosis.pm/safe-react-gateway-sdk'
+
+import { getClientGatewayUrl, getNetworkId } from 'src/config'
+import { checksumAddress } from 'src/utils/checksumAddress'
 
 export const fetchSafesByOwner = async (ownerAddress: string): Promise<string[]> => {
-  const url = `${getTxServiceUrl()}/owners/${ownerAddress}/safes`
-  const res = await axios.get<{ safes: string[] }>(url)
-  return res.data.safes
+  return getOwnedSafes(getClientGatewayUrl(), getNetworkId().toString(), checksumAddress(ownerAddress)).then(
+    ({ safes }) => safes,
+  )
 }

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -162,7 +162,7 @@ export const ReviewConfirm = ({
           origin: app.id,
           navigateToTransactionsTab: false,
           txNonce: txParameters.safeNonce,
-          safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+          safeTxGas: txParameters.safeTxGas,
           ethParameters: txParameters,
           notifiedTransaction: TX_NOTIFICATION_TYPES.STANDARD_TX,
         },

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -176,8 +176,8 @@ export const ReviewConfirm = ({
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 

--- a/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
@@ -173,7 +173,7 @@ export const ReviewMessage = ({
     <EditableTxParameters
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
       isOffChainSignature={isOffChainSignature}
       isExecution={isExecution}

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
@@ -118,8 +118,8 @@ const ContractInteractionReview = ({ onClose, onPrev, tx }: Props): React.ReactE
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -142,7 +142,7 @@ const ContractInteractionReview = ({ onClose, onPrev, tx }: Props): React.ReactE
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
@@ -106,7 +106,7 @@ const ContractInteractionReview = ({ onClose, onPrev, tx }: Props): React.ReactE
           valueInWei: txInfo?.txAmount,
           txData: txInfo?.txData,
           txNonce: txParameters.safeNonce,
-          safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+          safeTxGas: txParameters.safeTxGas,
           ethParameters: txParameters,
           notifiedTransaction: TX_NOTIFICATION_TYPES.STANDARD_TX,
         }),

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
@@ -82,7 +82,7 @@ const ReviewCustomTx = ({ onClose, onPrev, tx }: Props): ReactElement => {
           valueInWei: txValue,
           txData,
           txNonce: txParameters.safeNonce,
-          safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+          safeTxGas: txParameters.safeTxGas,
           ethParameters: txParameters,
           notifiedTransaction: TX_NOTIFICATION_TYPES.STANDARD_TX,
         }),

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
@@ -111,7 +111,7 @@ const ReviewCollectible = ({ onClose, onPrev, tx }: Props): React.ReactElement =
             valueInWei: '0',
             txData: data,
             txNonce: txParameters.safeNonce,
-            safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+            safeTxGas: txParameters.safeTxGas,
             ethParameters: txParameters,
             notifiedTransaction: TX_NOTIFICATION_TYPES.STANDARD_TX,
           }),

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
@@ -127,8 +127,8 @@ const ReviewCollectible = ({ onClose, onPrev, tx }: Props): React.ReactElement =
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -151,7 +151,7 @@ const ReviewCollectible = ({ onClose, onPrev, tx }: Props): React.ReactElement =
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
@@ -164,7 +164,7 @@ const ReviewSendFundsTx = ({ onClose, onPrev, tx }: ReviewTxProps): React.ReactE
         valueInWei: txValue,
         txData: data,
         txNonce: txParameters.safeNonce,
-        safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+        safeTxGas: txParameters.safeTxGas,
         ethParameters: txParameters,
         notifiedTransaction: TX_NOTIFICATION_TYPES.STANDARD_TX,
       }),

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
@@ -173,8 +173,8 @@ const ReviewSendFundsTx = ({ onClose, onPrev, tx }: ReviewTxProps): React.ReactE
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -197,7 +197,7 @@ const ReviewSendFundsTx = ({ onClose, onPrev, tx }: ReviewTxProps): React.ReactE
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
@@ -83,8 +83,8 @@ export const RemoveGuardModal = ({ onClose, guardAddress }: RemoveGuardModalProp
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -119,7 +119,7 @@ export const RemoveGuardModal = ({ onClose, guardAddress }: RemoveGuardModalProp
         isExecution={isExecution}
         ethGasLimit={gasLimit}
         ethGasPrice={gasPriceFormatted}
-        safeTxGas={gasEstimation.toString()}
+        safeTxGas={gasEstimation}
         closeEditModalCallback={closeEditModalCallback}
       >
         {(txParameters, toggleEditMode) => {

--- a/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
@@ -90,8 +90,8 @@ export const RemoveModuleModal = ({ onClose, selectedModulePair }: RemoveModuleM
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -126,7 +126,7 @@ export const RemoveModuleModal = ({ onClose, selectedModulePair }: RemoveModuleM
         isExecution={isExecution}
         ethGasLimit={gasLimit}
         ethGasPrice={gasPriceFormatted}
-        safeTxGas={gasEstimation.toString()}
+        safeTxGas={gasEstimation}
         closeEditModalCallback={closeEditModalCallback}
       >
         {(txParameters, toggleEditMode) => {

--- a/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
@@ -79,7 +79,7 @@ export const RemoveModuleModal = ({ onClose, selectedModulePair }: RemoveModuleM
           valueInWei: '0',
           txData,
           txNonce: txParameters.safeNonce,
-          safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+          safeTxGas: txParameters.safeTxGas,
           ethParameters: txParameters,
           notifiedTransaction: TX_NOTIFICATION_TYPES.SETTINGS_CHANGE_TX,
         }),

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/index.tsx
@@ -39,7 +39,7 @@ export const sendAddOwner = async (
       valueInWei: '0',
       txData,
       txNonce: txParameters.safeNonce,
-      safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+      safeTxGas: txParameters.safeTxGas,
       ethParameters: txParameters,
       notifiedTransaction: TX_NOTIFICATION_TYPES.SETTINGS_CHANGE_TX,
     }),

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
@@ -90,8 +90,8 @@ export const ReviewAddOwner = ({ onClickBack, onClose, onSubmit, values }: Revie
   }, [safeAddress, safeVersion, values.ownerAddress, values.threshold])
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -114,7 +114,7 @@ export const ReviewAddOwner = ({ onClickBack, onClose, onSubmit, values }: Revie
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/index.tsx
@@ -41,7 +41,7 @@ export const sendRemoveOwner = async (
       valueInWei: '0',
       txData,
       txNonce: txParameters.safeNonce,
-      safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+      safeTxGas: txParameters.safeTxGas,
       ethParameters: txParameters,
       notifiedTransaction: TX_NOTIFICATION_TYPES.SETTINGS_CHANGE_TX,
     }),

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
@@ -106,8 +106,8 @@ export const ReviewRemoveOwnerModal = ({
   }, [safeAddress, safeVersion, owner.address, threshold])
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -130,7 +130,7 @@ export const ReviewRemoveOwnerModal = ({
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/index.tsx
@@ -44,7 +44,7 @@ export const sendReplaceOwner = async (
       valueInWei: '0',
       txData,
       txNonce: txParameters.safeNonce,
-      safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+      safeTxGas: txParameters.safeTxGas,
       ethParameters: txParameters,
       notifiedTransaction: TX_NOTIFICATION_TYPES.SETTINGS_CHANGE_TX,
     }),

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
@@ -96,8 +96,8 @@ export const ReviewReplaceOwnerModal = ({
   }, [owner.address, safeAddress, safeVersion, newOwner.address])
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -120,7 +120,7 @@ export const ReviewReplaceOwnerModal = ({
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -240,8 +240,8 @@ export const ReviewSpendingLimits = ({ onBack, onClose, txToken, values }: Revie
     'One-time spending limit'
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -269,7 +269,7 @@ export const ReviewSpendingLimits = ({ onBack, onClose, txToken, values }: Revie
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
@@ -80,7 +80,7 @@ export const RemoveLimitModal = ({ onClose, spendingLimit, open }: RemoveSpendin
           valueInWei: '0',
           txData,
           txNonce: txParameters.safeNonce,
-          safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+          safeTxGas: txParameters.safeTxGas,
           ethParameters: txParameters,
           notifiedTransaction: TX_NOTIFICATION_TYPES.REMOVE_SPENDING_LIMIT_TX,
         }),

--- a/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
@@ -97,8 +97,8 @@ export const RemoveLimitModal = ({ onClose, spendingLimit, open }: RemoveSpendin
     getResetTimeOptions().find(({ value }) => +value === +spendingLimit.resetTime.resetTimeMin)?.label ?? ''
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -132,7 +132,7 @@ export const RemoveLimitModal = ({ onClose, spendingLimit, open }: RemoveSpendin
         isExecution={isExecution}
         ethGasLimit={gasLimit}
         ethGasPrice={gasPriceFormatted}
-        safeTxGas={gasEstimation.toString()}
+        safeTxGas={gasEstimation}
         closeEditModalCallback={closeEditModalCallback}
       >
         {(txParameters, toggleEditMode) => {

--- a/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
+++ b/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
@@ -110,8 +110,8 @@ export const ChangeThresholdModal = ({
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
     const oldSafeTxGas = gasEstimation
     const newSafeTxGas = txParameters.safeTxGas
 
@@ -134,7 +134,7 @@ export const ChangeThresholdModal = ({
       isExecution={isExecution}
       ethGasLimit={gasLimit}
       ethGasPrice={gasPriceFormatted}
-      safeTxGas={gasEstimation.toString()}
+      safeTxGas={gasEstimation}
       closeEditModalCallback={closeEditModalCallback}
     >
       {(txParameters, toggleEditMode) => (

--- a/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
+++ b/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
@@ -101,7 +101,7 @@ export const ChangeThresholdModal = ({
         valueInWei: '0',
         txData: data,
         txNonce: txParameters.safeNonce,
-        safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+        safeTxGas: txParameters.safeTxGas,
         ethParameters: txParameters,
         notifiedTransaction: TX_NOTIFICATION_TYPES.SETTINGS_CHANGE_TX,
       }),

--- a/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
@@ -67,7 +67,7 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
         valueInWei: '0',
         txData: multiSendCallData,
         txNonce: txParameters.safeNonce,
-        safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+        safeTxGas: txParameters.safeTxGas,
         ethParameters: txParameters,
         notifiedTransaction: 'STANDARD_TX',
         operation: Operation.DELEGATE,

--- a/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
@@ -309,15 +309,15 @@ export const ApproveTxModal = ({
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
 
     if (newGasPrice && oldGasPrice !== newGasPrice) {
-      setManualGasPrice(newGasPrice.toString())
+      setManualGasPrice(txParameters.ethGasPrice)
     }
 
     if (txParameters.ethGasLimit && gasLimit !== txParameters.ethGasLimit) {
-      setManualGasLimit(txParameters.ethGasLimit.toString())
+      setManualGasLimit(txParameters.ethGasLimit)
     }
   }
 
@@ -330,7 +330,7 @@ export const ApproveTxModal = ({
         ethGasLimit={gasLimit}
         ethGasPrice={gasPriceFormatted}
         safeNonce={nonce.toString()}
-        safeTxGas={safeTxGas.toString()}
+        safeTxGas={safeTxGas}
         closeEditModalCallback={closeEditModalCallback}
       >
         {(txParameters, toggleEditMode) => {

--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -63,7 +63,7 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
         valueInWei: '0',
         txNonce: nonce,
         origin,
-        safeTxGas: txParameters.safeTxGas ? txParameters.safeTxGas : undefined,
+        safeTxGas: txParameters.safeTxGas,
         ethParameters: txParameters,
         notifiedTransaction: TX_NOTIFICATION_TYPES.CANCELLATION_TX,
         navigateToTransactionsTab: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,9 +2556,10 @@
   dependencies:
     react-media "^1.10.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@git://github.com/gnosis/safe-react-gateway-sdk.git#f76f2a4":
-  version "2.2.2"
-  resolved "git://github.com/gnosis/safe-react-gateway-sdk.git#f76f2a4bc061ea30cb2d90dd93e981b35f10190c"
+"@gnosis.pm/safe-react-gateway-sdk@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.3.0.tgz#53833be3010e669b4474cf1ecbf3d65aac7b3cdc"
+  integrity sha512-kYnkX/h2zYvH7GNJCV3i6NiKmMKMFiRYIPQtaiLeqKGyFG+CFwBjQBOgR1et8/vy/UFHxeUO4pNtMI0el1V3hQ==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,10 +2556,9 @@
   dependencies:
     react-media "^1.10.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@^2.2.2":
+"@gnosis.pm/safe-react-gateway-sdk@git://github.com/gnosis/safe-react-gateway-sdk.git#f76f2a4":
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.2.2.tgz#aba4cb93469e12854655d0ffd67a4a7842f4b2e4"
-  integrity sha512-ADDAvykm6L7ok2OxrCe1A+RadJHy9c4Uuu29tSI446ivI7PRcn/hzT8lyAVEFgUIjLqUaUF8+Gd0n+JKwHgZaA==
+  resolved "git://github.com/gnosis/safe-react-gateway-sdk.git#f76f2a4bc061ea30cb2d90dd93e981b35f10190c"
   dependencies:
     isomorphic-unfetch "^3.1.0"
 


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-gateway-sdk/issues/14

## How this PR fixes it
Uses new function in the gateway SDK in order to estimate safeTxGas

### Bonus
It also uses the function to fetch owned safes through the client gateway instead transaction service

## How to test
 - Check that safeTxGas estimations are still correct
 - Check that owned safes are shown in sidebar correctly