### PR TITLE
Only poll when tags change on relevant paths

### DIFF
--- a/src/logic/safe/hooks/useLoadSafe.tsx
+++ b/src/logic/safe/hooks/useLoadSafe.tsx
@@ -14,9 +14,10 @@ export const useLoadSafe = (safeAddress?: string): boolean => {
 
   useEffect(() => {
     const fetchData = async () => {
+      setIsSafeLoaded(false)
       if (safeAddress) {
         await dispatch(fetchLatestMasterContractVersion())
-        await dispatch(fetchSafe(safeAddress))
+        await dispatch(fetchSafe(safeAddress, isSafeLoaded))
         setIsSafeLoaded(true)
         await dispatch(updateAvailableCurrencies())
         await dispatch(fetchTransactions(safeAddress))

--- a/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
+++ b/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from 'react'
-import { batch, useDispatch } from 'react-redux'
-
-import { fetchCollectibles } from 'src/logic/collectibles/store/actions/fetchCollectibles'
-import { fetchSafeTokens } from 'src/logic/tokens/store/actions/fetchSafeTokens'
+import { useDispatch } from 'react-redux'
 import { fetchSafe } from 'src/logic/safe/store/actions/fetchSafe'
-import fetchTransactions from 'src/logic/safe/store/actions/transactions/fetchTransactions'
 import { TIMEOUT } from 'src/utils/constants'
 
 export const useSafeScheduledUpdates = (safeLoaded: boolean, safeAddress?: string): void => {
@@ -16,14 +12,7 @@ export const useSafeScheduledUpdates = (safeLoaded: boolean, safeAddress?: strin
     // has to run again
     let mounted = true
     const fetchSafeData = async (address: string): Promise<void> => {
-      batch(async () => {
-        await Promise.all([
-          dispatch(fetchSafeTokens(address)),
-          dispatch(fetchTransactions(address)),
-          dispatch(fetchCollectibles(address)),
-          dispatch(fetchSafe(address)),
-        ])
-      })
+      await dispatch(fetchSafe(address))
 
       if (mounted) {
         timer.current = window.setTimeout(() => fetchSafeData(address), TIMEOUT * 3)

--- a/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
+++ b/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { batch, useDispatch } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { fetchSafe } from 'src/logic/safe/store/actions/fetchSafe'
 import { fetchSafeTokens } from 'src/logic/tokens/store/actions/fetchSafeTokens'
 import { TIMEOUT } from 'src/utils/constants'
@@ -13,9 +13,8 @@ export const useSafeScheduledUpdates = (safeLoaded: boolean, safeAddress?: strin
     // has to run again
     let mounted = true
     const fetchSafeData = async (address: string): Promise<void> => {
-      batch(async () => {
-        await Promise.all([dispatch(fetchSafeTokens(address)), dispatch(fetchSafe(address))])
-      })
+      dispatch(fetchSafe(address))
+      dispatch(fetchSafeTokens(address))
 
       if (mounted) {
         timer.current = window.setTimeout(() => fetchSafeData(address), TIMEOUT * 3)

--- a/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
+++ b/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
-import { useDispatch } from 'react-redux'
+import { batch, useDispatch } from 'react-redux'
 import { fetchSafe } from 'src/logic/safe/store/actions/fetchSafe'
+import { fetchSafeTokens } from 'src/logic/tokens/store/actions/fetchSafeTokens'
 import { TIMEOUT } from 'src/utils/constants'
 
 export const useSafeScheduledUpdates = (safeLoaded: boolean, safeAddress?: string): void => {
@@ -12,7 +13,9 @@ export const useSafeScheduledUpdates = (safeLoaded: boolean, safeAddress?: strin
     // has to run again
     let mounted = true
     const fetchSafeData = async (address: string): Promise<void> => {
-      await dispatch(fetchSafe(address))
+      batch(async () => {
+        await Promise.all([dispatch(fetchSafeTokens(address)), dispatch(fetchSafe(address))])
+      })
 
       if (mounted) {
         timer.current = window.setTimeout(() => fetchSafeData(address), TIMEOUT * 3)

--- a/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
+++ b/src/logic/safe/hooks/useSafeScheduledUpdates.tsx
@@ -13,7 +13,7 @@ export const useSafeScheduledUpdates = (safeLoaded: boolean, safeAddress?: strin
     // has to run again
     let mounted = true
     const fetchSafeData = async (address: string): Promise<void> => {
-      dispatch(fetchSafe(address))
+      dispatch(fetchSafe(address, safeLoaded))
       dispatch(fetchSafeTokens(address))
 
       if (mounted) {

--- a/src/logic/safe/store/actions/__tests__/utils.test.ts
+++ b/src/logic/safe/store/actions/__tests__/utils.test.ts
@@ -188,6 +188,9 @@ describe('extractRemoteSafeInfo', () => {
       needsUpdate: false,
       guard: undefined,
       featuresEnabled: [FEATURES.ERC721, FEATURES.ERC1155, FEATURES.SAFE_APPS, FEATURES.CONTRACT_INTERACTION],
+      collectiblesTag: undefined,
+      txHistoryTag: undefined,
+      txQueuedTag: undefined,
     }
 
     const remoteSafeInfo = await extractRemoteSafeInfo(remoteSafeInfoWithoutModules as any)
@@ -208,6 +211,9 @@ describe('extractRemoteSafeInfo', () => {
       needsUpdate: false,
       guard: '0x4f8a82d73729A33E0165aDeF3450A7F85f007528',
       featuresEnabled: [FEATURES.ERC721, FEATURES.ERC1155, FEATURES.SAFE_APPS, FEATURES.CONTRACT_INTERACTION],
+      collectiblesTag: undefined,
+      txHistoryTag: undefined,
+      txQueuedTag: undefined,
     }
 
     const remoteSafeInfo = await extractRemoteSafeInfo(remoteSafeInfoWithModules as any)

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -1,6 +1,5 @@
 import { Dispatch } from 'redux'
 import { Action } from 'redux-actions'
-
 import { updateSafe } from 'src/logic/safe/store/actions/updateSafe'
 import { SafeRecordProps } from 'src/logic/safe/store/models/safe'
 import { getLocalSafe } from 'src/logic/safe/utils'
@@ -13,8 +12,6 @@ import { currentSafe } from '../selectors'
 import fetchTransactions from './transactions/fetchTransactions'
 import { fetchCollectibles } from 'src/logic/collectibles/store/actions/fetchCollectibles'
 import { fetchSafeTokens } from 'src/logic/tokens/store/actions/fetchSafeTokens'
-import { SAFE_ROUTES } from 'src/routes/routes'
-import { matchPath } from 'react-router'
 
 /**
  * Builds a Safe Record that will be added to the app's store
@@ -86,11 +83,7 @@ export const fetchSafe =
       // If these polling timestamps have changed, fetch again
       const { collectiblesTag, txQueuedTag, txHistoryTag } = currentSafe(state)
 
-      const isCollectiblesPage = !!matchPath<{ safeAddress: string }>(state.router.location.pathname, {
-        path: SAFE_ROUTES.ASSETS_COLLECTIBLES,
-      })
-
-      const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag && isCollectiblesPage
+      const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag
       const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag
       const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag
 

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -56,7 +56,7 @@ export const buildSafe = async (safeAddress: string): Promise<SafeRecordProps> =
  * @param {boolean} isSafeLoaded
  */
 export const fetchSafe =
-  (safeAddress: string, isSafeLoaded: boolean) =>
+  (safeAddress: string, isSafeLoaded = false) =>
   async (dispatch: Dispatch<any>): Promise<Action<Partial<SafeRecordProps>> | void> => {
     let address = ''
     try {

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -11,7 +11,6 @@ import { store } from 'src/store'
 import { currentSafe } from '../selectors'
 import fetchTransactions from './transactions/fetchTransactions'
 import { fetchCollectibles } from 'src/logic/collectibles/store/actions/fetchCollectibles'
-import { fetchSafeTokens } from 'src/logic/tokens/store/actions/fetchSafeTokens'
 import { matchPath } from 'react-router-dom'
 import { SAFE_ROUTES } from 'src/routes/routes'
 
@@ -100,8 +99,6 @@ export const fetchSafe =
       if (shouldUpdateTxHistory || shouldUpdateTxQueued) {
         dispatch(fetchTransactions(safeAddress))
       }
-
-      dispatch(fetchSafeTokens(address))
     }
 
     const owners = buildSafeOwners(remoteSafeInfo?.owners)

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -54,6 +54,7 @@ export const buildSafe = async (safeAddress: string): Promise<SafeRecordProps> =
  *
  * @param {string} safeAddress
  */
+let isFirstSafeFetch = true
 export const fetchSafe =
   (safeAddress: string) =>
   async (dispatch: Dispatch<any>): Promise<Action<Partial<SafeRecordProps>> | void> => {
@@ -92,16 +93,17 @@ export const fetchSafe =
       const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag
       const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag
 
-      if (shouldUpdateCollectibles) {
+      if (shouldUpdateCollectibles || isFirstSafeFetch) {
         dispatch(fetchCollectibles(safeAddress))
       }
 
-      if (shouldUpdateTxHistory || shouldUpdateTxQueued) {
+      if (shouldUpdateTxHistory || shouldUpdateTxQueued || isFirstSafeFetch) {
         dispatch(fetchTransactions(safeAddress))
       }
     }
 
     const owners = buildSafeOwners(remoteSafeInfo?.owners)
 
+    isFirstSafeFetch = false
     return dispatch(updateSafe({ address, ...safeInfo, owners }))
   }

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -85,23 +85,21 @@ export const fetchSafe =
 
       // TODO: Use React Router's history object after upgrade
       const { pathname, hash } = state.router.location
-      const isPage = (str: string) => [pathname, hash].some((location) => location.includes(str))
-      const isCollectiblesPage = isPage('collectibles')
-      const isTransactionsPage = isPage('transactions') // Does not specify if queued/historical
+      const isCollectiblesPage = [pathname, hash].some((location) => location.includes('collectibles'))
 
       const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag && isCollectiblesPage
-      const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag && isTransactionsPage
-      const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag && isTransactionsPage
+      const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag
+      const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag
 
       if (shouldUpdateCollectibles) {
         dispatch(fetchCollectibles(safeAddress))
       }
 
-      if (shouldUpdateTxQueued) {
+      if (shouldUpdateTxHistory || shouldUpdateTxQueued) {
         dispatch(fetchTransactions(safeAddress))
       }
 
-      if (shouldUpdateTxHistory || shouldUpdateTxHistory) {
+      if (shouldUpdateTxHistory) {
         dispatch(fetchSafeTokens(address))
       }
     }

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -53,10 +53,10 @@ export const buildSafe = async (safeAddress: string): Promise<SafeRecordProps> =
  * @note It's being used by the app when it loads for the first time and for the Safe's data polling
  *
  * @param {string} safeAddress
+ * @param {boolean} isSafeLoaded
  */
-let isFirstSafeFetch = true
 export const fetchSafe =
-  (safeAddress: string) =>
+  (safeAddress: string, isSafeLoaded: boolean) =>
   async (dispatch: Dispatch<any>): Promise<Action<Partial<SafeRecordProps>> | void> => {
     let address = ''
     try {
@@ -93,17 +93,16 @@ export const fetchSafe =
       const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag
       const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag
 
-      if (shouldUpdateCollectibles || isFirstSafeFetch) {
+      if (shouldUpdateCollectibles || !isSafeLoaded) {
         dispatch(fetchCollectibles(safeAddress))
       }
 
-      if (shouldUpdateTxHistory || shouldUpdateTxQueued || isFirstSafeFetch) {
+      if (shouldUpdateTxHistory || shouldUpdateTxQueued || !isSafeLoaded) {
         dispatch(fetchTransactions(safeAddress))
       }
     }
 
     const owners = buildSafeOwners(remoteSafeInfo?.owners)
 
-    isFirstSafeFetch = false
     return dispatch(updateSafe({ address, ...safeInfo, owners }))
   }

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -13,6 +13,8 @@ import { currentSafe } from '../selectors'
 import fetchTransactions from './transactions/fetchTransactions'
 import { fetchCollectibles } from 'src/logic/collectibles/store/actions/fetchCollectibles'
 import { fetchSafeTokens } from 'src/logic/tokens/store/actions/fetchSafeTokens'
+import { SAFE_ROUTES } from 'src/routes/routes'
+import { matchPath } from 'react-router'
 
 /**
  * Builds a Safe Record that will be added to the app's store
@@ -78,14 +80,15 @@ export const fetchSafe =
     // remote (client-gateway)
     if (remoteSafeInfo) {
       safeInfo = await extractRemoteSafeInfo(remoteSafeInfo)
+
       const state = store.getState()
 
       // If these polling timestamps have changed, fetch again
       const { collectiblesTag, txQueuedTag, txHistoryTag } = currentSafe(state)
 
-      // TODO: Use React Router's history object after upgrade
-      const { pathname, hash } = state.router.location
-      const isCollectiblesPage = [pathname, hash].some((location) => location.includes('collectibles'))
+      const isCollectiblesPage = !!matchPath<{ safeAddress: string }>(state.router.location.pathname, {
+        path: SAFE_ROUTES.ASSETS_COLLECTIBLES,
+      })
 
       const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag && isCollectiblesPage
       const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -12,6 +12,8 @@ import { currentSafe } from '../selectors'
 import fetchTransactions from './transactions/fetchTransactions'
 import { fetchCollectibles } from 'src/logic/collectibles/store/actions/fetchCollectibles'
 import { fetchSafeTokens } from 'src/logic/tokens/store/actions/fetchSafeTokens'
+import { matchPath } from 'react-router-dom'
+import { SAFE_ROUTES } from 'src/routes/routes'
 
 /**
  * Builds a Safe Record that will be added to the app's store
@@ -83,7 +85,11 @@ export const fetchSafe =
       // If these polling timestamps have changed, fetch again
       const { collectiblesTag, txQueuedTag, txHistoryTag } = currentSafe(state)
 
-      const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag
+      const isCollectiblesPage = !!matchPath<{ safeAddress: string }>(state.router.location.pathname, {
+        path: SAFE_ROUTES.ASSETS_COLLECTIBLES,
+      })
+
+      const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag && isCollectiblesPage
       const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag
       const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag
 
@@ -95,9 +101,7 @@ export const fetchSafe =
         dispatch(fetchTransactions(safeAddress))
       }
 
-      if (shouldUpdateTxHistory) {
-        dispatch(fetchSafeTokens(address))
-      }
+      dispatch(fetchSafeTokens(address))
     }
 
     const owners = buildSafeOwners(remoteSafeInfo?.owners)

--- a/src/logic/safe/store/actions/utils.ts
+++ b/src/logic/safe/store/actions/utils.ts
@@ -91,6 +91,9 @@ export const extractRemoteSafeInfo = async (remoteSafeInfo: SafeInfo): Promise<P
   safeInfo.needsUpdate = safeNeedsUpdate(safeInfo.currentVersion, LATEST_SAFE_VERSION)
   safeInfo.featuresEnabled = enabledFeatures(safeInfo.currentVersion)
   safeInfo.guard = remoteSafeInfo.guard ? remoteSafeInfo.guard.value : undefined
+  safeInfo.collectiblesTag = remoteSafeInfo.collectiblesTag
+  safeInfo.txQueuedTag = remoteSafeInfo.txQueuedTag
+  safeInfo.txHistoryTag = remoteSafeInfo.txHistoryTag
 
   return safeInfo
 }

--- a/src/logic/safe/store/models/safe.ts
+++ b/src/logic/safe/store/models/safe.ts
@@ -38,6 +38,9 @@ export type SafeRecordProps = {
   featuresEnabled: Array<FEATURES>
   loadedViaUrl: boolean
   guard: string
+  collectiblesTag: string
+  txQueuedTag: string
+  txHistoryTag: string
 }
 
 const makeSafe = Record<SafeRecordProps>({
@@ -56,6 +59,9 @@ const makeSafe = Record<SafeRecordProps>({
   featuresEnabled: [],
   loadedViaUrl: true,
   guard: '',
+  collectiblesTag: '0',
+  txQueuedTag: '0',
+  txHistoryTag: '0',
 })
 
 export type SafeRecord = RecordOf<SafeRecordProps>

--- a/src/logic/safe/utils/__tests__/shouldSafeStoreBeUpdated.test.ts
+++ b/src/logic/safe/utils/__tests__/shouldSafeStoreBeUpdated.test.ts
@@ -41,6 +41,9 @@ const getMockedOldSafe = ({
     totalFiatBalance: '110',
     loadedViaUrl: false,
     guard: guard || mockedGuardAddress,
+    collectiblesTag: '0',
+    txQueuedTag: '0',
+    txHistoryTag: '0',
   }
 }
 


### PR DESCRIPTION
## What it solves
Resolves #2260

## How this PR fixes it
Three new flags (`collectiblesTag`, `txQueuedTag` and `txHistoryTag`) are saved in `store.safe` when the safe is fetched. Only when these flags change AND the user is on the relevant route are collectibles, tokens or transactions fetched again.

## How to test it
Check that the endpoints are not queried more than once in the Network tab. Make a transaction etc. and check that the correct endpoint(s) is queried again.