### PR TITLE
Use string for gas in ReviewMessage component

### DIFF
--- a/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
@@ -89,7 +89,7 @@ export const ReviewMessage = ({
   const explorerUrl = getExplorerInfo(safeAddress)
   const isOwner = useSelector(grantedSelector)
 
-  const [manualSafeTxGas, setManualSafeTxGas] = useState(0)
+  const [manualSafeTxGas, setManualSafeTxGas] = useState('0')
   const [manualGasPrice, setManualGasPrice] = useState<string | undefined>()
   const [manualGasLimit, setManualGasLimit] = useState<string | undefined>()
 
@@ -138,7 +138,7 @@ export const ReviewMessage = ({
           origin: app.id,
           navigateToTransactionsTab: false,
           txNonce: txParameters.safeNonce,
-          safeTxGas: txParameters.safeTxGas ? Number(txParameters.safeTxGas) : undefined,
+          safeTxGas: txParameters.safeTxGas,
           ethParameters: txParameters,
           notifiedTransaction: TX_NOTIFICATION_TYPES.STANDARD_TX,
         },
@@ -151,10 +151,10 @@ export const ReviewMessage = ({
   }
 
   const closeEditModalCallback = (txParameters: TxParameters) => {
-    const oldGasPrice = Number(gasPriceFormatted)
-    const newGasPrice = Number(txParameters.ethGasPrice)
-    const oldSafeTxGas = Number(gasEstimation)
-    const newSafeTxGas = Number(txParameters.safeTxGas)
+    const oldGasPrice = gasPriceFormatted
+    const newGasPrice = txParameters.ethGasPrice
+    const oldSafeTxGas = gasEstimation
+    const newSafeTxGas = txParameters.safeTxGas
 
     if (newGasPrice && oldGasPrice !== newGasPrice) {
       setManualGasPrice(txParameters.ethGasPrice)


### PR DESCRIPTION
## What it solves
After https://github.com/gnosis/safe-react/pull/2701 got merged, the dev branch didn't compile because the types were incompatible there.

## How this PR fixes it
- Make gas, etc. use string in ReviewMessage

## How to test it
I tested the signing flow with the safe-test-app, set manual gas, everything worked fine