### PR TITLE
Chore: Dont import react when not needed

### DIFF
--- a/src/components/App/ReceiveModal.tsx
+++ b/src/components/App/ReceiveModal.tsx
@@ -3,7 +3,7 @@ import IconButton from '@material-ui/core/IconButton'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
 import QRCode from 'qrcode.react'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Block from 'src/components/layout/Block'
 import Col from 'src/components/layout/Col'

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { SnackbarProvider } from 'notistack'
 import { useSelector } from 'react-redux'

--- a/src/components/AppLayout/AppLayout.stories.tsx
+++ b/src/components/AppLayout/AppLayout.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Icon } from '@gnosis.pm/safe-react-components'
 import { ListItemType } from 'src/components/List'
 import Layout from '.'

--- a/src/components/AppLayout/Header/components/KeyRing.tsx
+++ b/src/components/AppLayout/Header/components/KeyRing.tsx
@@ -1,6 +1,6 @@
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import Dot from '@material-ui/icons/FiberManualRecord'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Block from 'src/components/layout/Block'
 import Img from 'src/components/layout/Img'

--- a/src/components/AppLayout/Header/components/NetworkSelector.tsx
+++ b/src/components/AppLayout/Header/components/NetworkSelector.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef, Fragment } from 'react'
+import { ReactElement, useRef, Fragment } from 'react'
 import styled from 'styled-components'
 import { makeStyles } from '@material-ui/core/styles'
 import ClickAwayListener from '@material-ui/core/ClickAwayListener'

--- a/src/components/AppLayout/Header/index.tsx
+++ b/src/components/AppLayout/Header/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
 import Layout from './components/Layout'

--- a/src/components/AppLayout/MobileNotSupported/index.tsx
+++ b/src/components/AppLayout/MobileNotSupported/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Text, Card, Icon } from '@gnosis.pm/safe-react-components'
 import { alpha } from '@material-ui/core/styles/colorManipulator'
 import styled from 'styled-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { MobileView } from 'react-device-detect'
 
 import Phone from 'src/components/AppLayout/MobileStart/assets/phone@2x.png'

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.stories.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import WalletInfo from './index'
 
 export default {

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import {
   Icon,

--- a/src/components/AppLayout/Sidebar/index.stories.tsx
+++ b/src/components/AppLayout/Sidebar/index.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Sidebar from './index'
 import { ListItemType } from 'src/components/List'
 import { Icon } from '@gnosis.pm/safe-react-components'

--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import { Divider, IconText } from '@gnosis.pm/safe-react-components'
 

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react'
+import { useMemo, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, useRouteMatch } from 'react-router-dom'
 

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components'
 import { ListItemType } from 'src/components/List'
 

--- a/src/components/ButtonHelper/index.tsx
+++ b/src/components/ButtonHelper/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 const UnStyledButton = styled.button`

--- a/src/components/Collapse/index.tsx
+++ b/src/components/Collapse/index.tsx
@@ -1,8 +1,8 @@
+import { useState } from 'react'
 import CollapseMUI from '@material-ui/core/Collapse'
 import IconButton from '@material-ui/core/IconButton'
 import ExpandLess from '@material-ui/icons/ExpandLess'
 import ExpandMore from '@material-ui/icons/ExpandMore'
-import React from 'react'
 import styled from 'styled-components'
 
 const Wrapper = styled.div`
@@ -42,7 +42,7 @@ const Collapse: React.FC<CollapseProps> = ({
   collapseClassName,
   defaultExpanded = false,
 }): React.ReactElement => {
-  const [open, setOpen] = React.useState(defaultExpanded)
+  const [open, setOpen] = useState(defaultExpanded)
 
   const handleClick = () => {
     setOpen(!open)

--- a/src/components/ConnectButton/index.tsx
+++ b/src/components/ConnectButton/index.tsx
@@ -1,5 +1,5 @@
 import Onboard from 'bnc-onboard'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Button from 'src/components/layout/Button'
 import { getNetworkId, getNetworkName } from 'src/config'

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -1,7 +1,7 @@
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import { makeStyles } from '@material-ui/core/styles'
-import React, { ReactElement, useEffect, useRef, useState } from 'react'
+import { ReactElement, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import Button from 'src/components/layout/Button'
 import Link from 'src/components/layout/Link'

--- a/src/components/CustomIconText/index.tsx
+++ b/src/components/CustomIconText/index.tsx
@@ -1,5 +1,5 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 type Props = {
   address: string

--- a/src/components/Divider/divider.stories.tsx
+++ b/src/components/Divider/divider.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Divider from './index'
 
 export default {

--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { Icon, Divider as DividerSRC } from '@gnosis.pm/safe-react-components'
 

--- a/src/components/FlexSpacer/index.tsx
+++ b/src/components/FlexSpacer/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 // This component is used to create an empty div element to use inside a flex container.
 // It can be added into a flex component and use to justify content leaving space around with easier alignment rules.
 const FlexSpacer = (): React.ReactElement => <div></div>

--- a/src/components/GlobalErrorBoundary/index.tsx
+++ b/src/components/GlobalErrorBoundary/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import { Text, Link, Icon, FixedIcon, Title } from '@gnosis.pm/safe-react-components'
 import { IS_PRODUCTION } from 'src/utils/constants'

--- a/src/components/InfiniteScroll/index.tsx
+++ b/src/components/InfiniteScroll/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, forwardRef, MutableRefObject, ReactElement, ReactNode, useEffect, useState } from 'react'
+import { createContext, forwardRef, MutableRefObject, ReactElement, ReactNode, useEffect, useState } from 'react'
 import { InViewHookResponse, useInView } from 'react-intersection-observer'
 
 export const INFINITE_SCROLL_CONTAINER = 'infinite-scroll-container'

--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import { Icon, IconTypes } from '@gnosis.pm/safe-react-components'
 

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,5 +1,5 @@
 import Badge from '@material-ui/core/Badge'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Link, useHistory } from 'react-router-dom'
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'

--- a/src/components/List/list.stories.tsx
+++ b/src/components/List/list.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import List, { ListItemType } from '.'
 import ListIcon from './ListIcon'
 

--- a/src/components/ListContentLayout/List.tsx
+++ b/src/components/ListContentLayout/List.tsx
@@ -1,6 +1,6 @@
 import { withStyles } from '@material-ui/core/styles'
 import cn from 'classnames'
-import React from 'react'
+
 import styled from 'styled-components'
 
 // TODO: move these styles to a generic place

--- a/src/components/Modal/index.stories.tsx
+++ b/src/components/Modal/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 
 import TextField from 'src/components/forms/TextField'
 import GnoField from 'src/components/forms/Field'

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, Loader, theme, Title as TitleSRC } from '@gnosis.pm/safe-react-components'
 import { ButtonProps as ButtonPropsMUI, Modal as ModalMUI } from '@material-ui/core'
 import cn from 'classnames'
-import React, { ReactElement, ReactNode, ReactNodeArray } from 'react'
+import { ReactElement, ReactNode, ReactNodeArray } from 'react'
 import styled from 'styled-components'
 
 type Theme = typeof theme

--- a/src/components/ModalTitle/index.tsx
+++ b/src/components/ModalTitle/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { MuiThemeProvider, Theme as MuiTheme } from '@material-ui/core/styles'
 import { ConnectedRouter } from 'connected-react-router'
 import { Provider } from 'react-redux'

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -1,5 +1,5 @@
 import { theme as styledTheme, Loader } from '@gnosis.pm/safe-react-components'
-import React from 'react'
+
 import * as Sentry from '@sentry/react'
 
 import { LoadingContainer } from 'src/components/LoaderContainer'

--- a/src/components/SafeListSidebar/AddSafeButton.tsx
+++ b/src/components/SafeListSidebar/AddSafeButton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import Fab from '@material-ui/core/Fab'

--- a/src/components/SafeListSidebar/SafeList/AddressWrapper.tsx
+++ b/src/components/SafeListSidebar/SafeList/AddressWrapper.tsx
@@ -1,6 +1,6 @@
 import { EthHashInfo, Text } from '@gnosis.pm/safe-react-components'
 import { makeStyles } from '@material-ui/core/styles'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { SafeRecordWithNames } from 'src/logic/safe/store/selectors'
 import { formatAmount } from 'src/logic/tokens/utils/formatAmount'

--- a/src/components/SafeListSidebar/SafeList/OwnedAddress.tsx
+++ b/src/components/SafeListSidebar/SafeList/OwnedAddress.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath } from 'react-router-dom'
 import styled from 'styled-components'

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -1,8 +1,9 @@
+import { Fragment } from 'react'
 import MuiList from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import { makeStyles } from '@material-ui/core/styles'
 import { Icon } from '@gnosis.pm/safe-react-components'
-import React from 'react'
+
 import { generatePath } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -78,7 +79,7 @@ export const SafeList = ({ currentSafeAddress, onSafeClick, safes, ownedSafes }:
   return (
     <MuiList className={classes.list}>
       {safes.map((safe) => (
-        <React.Fragment key={safe.address}>
+        <Fragment key={safe.address}>
           <Link
             data-testid={SIDEBAR_SAFELIST_ROW_TESTID}
             onClick={onSafeClick}
@@ -92,19 +93,19 @@ export const SafeList = ({ currentSafeAddress, onSafeClick, safes, ownedSafes }:
             </ListItem>
           </Link>
           <Hairline />
-        </React.Fragment>
+        </Fragment>
       ))}
 
       {ownedSafes.length > 0 && (
         <ListItem classes={{ root: classes.listItemCollapse }}>
           <Collapse title={`All owned Safes (${ownedSafes.length})`} defaultExpanded={ownedSafesExpanded}>
             {ownedSafes.map((address: string) => (
-              <React.Fragment key={address}>
+              <Fragment key={address}>
                 <OwnedAddress address={address} onClick={onSafeClick} isAdded={isAddressAdded(safes, address)}>
                   {getLink(address)}
                 </OwnedAddress>
                 <Hairline />
-              </React.Fragment>
+              </Fragment>
             ))}
           </Collapse>
         </ListItem>

--- a/src/components/SafeListSidebar/index.tsx
+++ b/src/components/SafeListSidebar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactElement } from 'react'
+import { useState, ReactElement, createContext } from 'react'
 import Drawer from '@material-ui/core/Drawer'
 import { useSelector } from 'react-redux'
 
@@ -13,7 +13,7 @@ import { safeAddressFromUrl } from 'src/logic/safe/store/selectors'
 import useOwnerSafes from 'src/logic/safe/hooks/useOwnerSafes'
 import AddSafeButton from 'src/components/SafeListSidebar/AddSafeButton'
 
-export const SafeListSidebarContext = React.createContext({
+export const SafeListSidebarContext = createContext({
   isOpen: false,
   toggleSidebar: () => {},
 })

--- a/src/components/ScanQRModal/ScanQRWrapper/index.tsx
+++ b/src/components/ScanQRModal/ScanQRWrapper/index.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles'
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 
 import QRIcon from 'src/assets/icons/qrcode.svg'
 import { ScanQRModal } from 'src/components/ScanQRModal'

--- a/src/components/Stepper/index.tsx
+++ b/src/components/Stepper/index.tsx
@@ -1,9 +1,10 @@
+import { Children } from 'react'
 import FormStep from '@material-ui/core/Step'
 import StepContent from '@material-ui/core/StepContent'
 import StepLabel from '@material-ui/core/StepLabel'
 import Stepper from '@material-ui/core/Stepper'
 import { makeStyles } from '@material-ui/core/styles'
-import React, { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { FormApi } from 'final-form'
 
 import Controls from './Controls'
@@ -71,7 +72,7 @@ function GnoStepper<V>(props: GnoStepperProps<V>): React.ReactElement {
   }, [props.initialValues])
 
   const getPageProps: any = (pages) => {
-    const aux: any = React.Children.toArray(pages)[page]
+    const aux: any = Children.toArray(pages)[page]
     return aux.props
   }
 
@@ -89,7 +90,7 @@ function GnoStepper<V>(props: GnoStepperProps<V>): React.ReactElement {
   const validate = (valuesToValidate) => {
     const { children } = props
 
-    const activePage: any = React.Children.toArray(children)[page]
+    const activePage: any = Children.toArray(children)[page]
     return activePage.props.validate ? activePage.props.validate(valuesToValidate) : {}
   }
 
@@ -106,7 +107,7 @@ function GnoStepper<V>(props: GnoStepperProps<V>): React.ReactElement {
     const finalValues = { ...formValues, ...pageInitialProps }
 
     setValues(finalValues)
-    setPage(Math.min(page + 1, React.Children.count(children) - 1))
+    setPage(Math.min(page + 1, Children.count(children) - 1))
   }
 
   const previous = () => {
@@ -120,7 +121,7 @@ function GnoStepper<V>(props: GnoStepperProps<V>): React.ReactElement {
 
   const handleSubmit = async (formValues) => {
     const { children, onSubmit } = props
-    const isLastPage = page === React.Children.count(children) - 1
+    const isLastPage = page === Children.count(children) - 1
     if (isLastPage) {
       return onSubmit(formValues)
     }

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 import { border } from 'src/theme/variables'

--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -5,7 +5,7 @@ import Row from 'src/components/layout/Row'
 import Paragraph from 'src/components/layout/Paragraph'
 import Img from 'src/components/layout/Img'
 import InfoIcon from 'src/assets/icons/info_red.svg'
-import React from 'react'
+
 import { useSelector } from 'react-redux'
 import { currentSafeThreshold } from 'src/logic/safe/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'

--- a/src/components/TransactionsFees/index.tsx
+++ b/src/components/TransactionsFees/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
 import Paragraph from 'src/components/layout/Paragraph'
 import { getNetworkInfo } from 'src/config'

--- a/src/components/WhenFieldChanges/index.tsx
+++ b/src/components/WhenFieldChanges/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { OnChange } from 'react-final-form-listeners'
 
 import GnoField from 'src/components/forms/Field'

--- a/src/components/forms/Field/index.tsx
+++ b/src/components/forms/Field/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Field } from 'react-final-form'
 
 // $FlowFixMe

--- a/src/components/forms/SelectField/index.tsx
+++ b/src/components/forms/SelectField/index.tsx
@@ -2,7 +2,6 @@ import FormControl from '@material-ui/core/FormControl'
 import FormHelperText from '@material-ui/core/FormHelperText'
 import InputLabel from '@material-ui/core/InputLabel'
 import Select from '@material-ui/core/Select'
-import React from 'react'
 
 const style = {
   minWidth: '100%',

--- a/src/components/forms/TextAreaField/index.tsx
+++ b/src/components/forms/TextAreaField/index.tsx
@@ -1,5 +1,5 @@
 import { createStyles, makeStyles } from '@material-ui/core/styles'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Field from 'src/components/forms/Field'
 import TextField from 'src/components/forms/TextField'

--- a/src/components/forms/TextField/index.tsx
+++ b/src/components/forms/TextField/index.tsx
@@ -1,6 +1,5 @@
 import MuiTextField from '@material-ui/core/TextField'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
-import React from 'react'
 
 import { lg } from 'src/theme/variables'
 

--- a/src/components/layout/Backdrop/index.tsx
+++ b/src/components/layout/Backdrop/index.tsx
@@ -1,6 +1,6 @@
 import Backdrop from '@material-ui/core/Backdrop'
 import { makeStyles } from '@material-ui/core/styles'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import ReactDOM from 'react-dom'
 
 const useStyles = makeStyles({

--- a/src/components/layout/Img/index.tsx
+++ b/src/components/layout/Img/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames/bind'
-import React, { ReactElement, ImgHTMLAttributes } from 'react'
+import { ReactElement, ImgHTMLAttributes } from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/layout/Page/index.tsx
+++ b/src/components/layout/Page/index.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames/bind'
-import React from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/components/layout/Paragraph/index.tsx
+++ b/src/components/layout/Paragraph/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames/bind'
-import React, { MouseEventHandler, CSSProperties, ReactElement, ReactNode } from 'react'
+import { MouseEventHandler, CSSProperties, ReactElement, ReactNode } from 'react'
 
 import styles from './index.module.scss'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import { BigNumber } from 'bignumber.js'
-import React from 'react'
 import ReactDOM from 'react-dom'
 import * as Sentry from '@sentry/react'
 import { Integrations } from '@sentry/tracing'

--- a/src/logic/notifications/store/actions/enqueueSnackbar.tsx
+++ b/src/logic/notifications/store/actions/enqueueSnackbar.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { AnyAction } from 'redux'
 import { ThunkAction } from 'redux-thunk'
 import { createAction } from 'redux-actions'

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
+import React from 'react'
 import { Loader } from '@gnosis.pm/safe-react-components'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
 

--- a/src/routes/load/components/DetailsForm/index.tsx
+++ b/src/routes/load/components/DetailsForm/index.tsx
@@ -1,7 +1,7 @@
 import InputAdornment from '@material-ui/core/InputAdornment'
 import { makeStyles } from '@material-ui/core/styles'
 import CheckCircle from '@material-ui/icons/CheckCircle'
-import React, { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { FormApi } from 'final-form'
 import { useParams } from 'react-router'
 

--- a/src/routes/load/components/Layout.tsx
+++ b/src/routes/load/components/Layout.tsx
@@ -1,6 +1,6 @@
 import IconButton from '@material-ui/core/IconButton'
 import ChevronLeft from '@material-ui/icons/ChevronLeft'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useParams } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 

--- a/src/routes/load/components/OwnerList/index.tsx
+++ b/src/routes/load/components/OwnerList/index.tsx
@@ -1,7 +1,7 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import { makeStyles } from '@material-ui/core/styles'
 import TableContainer from '@material-ui/core/TableContainer'
-import React, { ReactElement, ReactNode, useEffect, useState } from 'react'
+import { ReactElement, ReactNode, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import { getExplorerInfo } from 'src/config'

--- a/src/routes/load/components/ReviewInformation/index.tsx
+++ b/src/routes/load/components/ReviewInformation/index.tsx
@@ -1,6 +1,6 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import TableContainer from '@material-ui/core/TableContainer'
-import React, { Fragment, ReactElement, ReactNode } from 'react'
+import { Fragment, ReactElement, ReactNode } from 'react'
 
 import { getExplorerInfo } from 'src/config'
 import Block from 'src/components/layout/Block'

--- a/src/routes/load/container/Load.tsx
+++ b/src/routes/load/container/Load.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { generatePath } from 'react-router-dom'
 

--- a/src/routes/open/components/ReviewInformation/index.tsx
+++ b/src/routes/open/components/ReviewInformation/index.tsx
@@ -1,5 +1,5 @@
 import TableContainer from '@material-ui/core/TableContainer'
-import React, { ReactElement, useEffect, useMemo } from 'react'
+import { ReactElement, useEffect, useMemo, Fragment } from 'react'
 import { getExplorerInfo, getNetworkInfo } from 'src/config'
 import Block from 'src/components/layout/Block'
 import Col from 'src/components/layout/Col'
@@ -93,7 +93,7 @@ const ReviewComponent = ({ values, form }: ReviewComponentProps): ReactElement =
             </Block>
             <Hairline />
             {names.map((name, index) => (
-              <React.Fragment key={`name${index}`}>
+              <Fragment key={`name${index}`}>
                 <Row className={classes.owner}>
                   <Col align="center" xs={12} data-testid={`create-safe-owner-details-${index}`}>
                     <EthHashInfo
@@ -107,7 +107,7 @@ const ReviewComponent = ({ values, form }: ReviewComponentProps): ReactElement =
                   </Col>
                 </Row>
                 <Hairline />
-              </React.Fragment>
+              </Fragment>
             ))}
           </TableContainer>
         </Col>

--- a/src/routes/open/container/Open.tsx
+++ b/src/routes/open/container/Open.tsx
@@ -1,7 +1,7 @@
 import { Loader } from '@gnosis.pm/safe-react-components'
 import { backOff } from 'exponential-backoff'
 import queryString from 'query-string'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { generatePath, useLocation } from 'react-router-dom'
 import { TransactionReceipt } from 'web3-core'

--- a/src/routes/opening/components/Footer.tsx
+++ b/src/routes/opening/components/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, SyntheticEvent } from 'react'
+import { ReactElement, SyntheticEvent } from 'react'
 import styled from 'styled-components'
 
 import { Icon, Link, Loader, Text } from '@gnosis.pm/safe-react-components'

--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -1,5 +1,5 @@
 import { Loader, Stepper } from '@gnosis.pm/safe-react-components'
-import React, { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/AddressBook/CreateEditEntryModal/index.tsx
+++ b/src/routes/safe/components/AddressBook/CreateEditEntryModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 
 import { useStyles } from './style'

--- a/src/routes/safe/components/AddressBook/DeleteEntryModal/index.tsx
+++ b/src/routes/safe/components/AddressBook/DeleteEntryModal/index.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { Modal } from 'src/components/Modal'
 import GnoForm from 'src/components/forms/GnoForm'

--- a/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
+++ b/src/routes/safe/components/AddressBook/EllipsisTransactionDetails/index.tsx
@@ -1,10 +1,11 @@
+import { useState } from 'react'
 import { ClickAwayListener, createStyles, Divider } from '@material-ui/core'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import { makeStyles } from '@material-ui/core/styles'
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz'
 import { push } from 'connected-react-router'
-import React from 'react'
+
 import { useDispatch, useSelector } from 'react-redux'
 import { generatePath } from 'react-router-dom'
 
@@ -47,7 +48,7 @@ export const EllipsisTransactionDetails = ({
   sendModalOpenHandler,
 }: EllipsisTransactionDetailsProps): React.ReactElement => {
   const classes = useStyles()
-  const [anchorEl, setAnchorEl] = React.useState(null)
+  const [anchorEl, setAnchorEl] = useState(null)
 
   const dispatch = useDispatch()
   const currentSafeAddress = useSelector(safeAddressFromUrl)

--- a/src/routes/safe/components/AddressBook/ExportEntriesModal/index.tsx
+++ b/src/routes/safe/components/AddressBook/ExportEntriesModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { format } from 'date-fns'
 import { useSelector, useDispatch } from 'react-redux'
 import { CSVDownloader, jsonToCSV } from 'react-papaparse'

--- a/src/routes/safe/components/AddressBook/HelpInfo/index.tsx
+++ b/src/routes/safe/components/AddressBook/HelpInfo/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { Text, Link, Icon } from '@gnosis.pm/safe-react-components'
 

--- a/src/routes/safe/components/AddressBook/ImportEntriesModal/index.tsx
+++ b/src/routes/safe/components/AddressBook/ImportEntriesModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 
 import styled from 'styled-components'
 import { Text } from '@gnosis.pm/safe-react-components'

--- a/src/routes/safe/components/AddressBook/index.tsx
+++ b/src/routes/safe/components/AddressBook/index.tsx
@@ -15,7 +15,7 @@ import TableRow from '@material-ui/core/TableRow'
 import { makeStyles } from '@material-ui/core/styles'
 import cn from 'classnames'
 import styled from 'styled-components'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { styles } from './style'

--- a/src/routes/safe/components/Apps/components/AddAppForm/AppAgreement.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/AppAgreement.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, Text } from '@gnosis.pm/safe-react-components'
-import React from 'react'
+
 import { useFormState } from 'react-final-form'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Apps/components/AddAppForm/AppUrl.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/AppUrl.tsx
@@ -1,6 +1,6 @@
+import { useEffect } from 'react'
 import { TextField } from '@gnosis.pm/safe-react-components'
 import createDecorator from 'final-form-calculate'
-import React from 'react'
 import { useField, useFormState } from 'react-final-form'
 import styled from 'styled-components'
 
@@ -42,7 +42,7 @@ export const AppInfoUpdater = ({ onAppInfo, onLoading, onError }: AppInfoUpdater
 
   const debouncedValue = useDebounce(appUrl, 500)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const updateAppInfo = async () => {
       onLoading(true)
 

--- a/src/routes/safe/components/Apps/components/AddAppForm/FormButtons.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/FormButtons.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react'
+import { ReactElement, useMemo } from 'react'
 import { useFormState } from 'react-final-form'
 
 import { Modal } from 'src/components/Modal'

--- a/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
@@ -1,5 +1,5 @@
 import { Icon, Link, Loader, Text, TextField } from '@gnosis.pm/safe-react-components'
-import React, { useState, ReactElement, useCallback, useEffect } from 'react'
+import { useState, ReactElement, useCallback, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, useHistory } from 'react-router-dom'
 import styled from 'styled-components'

--- a/src/routes/safe/components/Apps/components/AppCard/index.stories.tsx
+++ b/src/routes/safe/components/Apps/components/AppCard/index.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import AppCard from './index'
 
 import AddAppIcon from 'src/routes/safe/components/Apps/assets/addApp.svg'

--- a/src/routes/safe/components/Apps/components/AppCard/index.tsx
+++ b/src/routes/safe/components/Apps/components/AppCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from 'react'
+import { SyntheticEvent } from 'react'
 import styled from 'styled-components'
 import { alpha } from '@material-ui/core/styles/colorManipulator'
 import { Title, Text, Button, Card } from '@gnosis.pm/safe-react-components'

--- a/src/routes/safe/components/Apps/components/AppsList.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.tsx
@@ -1,6 +1,6 @@
 import { IconText, Loader, Menu, Text, Icon, Breadcrumb, BreadcrumbElement } from '@gnosis.pm/safe-react-components'
 import IconButton from '@material-ui/core/IconButton'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Link, generatePath } from 'react-router-dom'
 import styled, { css } from 'styled-components'

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/DecodedTxDetail.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/DecodedTxDetail.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import { getNetworkInfo } from 'src/config'

--- a/src/routes/safe/components/Apps/components/LegalDisclaimer.tsx
+++ b/src/routes/safe/components/Apps/components/LegalDisclaimer.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { FixedDialog, Text } from '@gnosis.pm/safe-react-components'
 
 interface OwnProps {

--- a/src/routes/safe/components/Apps/index.tsx
+++ b/src/routes/safe/components/Apps/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSafeAppUrl } from 'src/logic/hooks/useSafeAppUrl'
 
 import AppFrame from './components/AppFrame'

--- a/src/routes/safe/components/Balances/Coins/index.tsx
+++ b/src/routes/safe/components/Balances/Coins/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 import { useSelector } from 'react-redux'
 import { List } from 'immutable'

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { useEffect, Fragment, useState } from 'react'
 import Card from '@material-ui/core/Card'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import { useSelector } from 'react-redux'
@@ -80,8 +80,8 @@ const useStyles = makeStyles(
 const Collectibles = (): React.ReactElement => {
   const { trackEvent } = useAnalytics()
   const classes = useStyles()
-  const [selectedToken, setSelectedToken] = React.useState<NFTToken | undefined>()
-  const [sendNFTsModalOpen, setSendNFTsModalOpen] = React.useState(false)
+  const [selectedToken, setSelectedToken] = useState<NFTToken | undefined>()
+  const [sendNFTsModalOpen, setSendNFTsModalOpen] = useState(false)
 
   const nftTokens = useSelector(orderedNFTAssets)
   const nftAssetsFromNftTokens = useSelector(nftAssetsFromNftTokensSelector)
@@ -107,7 +107,7 @@ const Collectibles = (): React.ReactElement => {
         {nftAssetsFromNftTokens.length > 0 &&
           nftAssetsFromNftTokens.map((nftAsset) => {
             return (
-              <React.Fragment key={nftAsset.slug}>
+              <Fragment key={nftAsset.slug}>
                 <div className={classes.title}>
                   <div className={classes.titleImg} style={{ backgroundImage: `url(${nftAsset.image || ''})` }} />
                   <h2 className={classes.titleText}>{nftAsset.name}</h2>
@@ -124,7 +124,7 @@ const Collectibles = (): React.ReactElement => {
                       />
                     ))}
                 </div>
-              </React.Fragment>
+              </Fragment>
             )
           })}
       </div>

--- a/src/routes/safe/components/Balances/SendModal/SafeInfo/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/SafeInfo/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import styled from 'styled-components'

--- a/src/routes/safe/components/Balances/SendModal/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/index.tsx
@@ -1,6 +1,6 @@
 import { Loader } from '@gnosis.pm/safe-react-components'
 import { makeStyles } from '@material-ui/core/styles'
-import React, { Suspense, useEffect, useState } from 'react'
+import { Suspense, useEffect, useState, lazy } from 'react'
 
 import Modal from 'src/components/Modal'
 import { CollectibleTx } from './screens/ReviewCollectible'
@@ -12,23 +12,23 @@ import { NFTToken } from 'src/logic/collectibles/sources/collectibles.d'
 import { SendCollectibleTxInfo } from './screens/SendCollectible'
 import { Erc721Transfer } from '@gnosis.pm/safe-react-gateway-sdk'
 
-const ChooseTxType = React.lazy(() => import('./screens/ChooseTxType'))
+const ChooseTxType = lazy(() => import('./screens/ChooseTxType'))
 
-const SendFunds = React.lazy(() => import('./screens/SendFunds'))
+const SendFunds = lazy(() => import('./screens/SendFunds'))
 
-const SendCollectible = React.lazy(() => import('./screens/SendCollectible'))
+const SendCollectible = lazy(() => import('./screens/SendCollectible'))
 
-const ReviewCollectible = React.lazy(() => import('./screens/ReviewCollectible'))
+const ReviewCollectible = lazy(() => import('./screens/ReviewCollectible'))
 
-const ReviewSendFundsTx = React.lazy(() => import('./screens/ReviewSendFundsTx'))
+const ReviewSendFundsTx = lazy(() => import('./screens/ReviewSendFundsTx'))
 
-const ContractInteraction = React.lazy(() => import('./screens/ContractInteraction'))
+const ContractInteraction = lazy(() => import('./screens/ContractInteraction'))
 
-const ContractInteractionReview: any = React.lazy(() => import('./screens/ContractInteraction/Review'))
+const ContractInteractionReview: any = lazy(() => import('./screens/ContractInteraction/Review'))
 
-const SendCustomTx = React.lazy(() => import('./screens/ContractInteraction/SendCustomTx'))
+const SendCustomTx = lazy(() => import('./screens/ContractInteraction/SendCustomTx'))
 
-const ReviewCustomTx = React.lazy(() => import('./screens/ContractInteraction/ReviewCustomTx'))
+const ReviewCustomTx = lazy(() => import('./screens/ContractInteraction/ReviewCustomTx'))
 
 const useStyles = makeStyles({
   loaderStyle: {

--- a/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/AddressBookInput/index.tsx
@@ -1,7 +1,7 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import MuiTextField from '@material-ui/core/TextField'
 import Autocomplete, { AutocompleteProps } from '@material-ui/lab/Autocomplete'
-import React, { Dispatch, ReactElement, SetStateAction, useEffect, useState } from 'react'
+import { Dispatch, ReactElement, SetStateAction, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import { mustBeEthereumAddress, mustBeEthereumContractAddress } from 'src/components/forms/validator'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Buttons/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Buttons/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useField, useFormState } from 'react-final-form'
 
 import { ButtonStatus, Modal } from 'src/components/Modal'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ContractABI/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ContractABI/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { useField, useForm } from 'react-final-form'
+import { useRef, useEffect } from 'react'
 
 import { TextAreaField } from 'src/components/forms/TextAreaField'
 import { mustBeEthereumAddress, mustBeEthereumContractAddress } from 'src/components/forms/validator'
@@ -27,9 +27,9 @@ const ContractABI = (): React.ReactElement => {
     input: { value: contractAddress },
   } = useField('contractAddress', { subscription: { value: true } })
   const { mutators } = useForm()
-  const setAbiValue = React.useRef(mutators.setAbiValue)
+  const setAbiValue = useRef(mutators.setAbiValue)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const validateAndSetAbi = async () => {
       const isEthereumAddress = mustBeEthereumAddress(contractAddress) === undefined
       const isEthereumContractAddress = (await mustBeEthereumContractAddress(contractAddress)) === undefined

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/EthAddressInput/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/EthAddressInput/index.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useFormState, useField } from 'react-final-form'
 
 import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/FormErrorMessage/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/FormErrorMessage/index.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles'
-import React from 'react'
+
 import { useFormState } from 'react-final-form'
 
 import Row from 'src/components/layout/Row'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Header/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Header/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/MethodsDropdown/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/MethodsDropdown/index.tsx
@@ -6,7 +6,7 @@ import MenuItem from '@material-ui/core/MenuItem'
 import { MuiThemeProvider } from '@material-ui/core/styles'
 import SearchIcon from '@material-ui/icons/Search'
 import classNames from 'classnames'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useField, useFormState } from 'react-final-form'
 import { AbiItem } from 'web3-utils'
 

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/NativeCoinValue/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/NativeCoinValue/index.tsx
@@ -1,6 +1,6 @@
 import InputAdornment from '@material-ui/core/InputAdornment'
 import { makeStyles } from '@material-ui/core/styles'
-import React from 'react'
+
 import { useField } from 'react-final-form'
 import { useSelector } from 'react-redux'
 

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderInputParams/InputComponent/ArrayTypeInput.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderInputParams/InputComponent/ArrayTypeInput.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { TextAreaField } from 'src/components/forms/TextAreaField'
 import {
   isAddress,

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderInputParams/InputComponent/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderInputParams/InputComponent/index.tsx
@@ -1,5 +1,5 @@
 import { Checkbox } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Col from 'src/components/layout/Col'
 import Field from 'src/components/forms/Field'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderInputParams/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderInputParams/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useField } from 'react-final-form'
 
 import Row from 'src/components/layout/Row'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderOutputParams/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/RenderOutputParams/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useField } from 'react-final-form'
 import { makeStyles } from '@material-ui/core/styles'
 import TextField from 'src/components/forms/TextField'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
@@ -1,5 +1,5 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState, Fragment } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -197,7 +197,7 @@ const ContractInteractionReview = ({ onClose, onPrev, tx }: Props): React.ReactE
               const value: string = getValueFromTxInputs(key, type, tx)
 
               return (
-                <React.Fragment key={key}>
+                <Fragment key={key}>
                   <Row margin="xs">
                     <Paragraph color="disabled" noMargin size="md" style={{ letterSpacing: '-0.5px' }}>
                       {name} ({type})
@@ -208,7 +208,7 @@ const ContractInteractionReview = ({ onClose, onPrev, tx }: Props): React.ReactE
                       {value}
                     </Paragraph>
                   </Row>
-                </React.Fragment>
+                </Fragment>
               )
             })}
             <Row margin="xs">

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/SendCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/SendCustomTx/index.tsx
@@ -1,5 +1,5 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { useSelector } from 'react-redux'
 import IconButton from '@material-ui/core/IconButton'
 import InputAdornment from '@material-ui/core/InputAdornment'

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/index.tsx
@@ -1,7 +1,8 @@
 import { makeStyles } from '@material-ui/core/styles'
-import React from 'react'
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import Switch from '@material-ui/core/Switch'
+
 import { styles } from './style'
 import Divider from 'src/components/Divider'
 import GnoForm from 'src/components/forms/GnoForm'
@@ -56,7 +57,7 @@ const ContractInteraction: React.FC<ContractInteractionProps> = ({
   const safeAddress = useSelector(safeAddressFromUrl)
   let setCallResults
 
-  React.useMemo(() => {
+  useMemo(() => {
     if (contractAddress) {
       initialValues.contractAddress = contractAddress
     }

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
-import React, { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 

--- a/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/CollectibleSelectField/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/CollectibleSelectField/index.tsx
@@ -2,7 +2,6 @@ import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import MenuItem from '@material-ui/core/MenuItem'
 import { makeStyles } from '@material-ui/core/styles'
-import React from 'react'
 
 import { selectStyles, selectedTokenStyles } from './style'
 

--- a/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/TokenSelectField/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/TokenSelectField/index.tsx
@@ -2,7 +2,6 @@ import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import MenuItem from '@material-ui/core/MenuItem'
 import { makeStyles } from '@material-ui/core/styles'
-import React from 'react'
 
 import { selectStyles, selectedTokenStyles } from './style'
 

--- a/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/index.tsx
@@ -2,7 +2,7 @@ import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
-import React, { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
 import Divider from 'src/components/Divider'
@@ -95,7 +95,7 @@ const SendCollectible = ({
   const [pristine, setPristine] = useState(true)
   const [isValidAddress, setIsValidAddress] = useState(false)
 
-  React.useMemo(() => {
+  useMemo(() => {
     if (selectedEntry === null && pristine) {
       setPristine(false)
     }

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/SpendingLimitRow.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/SpendingLimitRow.tsx
@@ -1,6 +1,6 @@
 import { RadioButtons, Text } from '@gnosis.pm/safe-react-components'
 import { BigNumber } from 'bignumber.js'
-import React, { ReactElement, useMemo } from 'react'
+import { ReactElement, useMemo } from 'react'
 import { useForm } from 'react-final-form'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/TokenSelectField/index.tsx
@@ -3,7 +3,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import MenuItem from '@material-ui/core/MenuItem'
 import { List } from 'immutable'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Field from 'src/components/forms/Field'
 import SelectField from 'src/components/forms/SelectField'

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -3,7 +3,7 @@ import InputAdornment from '@material-ui/core/InputAdornment'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
 import { BigNumber } from 'bignumber.js'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import { getExplorerInfo } from 'src/config'

--- a/src/routes/safe/components/Balances/index.tsx
+++ b/src/routes/safe/components/Balances/index.tsx
@@ -1,5 +1,5 @@
 import { Breadcrumb, BreadcrumbElement, Menu } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState, lazy } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
 
@@ -15,8 +15,8 @@ import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import { FEATURES } from 'src/config/networks/network.d'
 
-const Collectibles = React.lazy(() => import('src/routes/safe/components/Balances/Collectibles'))
-const Coins = React.lazy(() => import('src/routes/safe/components/Balances/Coins'))
+const Collectibles = lazy(() => import('src/routes/safe/components/Balances/Collectibles'))
+const Coins = lazy(() => import('src/routes/safe/components/Balances/Coins'))
 
 export const MANAGE_TOKENS_BUTTON_TEST_ID = 'manage-tokens-btn'
 export const BALANCE_ROW_TEST_ID = 'balance-row'

--- a/src/routes/safe/components/CurrencyDropdown/index.tsx
+++ b/src/routes/safe/components/CurrencyDropdown/index.tsx
@@ -6,7 +6,7 @@ import MenuItem from '@material-ui/core/MenuItem'
 import { MuiThemeProvider } from '@material-ui/core/styles'
 import SearchIcon from '@material-ui/icons/Search'
 import classNames from 'classnames'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import CheckIcon from './img/check.svg'

--- a/src/routes/safe/components/Settings/Advanced/ModulesTable.tsx
+++ b/src/routes/safe/components/Settings/Advanced/ModulesTable.tsx
@@ -1,7 +1,8 @@
 import { Icon, EthHashInfo } from '@gnosis.pm/safe-react-components'
 import TableContainer from '@material-ui/core/TableContainer'
 import cn from 'classnames'
-import React from 'react'
+import { useState, Fragment } from 'react'
+
 import { useSelector } from 'react-redux'
 
 import { generateColumns, ModuleAddressColumn, MODULES_TABLE_ADDRESS_ID } from './dataFetcher'
@@ -32,10 +33,10 @@ export const ModulesTable = ({ moduleData }: ModulesTableProps): React.ReactElem
 
   const granted = useSelector(grantedSelector)
 
-  const [viewRemoveModuleModal, setViewRemoveModuleModal] = React.useState(false)
+  const [viewRemoveModuleModal, setViewRemoveModuleModal] = useState(false)
   const hideRemoveModuleModal = () => setViewRemoveModuleModal(false)
 
-  const [selectedModulePair, setSelectedModulePair] = React.useState<ModulePair>()
+  const [selectedModulePair, setSelectedModulePair] = useState<ModulePair>()
   const triggerRemoveSelectedModule = (modulePair: ModulePair): void => {
     setSelectedModulePair(modulePair)
     setViewRemoveModuleModal(true)
@@ -68,7 +69,7 @@ export const ModulesTable = ({ moduleData }: ModulesTableProps): React.ReactElem
                   const [, moduleAddress] = rowElement
 
                   return (
-                    <React.Fragment key={`${columnId}-${index}`}>
+                    <Fragment key={`${columnId}-${index}`}>
                       <TableCell align={column.align} component="td" key={columnId}>
                         {columnId === MODULES_TABLE_ADDRESS_ID ? (
                           <Block justify="left">
@@ -95,7 +96,7 @@ export const ModulesTable = ({ moduleData }: ModulesTableProps): React.ReactElem
                           )}
                         </Row>
                       </TableCell>
-                    </React.Fragment>
+                    </Fragment>
                   )
                 })}
               </TableRow>

--- a/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
@@ -2,7 +2,7 @@ import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
 import cn from 'classnames'
-import React, { ReactElement, useMemo, useState } from 'react'
+import { ReactElement, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Block from 'src/components/layout/Block'

--- a/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
@@ -2,7 +2,7 @@ import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
 import cn from 'classnames'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Block from 'src/components/layout/Block'

--- a/src/routes/safe/components/Settings/Advanced/TransactionGuard.tsx
+++ b/src/routes/safe/components/Settings/Advanced/TransactionGuard.tsx
@@ -1,7 +1,7 @@
 import { Icon, EthHashInfo } from '@gnosis.pm/safe-react-components'
 import TableContainer from '@material-ui/core/TableContainer'
 import cn from 'classnames'
-import React from 'react'
+import { useState, Fragment } from 'react'
 import { useSelector } from 'react-redux'
 
 import { generateColumns } from './dataFetcher'
@@ -31,7 +31,7 @@ export const TransactionGuard = ({ address }: TransactionGuardProps): React.Reac
 
   const granted = useSelector(grantedSelector)
 
-  const [viewRemoveGuardModal, setViewRemoveGuardModal] = React.useState(false)
+  const [viewRemoveGuardModal, setViewRemoveGuardModal] = useState(false)
   const hideRemoveGuardModal = () => setViewRemoveGuardModal(false)
 
   const triggerRemoveSelectedGuard = (): void => {
@@ -53,7 +53,7 @@ export const TransactionGuard = ({ address }: TransactionGuardProps): React.Reac
                 {autoColumns.map((column, index) => {
                   const columnId = column.id
                   return (
-                    <React.Fragment key={`${columnId}-${index}`}>
+                    <Fragment key={`${columnId}-${index}`}>
                       <TableCell align={column.align} component="td" key={columnId}>
                         <Block justify="left">
                           <EthHashInfo hash={row} showCopyBtn showAvatar explorerUrl={getExplorerInfo(row)} />
@@ -68,7 +68,7 @@ export const TransactionGuard = ({ address }: TransactionGuardProps): React.Reac
                           )}
                         </Row>
                       </TableCell>
-                    </React.Fragment>
+                    </Fragment>
                   )
                 })}
               </TableRow>

--- a/src/routes/safe/components/Settings/Advanced/index.tsx
+++ b/src/routes/safe/components/Settings/Advanced/index.tsx
@@ -1,5 +1,5 @@
 import { Text, theme, Title } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, useEffect } from 'react'
+import { ReactElement, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Modal from 'src/components/Modal'

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/OwnerForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/OwnerForm/index.tsx
@@ -2,7 +2,7 @@ import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
 import { Mutator } from 'final-form'
-import React from 'react'
+
 import { useSelector } from 'react-redux'
 import { OnChange } from 'react-final-form-listeners'
 

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState, Fragment } from 'react'
 import { useSelector } from 'react-redux'
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 
@@ -164,7 +164,7 @@ export const ReviewAddOwner = ({ onClickBack, onClose, onSubmit, values }: Revie
                 </Row>
                 <Hairline />
                 {owners?.map((owner) => (
-                  <React.Fragment key={owner.address}>
+                  <Fragment key={owner.address}>
                     <Row className={classes.owner}>
                       <Col align="center" xs={12}>
                         <EthHashInfo
@@ -177,7 +177,7 @@ export const ReviewAddOwner = ({ onClickBack, onClose, onSubmit, values }: Revie
                       </Col>
                     </Row>
                     <Hairline />
-                  </React.Fragment>
+                  </Fragment>
                 ))}
                 <Row align="center" className={classes.info}>
                   <Paragraph color="primary" noMargin size="md" weight="bolder">

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/ThresholdForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/ThresholdForm/index.tsx
@@ -2,7 +2,7 @@ import IconButton from '@material-ui/core/IconButton'
 import MenuItem from '@material-ui/core/MenuItem'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 
 import { styles } from './style'

--- a/src/routes/safe/components/Settings/ManageOwners/EditOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/EditOwnerModal/index.tsx
@@ -1,6 +1,6 @@
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React from 'react'
+
 import { useDispatch } from 'react-redux'
 
 import Field from 'src/components/forms/Field'

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { OwnerData } from 'src/routes/safe/components/Settings/ManageOwners/dataFetcher'
 

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/CheckOwner/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/CheckOwner/index.tsx
@@ -1,6 +1,6 @@
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Block from 'src/components/layout/Block'
 import Col from 'src/components/layout/Col'

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
@@ -1,6 +1,6 @@
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState, Fragment } from 'react'
 import { useSelector } from 'react-redux'
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 
@@ -184,7 +184,7 @@ export const ReviewRemoveOwnerModal = ({
                 {owners?.map(
                   (safeOwner) =>
                     !sameAddress(safeOwner.address, owner.address) && (
-                      <React.Fragment key={safeOwner.address}>
+                      <Fragment key={safeOwner.address}>
                         <Row className={classes.owner}>
                           <Col align="center" xs={12}>
                             <EthHashInfo
@@ -197,7 +197,7 @@ export const ReviewRemoveOwnerModal = ({
                           </Col>
                         </Row>
                         <Hairline />
-                      </React.Fragment>
+                      </Fragment>
                     ),
                 )}
                 <Row align="center" className={classes.info}>

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/ThresholdForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/ThresholdForm/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@material-ui/core/IconButton'
 import MenuItem from '@material-ui/core/MenuItem'
 import Close from '@material-ui/icons/Close'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 
 import { useStyles } from './style'

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Modal from 'src/components/Modal'

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/OwnerForm/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/OwnerForm/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
 import { Mutator } from 'final-form'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 import { OnChange } from 'react-final-form-listeners'
 

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
@@ -1,6 +1,6 @@
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState, Fragment } from 'react'
 import { useSelector } from 'react-redux'
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 
@@ -172,7 +172,7 @@ export const ReviewReplaceOwnerModal = ({
                 {owners?.map(
                   (safeOwner) =>
                     !sameAddress(safeOwner.address, owner.address) && (
-                      <React.Fragment key={safeOwner.address}>
+                      <Fragment key={safeOwner.address}>
                         <Row className={classes.owner}>
                           <Col align="center" xs={12}>
                             <EthHashInfo
@@ -185,7 +185,7 @@ export const ReviewReplaceOwnerModal = ({
                           </Col>
                         </Row>
                         <Hairline />
-                      </React.Fragment>
+                      </Fragment>
                     ),
                 )}
                 <Row align="center" className={classes.info}>

--- a/src/routes/safe/components/Settings/ManageOwners/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactElement } from 'react'
+import { useState, useEffect, ReactElement } from 'react'
 import { EthHashInfo, Icon } from '@gnosis.pm/safe-react-components'
 import TableCell from '@material-ui/core/TableCell'
 import TableContainer from '@material-ui/core/TableContainer'

--- a/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
@@ -1,7 +1,7 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React from 'react'
+
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useStyles } from './style'

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -1,6 +1,6 @@
 import { Icon, Link, Text } from '@gnosis.pm/safe-react-components'
 import { makeStyles } from '@material-ui/core/styles'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Settings/SpendingLimit/FormFields/Amount.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/FormFields/Amount.tsx
@@ -1,5 +1,5 @@
 import { TextField as SRCTextField } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useField } from 'react-final-form'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'

--- a/src/routes/safe/components/Settings/SpendingLimit/FormFields/Beneficiary.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/FormFields/Beneficiary.tsx
@@ -1,5 +1,5 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React, { KeyboardEvent, ReactElement, useEffect, useState } from 'react'
+import { KeyboardEvent, ReactElement, useEffect, useState } from 'react'
 import { useForm, useFormState } from 'react-final-form'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'

--- a/src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime.tsx
@@ -1,6 +1,6 @@
 import { RadioButtons, Text } from '@gnosis.pm/safe-react-components'
 import { FormControlLabel, hexToRgb, Switch as SwitchMui } from '@material-ui/core'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useField } from 'react-final-form'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Settings/SpendingLimit/FormFields/Token.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/FormFields/Token.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/AddressInfo.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/AddressInfo.tsx
@@ -1,5 +1,5 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 
 import { getExplorerInfo } from 'src/config'

--- a/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/DataDisplay.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/DataDisplay.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 interface GenericInfoProps {
   title?: string

--- a/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/ResetTimeInfo.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/ResetTimeInfo.tsx
@@ -1,5 +1,5 @@
 import { IconText, Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Row from 'src/components/layout/Row'
 

--- a/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/TokenInfo.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/InfoDisplay/TokenInfo.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import { Token } from 'src/logic/tokens/store/model/token'

--- a/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/SpentVsAmount.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/SpentVsAmount.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, useMemo } from 'react'
+import { ReactElement, useMemo } from 'react'
 import styled from 'styled-components'
 
 import { Token } from 'src/logic/tokens/store/model/token'

--- a/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/index.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/LimitsTable/index.tsx
@@ -1,7 +1,7 @@
 import { Text, Icon } from '@gnosis.pm/safe-react-components'
 import TableContainer from '@material-ui/core/TableContainer'
 import cn from 'classnames'
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import ButtonHelper from 'src/components/ButtonHelper'

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Create.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Create.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@gnosis.pm/safe-react-components'
 import { FormState, Mutator } from 'final-form'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import GnoForm from 'src/components/forms/GnoForm'

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, useEffect, useMemo, useState } from 'react'
+import { ReactElement, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Col from 'src/components/layout/Col'

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/index.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/index.tsx
@@ -1,5 +1,5 @@
 import { List } from 'immutable'
-import React, { ReactElement, Reducer, useCallback, useReducer } from 'react'
+import { ReactElement, Reducer, useCallback, useReducer } from 'react'
 import { useSelector } from 'react-redux'
 
 import { Modal } from 'src/components/Modal'

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitSteps.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitSteps.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import Img from 'src/components/layout/Img'

--- a/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Col from 'src/components/layout/Col'

--- a/src/routes/safe/components/Settings/SpendingLimit/index.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Text, Title } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
+++ b/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@material-ui/core/IconButton'
 import MenuItem from '@material-ui/core/MenuItem'
 import Close from '@material-ui/icons/Close'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Field from 'src/components/forms/Field'

--- a/src/routes/safe/components/Settings/ThresholdSettings/index.tsx
+++ b/src/routes/safe/components/Settings/ThresholdSettings/index.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles'
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 
 import Modal from 'src/components/Modal'

--- a/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
@@ -1,7 +1,7 @@
 import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 
 import { useStyles } from './style'

--- a/src/routes/safe/components/Settings/assets/icons/OwnersIcon.tsx
+++ b/src/routes/safe/components/Settings/assets/icons/OwnersIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const OwnersIcon = () => (
   <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">

--- a/src/routes/safe/components/Settings/assets/icons/RequiredConfirmationsIcon.tsx
+++ b/src/routes/safe/components/Settings/assets/icons/RequiredConfirmationsIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const RequiredConfirmationsIcon = () => (
   <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">

--- a/src/routes/safe/components/Settings/assets/icons/SafeDetailsIcon.tsx
+++ b/src/routes/safe/components/Settings/assets/icons/SafeDetailsIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const SafeDetailsIcon = () => (
   <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">

--- a/src/routes/safe/components/Settings/index.tsx
+++ b/src/routes/safe/components/Settings/index.tsx
@@ -1,7 +1,7 @@
 import { Breadcrumb, BreadcrumbElement, Loader, Icon, Menu } from '@gnosis.pm/safe-react-components'
 import { LoadingContainer } from 'src/components/LoaderContainer'
 import { makeStyles } from '@material-ui/core/styles'
-import React, { useState } from 'react'
+import { useState, lazy } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, Route, Switch, useRouteMatch } from 'react-router-dom'
 
@@ -15,12 +15,12 @@ import Span from 'src/components/layout/Span'
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 
-const Advanced = React.lazy(() => import('./Advanced'))
-const SpendingLimitSettings = React.lazy(() => import('./SpendingLimit'))
-const ManageOwners = React.lazy(() => import('./ManageOwners'))
-const RemoveSafeModal = React.lazy(() => import('./RemoveSafeModal'))
-const SafeDetails = React.lazy(() => import('./SafeDetails'))
-const ThresholdSettings = React.lazy(() => import('./ThresholdSettings'))
+const Advanced = lazy(() => import('./Advanced'))
+const SpendingLimitSettings = lazy(() => import('./SpendingLimit'))
+const ManageOwners = lazy(() => import('./ManageOwners'))
+const RemoveSafeModal = lazy(() => import('./RemoveSafeModal'))
+const SafeDetails = lazy(() => import('./SafeDetails'))
+const ThresholdSettings = lazy(() => import('./ThresholdSettings'))
 
 export const OWNERS_SETTINGS_TAB_TEST_ID = 'owner-settings-tab'
 

--- a/src/routes/safe/components/Transactions/TxList/ActionModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/ActionModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react'
+import { ReactElement, useContext } from 'react'
 import { useSelector } from 'react-redux'
 
 import { ExpandedTxDetails, Transaction } from 'src/logic/safe/store/models/types/gateway.d'

--- a/src/routes/safe/components/Transactions/TxList/AddressInfo.tsx
+++ b/src/routes/safe/components/Transactions/TxList/AddressInfo.tsx
@@ -1,5 +1,5 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { getExplorerInfo } from 'src/config'
 import { useKnownAddress } from './hooks/useKnownAddress'

--- a/src/routes/safe/components/Transactions/TxList/HexEncodedData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/HexEncodedData.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@gnosis.pm/safe-react-components'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
-import React, { ReactElement, useState } from 'react'
+import { ReactElement, useState } from 'react'
 
 import Paragraph from 'src/components/layout/Paragraph'
 import LinkWithRef from 'src/components/layout/Link'

--- a/src/routes/safe/components/Transactions/TxList/HistoryTransactions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/HistoryTransactions.tsx
@@ -1,5 +1,5 @@
 import { Loader, Title } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { usePagedHistoryTransactions } from './hooks/usePagedHistoryTransactions'
 import { Centered, NoTransactions } from './styled'

--- a/src/routes/safe/components/Transactions/TxList/HistoryTxList.tsx
+++ b/src/routes/safe/components/Transactions/TxList/HistoryTxList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react'
+import { ReactElement, useContext } from 'react'
 
 import { TransactionDetails } from 'src/logic/safe/store/models/types/gateway.d'
 import { TxsInfiniteScrollContext } from 'src/routes/safe/components/Transactions/TxList/TxsInfiniteScroll'

--- a/src/routes/safe/components/Transactions/TxList/InfoDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/InfoDetails.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 type InfoDetailsProps = {
   children: ReactNode

--- a/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React from 'react'
+
 import styled from 'styled-components'
 
 import { isArrayParameter } from 'src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils'

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -1,5 +1,5 @@
 import { Text, EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React from 'react'
+
 import styled from 'styled-components'
 
 import {

--- a/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
@@ -1,6 +1,6 @@
 import { AccordionSummary, IconText } from '@gnosis.pm/safe-react-components'
 import { DataDecoded, TransactionData } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 import { getNetworkInfo } from 'src/config'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'

--- a/src/routes/safe/components/Transactions/TxList/OwnerRow.tsx
+++ b/src/routes/safe/components/Transactions/TxList/OwnerRow.tsx
@@ -1,5 +1,5 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 
 import { getExplorerInfo } from 'src/config'

--- a/src/routes/safe/components/Transactions/TxList/QueueTransactions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/QueueTransactions.tsx
@@ -1,5 +1,5 @@
 import { Loader, Title } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import Img from 'src/components/layout/Img'
 import { ActionModal } from './ActionModal'

--- a/src/routes/safe/components/Transactions/TxList/QueueTxList.tsx
+++ b/src/routes/safe/components/Transactions/TxList/QueueTxList.tsx
@@ -1,5 +1,5 @@
 import { Icon, Link, Text } from '@gnosis.pm/safe-react-components'
-import React, { Fragment, ReactElement, useContext } from 'react'
+import { Fragment, ReactElement, useContext } from 'react'
 import { useSelector } from 'react-redux'
 
 import { Transaction, TransactionDetails } from 'src/logic/safe/store/models/types/gateway.d'

--- a/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
@@ -1,9 +1,9 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React from 'react'
-import { sameString } from 'src/utils/strings'
+import { useMemo } from 'react'
 import styled from 'styled-components'
 
 import useTokenInfo from 'src/logic/safe/hooks/useTokenInfo'
+import { sameString } from 'src/utils/strings'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
 import { getResetTimeOptions } from 'src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime'
 import { AddressInfo, ResetTimeInfo, TokenInfo } from 'src/routes/safe/components/Settings/SpendingLimit/InfoDisplay'
@@ -29,12 +29,12 @@ const SpendingLimitRow = styled.div`
 `
 
 export const ModifySpendingLimitDetails = ({ data }: { data: DataDecoded }): React.ReactElement => {
-  const [beneficiary, tokenAddress, amount, resetTimeMin] = React.useMemo(
+  const [beneficiary, tokenAddress, amount, resetTimeMin] = useMemo(
     () => data.parameters?.map(({ value }) => value) ?? [],
     [data.parameters],
   )
 
-  const resetTimeLabel = React.useMemo(
+  const resetTimeLabel = useMemo(
     () => getResetTimeOptions().find(({ value }) => +value === +resetTimeMin)?.label ?? '',
     [resetTimeMin],
   )
@@ -64,10 +64,7 @@ export const ModifySpendingLimitDetails = ({ data }: { data: DataDecoded }): Rea
 }
 
 export const DeleteSpendingLimitDetails = ({ data }: { data: DataDecoded }): React.ReactElement => {
-  const [beneficiary, tokenAddress] = React.useMemo(
-    () => data.parameters?.map(({ value }) => value) ?? [],
-    [data.parameters],
-  )
+  const [beneficiary, tokenAddress] = useMemo(() => data.parameters?.map(({ value }) => value) ?? [], [data.parameters])
   const tokenInfo = useTokenInfo(tokenAddress as string)
 
   return (

--- a/src/routes/safe/components/Transactions/TxList/TokenTransferAmount.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TokenTransferAmount.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@gnosis.pm/safe-react-components'
 import { TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import Img from 'src/components/layout/Img'

--- a/src/routes/safe/components/Transactions/TxList/TxActionProvider.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxActionProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactElement, ReactNode, useCallback, useRef, useState } from 'react'
+import { createContext, ReactElement, ReactNode, useCallback, useRef, useState } from 'react'
 import { useDispatch } from 'react-redux'
 
 import { fetchTransactionDetails } from 'src/logic/safe/store/actions/fetchTransactionDetails'

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
@@ -1,6 +1,6 @@
 import { Dot, IconText as IconTextSrc, Loader, Text, Tooltip } from '@gnosis.pm/safe-react-components'
 import { ThemeColors } from '@gnosis.pm/safe-react-components/dist/theme'
-import React, { ReactElement, useContext, useRef } from 'react'
+import { ReactElement, useContext, useRef } from 'react'
 import styled from 'styled-components'
 
 import { CustomIconText } from 'src/components/CustomIconText'

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -1,7 +1,7 @@
 import { Icon, Tooltip } from '@gnosis.pm/safe-react-components'
 import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { default as MuiIconButton } from '@material-ui/core/IconButton'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 

--- a/src/routes/safe/components/Transactions/TxList/TxData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxData.tsx
@@ -1,5 +1,5 @@
 import { TransactionData } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 import { getNetworkInfo } from 'src/config'
 import { ExpandedTxDetails, isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway.d'

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -1,6 +1,6 @@
 import { Icon, Link, Loader, Text } from '@gnosis.pm/safe-react-components'
 import cn from 'classnames'
-import React, { ReactElement, useContext } from 'react'
+import { ReactElement, useContext } from 'react'
 import styled from 'styled-components'
 
 import {

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -1,6 +1,6 @@
 import { Button, Tooltip } from '@gnosis.pm/safe-react-components'
 import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 
 import { currentSafeNonce } from 'src/logic/safe/store/selectors'

--- a/src/routes/safe/components/Transactions/TxList/TxHistoryCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxHistoryCollapsed.tsx
@@ -1,5 +1,5 @@
 import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { useAssetInfo } from './hooks/useAssetInfo'

--- a/src/routes/safe/components/Transactions/TxList/TxHistoryRow.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxHistoryRow.tsx
@@ -1,5 +1,5 @@
 import { AccordionDetails } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { isCreationTxInfo, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { NoPaddingAccordion, StyledAccordionSummary } from './styled'

--- a/src/routes/safe/components/Transactions/TxList/TxHoverProvider.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxHoverProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactElement, ReactNode, useState } from 'react'
+import { createContext, ReactElement, ReactNode, useState } from 'react'
 
 export const TxHoverContext = createContext<{
   activeHover?: string

--- a/src/routes/safe/components/Transactions/TxList/TxInfo.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfo.tsx
@@ -1,5 +1,5 @@
 import { SettingsChange, TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { isSettingsChangeTxInfo, isTransferTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
 import { TxInfoSettings } from './TxInfoSettings'

--- a/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'

--- a/src/routes/safe/components/Transactions/TxList/TxInfoDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoDetails.tsx
@@ -1,5 +1,5 @@
 import { Erc721Transfer, Transfer, TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement, useContext, useEffect, useState } from 'react'
+import { ReactElement, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'

--- a/src/routes/safe/components/Transactions/TxList/TxInfoSettings.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoSettings.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@gnosis.pm/safe-react-components'
 import { SettingsChange } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { AddressInfo } from './AddressInfo'
 import { InfoDetails } from './InfoDetails'

--- a/src/routes/safe/components/Transactions/TxList/TxInfoTransfer.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoTransfer.tsx
@@ -1,5 +1,5 @@
 import { Transfer } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 
 import { useAssetInfo } from './hooks/useAssetInfo'
 import { TxInfoDetails } from './TxInfoDetails'

--- a/src/routes/safe/components/Transactions/TxList/TxLocationProvider.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxLocationProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactElement, ReactNode, useState } from 'react'
+import { createContext, ReactElement, ReactNode, useState } from 'react'
 import { TxLocation } from 'src/logic/safe/store/models/types/gateway.d'
 
 export type TxLocationProps = {

--- a/src/routes/safe/components/Transactions/TxList/TxOwners.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxOwners.tsx
@@ -1,5 +1,5 @@
 import { Text, Icon } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import Img from 'src/components/layout/Img'

--- a/src/routes/safe/components/Transactions/TxList/TxQueueCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxQueueCollapsed.tsx
@@ -1,5 +1,5 @@
 import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { useAssetInfo } from './hooks/useAssetInfo'

--- a/src/routes/safe/components/Transactions/TxList/TxQueueRow.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxQueueRow.tsx
@@ -1,6 +1,6 @@
 import { AccordionDetails } from '@gnosis.pm/safe-react-components'
 import { TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement, useContext, useEffect, useState } from 'react'
+import { ReactElement, useContext, useEffect, useState } from 'react'
 
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { useTransactionActions } from 'src/routes/safe/components/Transactions/TxList/hooks/useTransactionActions'

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@gnosis.pm/safe-react-components'
 import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 
 import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'

--- a/src/routes/safe/components/Transactions/TxList/TxsInfiniteScroll.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxsInfiniteScroll.tsx
@@ -1,5 +1,5 @@
 import { Loader } from '@gnosis.pm/safe-react-components'
-import React, { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 import { INFINITE_SCROLL_CONTAINER, InfiniteScroll } from 'src/components/InfiniteScroll'
 import { HorizontallyCentered, ScrollableTransactionsContainer } from './styled'

--- a/src/routes/safe/components/Transactions/TxList/index.tsx
+++ b/src/routes/safe/components/Transactions/TxList/index.tsx
@@ -1,6 +1,6 @@
 import { Menu, Tab, Breadcrumb, BreadcrumbElement } from '@gnosis.pm/safe-react-components'
 import { Item } from '@gnosis.pm/safe-react-components/dist/navigation/Tab'
-import React, { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 
 import Col from 'src/components/layout/Col'
 import { SAFE_NAVIGATION_EVENT, useAnalytics } from 'src/utils/googleAnalytics'

--- a/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
@@ -10,7 +10,7 @@ import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React, { useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useStyles } from './style'

--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -1,7 +1,7 @@
 import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
-import React from 'react'
+
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useStyles } from './style'

--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
 import { makeStyles } from '@material-ui/core/styles'

--- a/src/routes/safe/components/Transactions/helpers/EditableTxParameters.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditableTxParameters.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { TxParameters, useTransactionParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { EditTxParametersForm } from 'src/routes/safe/components/Transactions/helpers/EditTxParametersForm'
 import { ParametersStatus } from './utils'

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { Text, ButtonLink, Accordion, AccordionSummary, AccordionDetails } from '@gnosis.pm/safe-react-components'
 

--- a/src/routes/safe/components/assets/AddressBookIcon.tsx
+++ b/src/routes/safe/components/assets/AddressBookIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const AddressBookIcon = () => (
   <svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">

--- a/src/routes/safe/components/assets/BalancesIcon.tsx
+++ b/src/routes/safe/components/assets/BalancesIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const BalancesIcon = () => (
   <svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">

--- a/src/routes/safe/components/assets/SettingsIcon.tsx
+++ b/src/routes/safe/components/assets/SettingsIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const SettingsIcon = () => (
   <svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">

--- a/src/routes/safe/components/assets/TransactionsIcon.tsx
+++ b/src/routes/safe/components/assets/TransactionsIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export const TransactionsIcon = () => (
   <svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
     <g fill="none" fillRule="evenodd">

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -1,5 +1,5 @@
 import { GenericModal, Loader } from '@gnosis.pm/safe-react-components'
-import React, { useState } from 'react'
+import { useState, lazy } from 'react'
 import { useSelector } from 'react-redux'
 import { generatePath, Redirect, Route, Switch } from 'react-router-dom'
 
@@ -17,11 +17,11 @@ export const ADDRESS_BOOK_TAB_BTN_TEST_ID = 'address-book-tab-btn'
 export const SAFE_VIEW_NAME_HEADING_TEST_ID = 'safe-name-heading'
 export const TRANSACTIONS_TAB_NEW_BTN_TEST_ID = 'transactions-tab-new-btn'
 
-const Apps = React.lazy(() => import('src/routes/safe/components/Apps'))
-const Settings = React.lazy(() => import('src/routes/safe/components/Settings'))
-const Balances = React.lazy(() => import('src/routes/safe/components/Balances'))
-const TxList = React.lazy(() => import('src/routes/safe/components/Transactions/TxList'))
-const AddressBookTable = React.lazy(() => import('src/routes/safe/components/AddressBook'))
+const Apps = lazy(() => import('src/routes/safe/components/Apps'))
+const Settings = lazy(() => import('src/routes/safe/components/Settings'))
+const Balances = lazy(() => import('src/routes/safe/components/Balances'))
+const TxList = lazy(() => import('src/routes/safe/components/Transactions/TxList'))
+const AddressBookTable = lazy(() => import('src/routes/safe/components/AddressBook'))
 
 const Container = (): React.ReactElement => {
   const safeAddress = useSelector(safeAddressFromUrl)

--- a/src/routes/welcome/components/index.tsx
+++ b/src/routes/welcome/components/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import {
   Card,

--- a/src/routes/welcome/container/index.tsx
+++ b/src/routes/welcome/container/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { WelcomeLayout } from 'src/routes/welcome/components'
 
 import Page from 'src/components/layout/Page'

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import { render, RenderResult } from '@testing-library/react'
 import { theme as styledTheme } from '@gnosis.pm/safe-react-components'
 import Providers from 'src/components/Providers'

--- a/src/utils/wrapInSuspense.tsx
+++ b/src/utils/wrapInSuspense.tsx
@@ -1,6 +1,6 @@
-import React, { SuspenseProps } from 'react'
+import { Suspense, SuspenseProps } from 'react'
 
 export const wrapInSuspense = (
   component: Required<SuspenseProps['children']>,
   fallback: SuspenseProps['fallback'] = null,
-) => <React.Suspense fallback={fallback}>{component}</React.Suspense>
+) => <Suspense fallback={fallback}>{component}</Suspense>


### PR DESCRIPTION
## What it solves
https://github.com/gnosis/safe-react/pull/2701 changed the ESLint configuration making it not necessary to import react to use JSX. What I didn't expect was that ESLint would treat an unused React import as an error

## How this PR fixes it
by removing all unnecessary react imports across the app

## How to test it
`yarn build`
