### PR TITLE
Fix currency dropdown not updating

### DIFF
--- a/src/logic/safe/hooks/useLoadSafe.tsx
+++ b/src/logic/safe/hooks/useLoadSafe.tsx
@@ -7,6 +7,7 @@ import { fetchSafe } from 'src/logic/safe/store/actions/fetchSafe'
 import fetchTransactions from 'src/logic/safe/store/actions/transactions/fetchTransactions'
 import { Dispatch } from 'src/logic/safe/store/actions/types.d'
 import { updateAvailableCurrencies } from 'src/logic/currencyValues/store/actions/updateAvailableCurrencies'
+import { fetchSelectedCurrency } from 'src/logic/currencyValues/store/actions/fetchSelectedCurrency'
 
 export const useLoadSafe = (safeAddress?: string): boolean => {
   const dispatch = useDispatch<Dispatch>()
@@ -15,6 +16,7 @@ export const useLoadSafe = (safeAddress?: string): boolean => {
   useEffect(() => {
     const fetchData = async () => {
       if (safeAddress) {
+        await dispatch(fetchSelectedCurrency())
         await dispatch(fetchLatestMasterContractVersion())
         await dispatch(fetchSafe(safeAddress))
         setIsSafeLoaded(true)


### PR DESCRIPTION
## What it solves
Related to #2728

This PR fixes the selected currency (on the dropdown) not being persisted when app reloads
