### PR TITLE
Feature: Review Safe App Transaction modal tests

### DIFF
--- a/src/logic/safe/transactions/multisend.ts
+++ b/src/logic/safe/transactions/multisend.ts
@@ -18,7 +18,8 @@ export const encodeMultiSendCall = (txs: Transaction[]): string => {
       [
         web3.eth.abi.encodeParameter('uint8', 0).slice(-2),
         web3.eth.abi.encodeParameter('address', tx.to).slice(-40),
-        web3.eth.abi.encodeParameter('uint256', tx.value).slice(-64),
+        // if you pass wei as number, it will overflow
+        web3.eth.abi.encodeParameter('uint256', tx.value.toString()).slice(-64),
         web3.eth.abi.encodeParameter('uint256', web3.utils.hexToBytes(tx.data).length).slice(-64),
         tx.data.replace(/^0x/, ''),
       ].join(''),

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
@@ -111,6 +111,7 @@ describe('ConfirmTxModal Component', () => {
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
         safeName="test safe"
         ethBalance="100000000000000000"
+        // @ts-expect-error txs are malformed for testing purposes
         txs={txs}
         onClose={jest.fn()}
         onUserConfirm={jest.fn()}
@@ -141,6 +142,7 @@ describe('ConfirmTxModal Component', () => {
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
         safeName="test safe"
         ethBalance="100000000000000000"
+        // @ts-expect-error txs are malformed for testing purposes
         txs={txs}
         onClose={jest.fn()}
         onUserConfirm={jest.fn()}
@@ -171,6 +173,7 @@ describe('ConfirmTxModal Component', () => {
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
         safeName="test safe"
         ethBalance="100000000000000000"
+        // @ts-expect-error txs are malformed for testing purposes
         txs={txs}
         onClose={jest.fn()}
         onUserConfirm={jest.fn()}
@@ -227,6 +230,7 @@ describe('ConfirmTxModal Component', () => {
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
         safeName="test safe"
         ethBalance="100000000000000000"
+        // @ts-expect-error txs are malformed for testing purposes
         txs={txs}
         onClose={jest.fn()}
         onUserConfirm={jest.fn()}
@@ -254,6 +258,7 @@ describe('ConfirmTxModal Component', () => {
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
         safeName="test safe"
         ethBalance="100000000000000000"
+        // @ts-expect-error txs are malformed for testing purposes
         txs={txs}
         onClose={jest.fn()}
         onUserConfirm={jest.fn()}
@@ -286,6 +291,7 @@ describe('ConfirmTxModal Component', () => {
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
         safeName="test safe"
         ethBalance="100000000000000000"
+        // @ts-expect-error txs are malformed for testing purposes
         txs={txs}
         onClose={jest.fn()}
         onUserConfirm={jest.fn()}

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from 'src/utils/test-utils'
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
 
 import { ConfirmTxModal } from './'
 import { getEmptySafeApp } from '../../utils'

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from 'src/utils/test-utils'
+import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
+
+import { ConfirmTxModal } from './'
+import { getEmptySafeApp } from '../../utils'
+import { BaseTransaction } from '@gnosis.pm/safe-apps-sdk'
+
+jest.mock('src/logic/hooks/useEstimateTransactionGas', () => ({
+  useEstimateTransactionGas: () => ({
+    txEstimationExecutionStatus: 'SUCCESS',
+    gasEstimation: 0,
+    gasCost: '0',
+    gasCostFormatted: '0',
+    gasPrice: '0',
+    gasPriceFormatted: '0',
+    gasLimit: '0',
+    isExecution: true,
+    isCreation: false,
+    isOffChainSignature: false,
+  }),
+  EstimationStatus: { LOADING: 'LOADING' },
+}))
+
+const MULTISEND_ADDRESS = '0x42424242424242424242424242424242424242424'
+jest.mock('src/logic/contracts/safeContracts', () => ({
+  ...jest.requireActual('src/logic/contracts/safeContracts'),
+  getMultisendContractAddress: () => MULTISEND_ADDRESS,
+  getMultisendContract: () => ({
+    methods: {
+      multiSend: () => ({
+        encodeABI: () => '0x',
+      }),
+    },
+  }),
+}))
+
+describe('ConfirmTxModal Component', () => {
+  test('Shows transaction details correctly for a single, non-multisend transaction', () => {
+    const txs: BaseTransaction[] = [
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        value: '2000000000000000000',
+        data: '0x',
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    expect(screen.getByText('Send 2 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText(txs[0].to)).toBeInTheDocument()
+  })
+
+  test('Shows transaction details correctly for multiple transactions send via multisend', () => {
+    const txs: BaseTransaction[] = [
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        value: '0',
+        data: '0x',
+      },
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        value: '0',
+        data: '0x',
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    // No ETH value should be sent to the multisend address
+    expect(screen.getByText('Send 0 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText(MULTISEND_ADDRESS)).toBeInTheDocument()
+  })
+
+  test('Shows malformed txs screen in case the app sends invalid transaction object', () => {
+    const txs = [
+      {
+        value: '0',
+        data: '0x',
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+  })
+})

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
@@ -97,7 +97,7 @@ describe('ConfirmTxModal Component', () => {
     expect(screen.getByText(MULTISEND_ADDRESS)).toBeInTheDocument()
   })
 
-  test('Shows malformed txs screen in case the app sends invalid transaction object', () => {
+  test('Shows malformed txs screen in case the transaction misses the recipient', () => {
     const txs = [
       {
         value: '0',
@@ -119,5 +119,184 @@ describe('ConfirmTxModal Component', () => {
         app={getEmptySafeApp()}
       />,
     )
+
+    expect(
+      screen.getByText(
+        'This Safe App initiated a transaction which cannot be processed. Please get in touch with the developer of this Safe App for more information.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  test('Shows malformed txs screen in case the transaction misses value', () => {
+    const txs = [
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        data: '0x',
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'This Safe App initiated a transaction which cannot be processed. Please get in touch with the developer of this Safe App for more information.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  test('Shows malformed txs screen in case the transaction misses value', () => {
+    const txs = [
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        data: '0x',
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'This Safe App initiated a transaction which cannot be processed. Please get in touch with the developer of this Safe App for more information.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  test('Shows malformed txs screen in case transactions array is empty', () => {
+    const txs = []
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        'This Safe App initiated a transaction which cannot be processed. Please get in touch with the developer of this Safe App for more information.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  test('Accepts value equal 0 as a number (backward compatibility with the legacy v0.x SDKs)', () => {
+    const txs = [
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        data: '0x',
+        value: 0,
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    expect(screen.getByText('Send 0 ETH to:')).toBeInTheDocument()
+  })
+
+  test('Accepts value equal 2 eth as a number (backward compatibility with the legacy v0.x SDKs)', () => {
+    const txs = [
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        data: '0x',
+        value: 2000000000000000000,
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    expect(screen.getByText('Send 2 ETH to:')).toBeInTheDocument()
+  })
+
+  test('Accepts value as a number in multisend transactions (backward compatibility with the legacy v0.x SDKs)', () => {
+    const txs = [
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        data: '0x',
+        value: 2000000000000000000,
+      },
+      {
+        to: '0x75096d02718d1B56BEaE4273b178d34F6695F097',
+        data: '0x',
+        value: 0,
+      },
+    ]
+
+    render(
+      <ConfirmTxModal
+        isOpen
+        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        safeName="test safe"
+        ethBalance="100000000000000000"
+        txs={txs}
+        onClose={jest.fn()}
+        onUserConfirm={jest.fn()}
+        onTxReject={jest.fn()}
+        requestId="1"
+        app={getEmptySafeApp()}
+      />,
+    )
+
+    // No ETH value should be sent to the multisend address
+    expect(screen.getByText('Send 0 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText(MULTISEND_ADDRESS)).toBeInTheDocument()
   })
 })

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -60,7 +60,6 @@ const StyledBlock = styled(Block)`
 `
 
 type Props = ConfirmTxModalProps & {
-  areTxsMalformed: boolean
   showDecodedTxData: (decodedTxDetails: DecodedTxDetail) => void
   hidden: boolean // used to prevent re-rendering the modal each time a tx is inspected
 }
@@ -80,7 +79,6 @@ export const ReviewConfirm = ({
   onUserConfirm,
   onClose,
   onTxReject,
-  areTxsMalformed,
   requestId,
   showDecodedTxData,
 }: Props): ReactElement => {
@@ -99,8 +97,7 @@ export const ReviewConfirm = ({
     [txs, isMultiSend],
   )
   const txValue: string | undefined = useMemo(
-    // Value is converted to string because numbers were allowed in the safe-apps-sdk v1, so 0 and anything would evaluate as false
-    () => (isMultiSend ? '0' : txs[0]?.value.toString() && parseTxValue(txs[0]?.value)),
+    () => (isMultiSend ? '0' : parseTxValue(txs[0]?.value)),
     [txs, isMultiSend],
   )
   const operation = useMemo(() => (isMultiSend ? Operation.DELEGATE : Operation.CALL), [isMultiSend])
@@ -259,7 +256,7 @@ export const ReviewConfirm = ({
               cancelButtonProps={{ onClick: handleTxRejection }}
               confirmButtonProps={{
                 onClick: () => confirmTransactions(txParameters),
-                disabled: !isOwner || areTxsMalformed,
+                disabled: !isOwner,
                 status: buttonStatus,
                 text: txEstimationExecutionStatus === EstimationStatus.LOADING ? 'Estimating' : undefined,
               }}

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/SafeAppLoadError.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/SafeAppLoadError.tsx
@@ -3,6 +3,10 @@ import { Icon, Text, Title, ModalFooterConfirmation } from '@gnosis.pm/safe-reac
 import styled from 'styled-components'
 import { ConfirmTxModalProps } from '.'
 
+const Container = styled.div`
+  padding: ${({ theme }) => `${theme.margin.sm} ${theme.margin.lg}`};
+`
+
 const IconText = styled.div`
   display: flex;
   align-items: center;
@@ -23,7 +27,7 @@ export const SafeAppLoadError = ({ onTxReject, onClose, requestId }: ConfirmTxMo
   }
 
   return (
-    <>
+    <Container>
       <IconText>
         <Icon color="error" size="md" type="info" />
         <Title size="xs">Transaction error</Title>
@@ -42,6 +46,6 @@ export const SafeAppLoadError = ({ onTxReject, onClose, requestId }: ConfirmTxMo
           okText="Submit"
         />
       </FooterWrapper>
-    </>
+    </Container>
   )
 }

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/index.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/index.tsx
@@ -42,7 +42,7 @@ export type DecodedTxDetail = DecodedDataParameterValue | DecodedData | undefine
 
 export const ConfirmTxModal = (props: ConfirmTxModalProps): ReactElement => {
   const [decodedTxDetails, setDecodedTxDetails] = useState<DecodedTxDetail>()
-  const areTxsMalformed = props.txs.some((t) => !isTxValid(t))
+  const invalidTransactions = !props.txs.length || props.txs.some((t) => !isTxValid(t))
 
   const showDecodedTxData = setDecodedTxDetails
   const hideDecodedTxData = () => setDecodedTxDetails(undefined)
@@ -52,9 +52,16 @@ export const ConfirmTxModal = (props: ConfirmTxModalProps): ReactElement => {
     props.onClose()
   }
 
+  if (invalidTransactions) {
+    return (
+      <Modal description="Safe App transaction" title="Safe App transaction" open={props.isOpen}>
+        <SafeAppLoadError {...props} />
+      </Modal>
+    )
+  }
+
   return (
     <Modal description="Safe App transaction" title="Safe App transaction" open={props.isOpen}>
-      {areTxsMalformed && <SafeAppLoadError {...props} />}
       {decodedTxDetails && (
         <DecodedTxDetail
           onClose={closeDecodedTxDetail}
@@ -63,12 +70,7 @@ export const ConfirmTxModal = (props: ConfirmTxModalProps): ReactElement => {
         />
       )}
 
-      <ReviewConfirm
-        {...props}
-        areTxsMalformed={areTxsMalformed}
-        showDecodedTxData={showDecodedTxData}
-        hidden={areTxsMalformed || !!decodedTxDetails}
-      />
+      <ReviewConfirm {...props} showDecodedTxData={showDecodedTxData} hidden={!!decodedTxDetails} />
     </Modal>
   )
 }


### PR DESCRIPTION
## What it solves
Resolves #2709 

## How this PR fixes it
The PR adds tests for happy paths, malformed transactions and also checks backward compatibility with v0.X SDKs
It helped to catch few bugs:
- If transactions are malformed, we'd render the error message but still pass malformed transactions to the underlying functions (encoding, gas estimation, etc.), and they'd error
- Large eth values as numbers from v0.X SDKs can overflow

## How to test it
Good question
