### PR TITLE
Fix amount validtion in Send Funds

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -145,29 +145,31 @@ const SendFunds = ({
   const spendingLimits = useSelector(currentSafeSpendingLimits)
   const currentUser = useSelector(userAccountSelector)
 
-  const sendFundsValidation = (values) => {
+  const sendFundsValidation = (values: { amount?: string; token?: string; txType?: string }) => {
     const { amount, token: tokenAddress, txType } = values ?? {}
-    if (!amount || !tokenAddress) {
-      return
-    }
+    const tokenValidation = composeValidators(required)(tokenAddress)
 
     const isSpendingLimit = tokenSpendingLimit && txType === 'spendingLimit'
     const tokenDecimals =
-      Number(getBalanceAndDecimalsFromToken({ tokenAddress, tokens })?.decimals) || nativeCoin.decimals
+      (tokenAddress && Number(getBalanceAndDecimalsFromToken({ tokenAddress, tokens })?.decimals)) ||
+      nativeCoin.decimals
     const amountValidation = composeValidators(
       required,
       mustBeFloat,
       minMaxDecimalsLength(1, tokenDecimals),
       minValue(0, false),
-      maxValue(
-        isSpendingLimit
-          ? spendingLimitAllowedBalance({ tokenAddress, tokenSpendingLimit, tokens })
-          : getBalanceAndDecimalsFromToken({ tokenAddress, tokens })?.balance ?? 0,
-      ),
+      tokenAddress
+        ? maxValue(
+            isSpendingLimit
+              ? spendingLimitAllowedBalance({ tokenAddress, tokenSpendingLimit, tokens })
+              : getBalanceAndDecimalsFromToken({ tokenAddress, tokens })?.balance ?? 0,
+          )
+        : () => undefined,
     )(amount)
 
     return {
       amount: amountValidation,
+      token: tokenValidation,
     }
   }
 


### PR DESCRIPTION
## What it solves
Resolves #2711 

Looks like it was [a regression](https://github.com/gnosis/safe-react/pull/1637/files#diff-992f0b2127f35603d38b3ed7b99b326bdcf6d45084cc40879fc95fa3b4f173fdR127-R129) from when Spending Limits were introduced.

## How this PR fixes it
Returns a validation object when amount is not set.

## How to test it
Try to submit the Send Funds form with no amount.
