### PR TITLE
Render Footer component conditionaly

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-cla-document: 'https://github.com/gnosis/safe-react/blob/main/GNOSISCLA.md'
           branch: 'cla-signatures'
-          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook,DiogoSoaress
+          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import styled from 'styled-components'
+import { useLocation } from 'react-router-dom'
 import { ListItemType } from 'src/components/List'
 
 import Header from './Header'
@@ -91,6 +92,9 @@ const Layout: React.FC<Props> = ({
 
   const closeMobileNotSupported = () => setMobileNotSupportedClosed(true)
 
+  const hasFooterRegex = new RegExp(/\/(welcome|safes\/0x[a-fA-F0-9]{40}\/settings)/)
+  const hasFooter = hasFooterRegex.test(useLocation().pathname)
+
   return (
     <Container>
       <HeaderWrapper>
@@ -111,7 +115,7 @@ const Layout: React.FC<Props> = ({
         </SidebarWrapper>
         <ContentWrapper>
           <div>{children}</div>
-          <Footer />
+          {hasFooter && <Footer />}
         </ContentWrapper>
       </BodyWrapper>
 

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import styled from 'styled-components'
-import { useLocation, generatePath } from 'react-router-dom'
+import { useLocation, matchPath } from 'react-router-dom'
+
 import { ListItemType } from 'src/components/List'
 import { WELCOME_ADDRESS, SAFE_ROUTES } from 'src/routes/routes'
 
@@ -90,16 +91,13 @@ const Layout: React.FC<Props> = ({
   sidebarItems,
 }): React.ReactElement => {
   const [mobileNotSupportedClosed, setMobileNotSupportedClosed] = useState(false)
+  const { pathname } = useLocation()
 
   const closeMobileNotSupported = () => setMobileNotSupportedClosed(true)
 
-  const settingsBaseRoute = safeAddress
-    ? generatePath(SAFE_ROUTES.SETTINGS_BASE_ROUTE, {
-        safeAddress,
-      })
-    : undefined
-  const footerRegex = new RegExp(`(${WELCOME_ADDRESS}|${settingsBaseRoute})`)
-  const hasFooter = footerRegex.test(useLocation().pathname)
+  const hasFooter = !!matchPath(pathname, {
+    path: [SAFE_ROUTES.SETTINGS_BASE_ROUTE, WELCOME_ADDRESS],
+  })
 
   return (
     <Container>

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import styled from 'styled-components'
-import { useLocation } from 'react-router-dom'
+import { useLocation, generatePath } from 'react-router-dom'
 import { ListItemType } from 'src/components/List'
+import { WELCOME_ADDRESS, SAFE_ROUTES } from 'src/routes/routes'
 
 import Header from './Header'
 import Footer from './Footer'
@@ -68,9 +69,9 @@ const ContentWrapper = styled.div`
 
 type Props = {
   sidebarItems: ListItemType[]
-  safeAddress: string | undefined
-  safeName: string | undefined
-  balance: string | undefined
+  safeAddress?: string
+  safeName?: string
+  balance?: string
   granted: boolean
   onToggleSafeList: () => void
   onReceiveClick: () => void
@@ -92,8 +93,13 @@ const Layout: React.FC<Props> = ({
 
   const closeMobileNotSupported = () => setMobileNotSupportedClosed(true)
 
-  const hasFooterRegex = new RegExp(/\/(welcome|safes\/0x[a-fA-F0-9]{40}\/settings)/)
-  const hasFooter = hasFooterRegex.test(useLocation().pathname)
+  const settingsBaseRoute = safeAddress
+    ? generatePath(SAFE_ROUTES.SETTINGS_BASE_ROUTE, {
+        safeAddress,
+      })
+    : undefined
+  const footerRegex = new RegExp(`(${WELCOME_ADDRESS}|${settingsBaseRoute})`)
+  const hasFooter = footerRegex.test(useLocation().pathname)
 
   return (
     <Container>

--- a/src/components/Table/TableHead.tsx
+++ b/src/components/Table/TableHead.tsx
@@ -35,7 +35,7 @@ class GnoTableHead extends React.PureComponent<any> {
             <TableCell
               align={column.align}
               key={column.id}
-              padding={column.disablePadding ? 'none' : 'normal'}
+              padding={column.disablePadding ? 'none' : 'default'}
               sortDirection={orderBy === column.id ? order : false}
             >
               {column.static ? (

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -40,7 +40,7 @@ import { SignMessageModal } from './SignMessageModal'
 const AppWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  height: calc(100% + 59px);
+  height: 100%;
   margin: 0 -16px;
 `
 

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -86,6 +86,12 @@ export const StyledTransactions = styled.div`
     &:last-child {
       border-bottom: none;
     }
+
+    &:last-of-type {
+      div {
+        row-gap: 0px;
+      }
+    }
   }
 `
 
@@ -487,7 +493,7 @@ export const StyledScrollableBar = styled.div`
 `
 
 export const ScrollableTransactionsContainer = styled(StyledScrollableBar)`
-  height: calc(100vh - 225px);
+  margin-bottom: 16px;
   overflow-x: hidden;
   overflow-y: auto;
   width: 100%;
@@ -502,7 +508,7 @@ export const Centered = styled.div<{ padding?: number }>`
 `
 
 export const HorizontallyCentered = styled(Centered)<{ isVisible: boolean }>`
-  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+  display: ${({ isVisible }) => (isVisible ? 'block' : 'none')};
   height: 100px;
 `
 

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -493,7 +493,7 @@ export const StyledScrollableBar = styled.div`
 `
 
 export const ScrollableTransactionsContainer = styled(StyledScrollableBar)`
-  margin-bottom: 16px;
+  height: calc(100vh - 170px);
   overflow-x: hidden;
   overflow-y: auto;
   width: 100%;
@@ -508,7 +508,7 @@ export const Centered = styled.div<{ padding?: number }>`
 `
 
 export const HorizontallyCentered = styled(Centered)<{ isVisible: boolean }>`
-  display: ${({ isVisible }) => (isVisible ? 'block' : 'none')};
+  display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
   height: 100px;
 `
 


### PR DESCRIPTION
## What it solves
Resolves #2714

## How this PR fixes it
Renders the `Footer` component if the navigation is in the _Welcome Page_ or in the _Settings_ route

## How to test it
Navigate to the _Welcome Page_ or _Settings_ route and check the `Footer` is present. In all the others pages it shouldn't be displayed

## Screenshots
![Screen Shot 2021-09-28 at 15 31 53](https://user-images.githubusercontent.com/32431609/135096796-a777daf8-f2bc-428e-a670-7a5921ade5bc.png)
![Screen Shot 2021-09-28 at 15 31 43](https://user-images.githubusercontent.com/32431609/135096803-f86bcbd1-1dab-4686-be6c-93942ccc760e.png)
![Screen Shot 2021-09-28 at 15 31 24](https://user-images.githubusercontent.com/32431609/135096807-7f5d311f-8f19-48d5-8cff-ab3422bbac1c.png)
