### PR TITLE
Fix warning of renamed prop type from MaterialUI

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-cla-document: 'https://github.com/gnosis/safe-react/blob/main/GNOSISCLA.md'
           branch: 'cla-signatures'
-          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook,diogosoaress
+          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook,DiogoSoaress,'diogo Soares'
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-cla-document: 'https://github.com/gnosis/safe-react/blob/main/GNOSISCLA.md'
           branch: 'cla-signatures'
-          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook,DiogoSoaress,'diogo Soares'
+          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook,DiogoSoaress
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-cla-document: 'https://github.com/gnosis/safe-react/blob/main/GNOSISCLA.md'
           branch: 'cla-signatures'
-          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook
+          allowlist: lukasschor,mikheevm,rmeissner,germartinez,davidalbela,Uxio0,dasanra,francovenica,tschubotz,luarx,giacomolicari,gnosis-info,bot*,katspaugh,DaniSomoza,iamacook,diogosoaress
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/src/components/Table/TableHead.tsx
+++ b/src/components/Table/TableHead.tsx
@@ -35,7 +35,7 @@ class GnoTableHead extends React.PureComponent<any> {
             <TableCell
               align={column.align}
               key={column.id}
-              padding={column.disablePadding ? 'none' : 'default'}
+              padding={column.disablePadding ? 'none' : 'normal'}
               sortDirection={orderBy === column.id ? order : false}
             >
               {column.static ? (


### PR DESCRIPTION
## What it solves
Resolves #N/A
Resolves the Material UI warning on the DevTools console

## How this PR fixes it
Updates the prop type

## How to test it
When navigating to the ASSETS>COINS which has a table, the warning should be gone 

## Screenshots
![Screen Shot 2021-09-27 at 16 48 44](https://user-images.githubusercontent.com/32431609/134932278-1d9b72eb-48fb-4df2-987b-d3c32d236584.png)


