### PR TITLE
Fix web3 instance after switching chain

### DIFF
--- a/src/components/DecodeTxs/index.tsx
+++ b/src/components/DecodeTxs/index.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components'
 import { Transaction } from '@gnosis.pm/safe-apps-sdk-v1'
 import { Text, EthHashInfo, CopyToClipboardBtn, IconText, FixedIcon } from '@gnosis.pm/safe-react-components'
 import get from 'lodash.get'
+import { hexToBytes } from 'web3-utils'
 
-import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
 import { getExplorerInfo, getNetworkInfo } from 'src/config'
 import { DecodedData, DecodedDataBasicParameter, DecodedDataParameterValue } from 'src/types/transactions/decode.d'
 import { DecodedTxDetail } from 'src/routes/safe/components/Apps/components/ConfirmTxModal'
@@ -56,7 +56,7 @@ export const getByteLength = (data: string | string[]): number => {
     }
     // Return the sum of the byte sizes of each hex string
     return data.reduce((result, hex) => {
-      const bytes = web3.utils.hexToBytes(hex)
+      const bytes = hexToBytes(hex)
       return result + bytes.length
     }, 0)
   } catch (err) {

--- a/src/logic/contractInteraction/sources/ABIService/index.ts
+++ b/src/logic/contractInteraction/sources/ABIService/index.ts
@@ -1,6 +1,4 @@
-import { AbiItem } from 'web3-utils'
-
-import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
+import { AbiItem, keccak256 } from 'web3-utils'
 
 export interface AllowedAbiItem extends AbiItem {
   name: string
@@ -19,7 +17,7 @@ export const getMethodSignature = ({ inputs, name }: AbiItem): string => {
 }
 
 export const getSignatureHash = (signature: string): string => {
-  return web3.utils.keccak256(signature).toString()
+  return keccak256(signature).toString()
 }
 
 export const getMethodHash = (method: AbiItem): string => {

--- a/src/logic/contracts/generateBatchRequests.ts
+++ b/src/logic/contracts/generateBatchRequests.ts
@@ -1,4 +1,4 @@
-import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { BatchRequest } from 'web3-core'
 import { AbiItem } from 'web3-utils'
 
@@ -29,6 +29,7 @@ const generateBatchRequests = <ReturnValues>({
   context,
   methods,
 }: Props): Promise<ReturnValues> => {
+  const web3 = getWeb3ReadOnly()
   const contractInstance = new web3.eth.Contract(abi, address)
   const localBatch = new web3.BatchRequest()
 

--- a/src/logic/contracts/methodIds.ts
+++ b/src/logic/contracts/methodIds.ts
@@ -7,7 +7,7 @@ import {
   TOKEN_TRANSFER_METHOD_ID_TO_NAME,
   TOKEN_TRANSFER_METHODS_NAMES,
 } from 'src/logic/safe/store/models/types/transactions.d'
-import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { sameString } from 'src/utils/strings'
 
 type DecodeInfoProps = {
@@ -16,6 +16,7 @@ type DecodeInfoProps = {
 }
 
 const decodeInfo = ({ paramsHash, params }: DecodeInfoProps): DataDecoded['parameters'] => {
+  const web3 = getWeb3ReadOnly()
   const decodedParameters = web3.eth.abi.decodeParameters(Object.values(params), paramsHash)
 
   return Object.keys(params).map((name, index) => ({

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -13,7 +13,7 @@ import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
 import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
 import { calculateGasPrice } from 'src/logic/wallets/ethTransactions'
 import { currentSafe } from 'src/logic/safe/store/selectors'
-import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { providerSelector } from 'src/logic/wallets/store/selectors'
 
 import { Confirmation } from 'src/logic/safe/store/models/types/confirmation'
@@ -135,6 +135,7 @@ export const useEstimateTransactionGas = ({
   const { address: safeAddress = '', threshold = 1, currentVersion: safeVersion = '' } = useSelector(currentSafe) ?? {}
   const { account: from, smartContractWallet, name: providerName } = useSelector(providerSelector)
   useEffect(() => {
+    const web3 = getWeb3ReadOnly()
     const estimateGas = async () => {
       if (!txData.length) {
         return

--- a/src/logic/safe/transactions/__tests__/txMonitor.test.ts
+++ b/src/logic/safe/transactions/__tests__/txMonitor.test.ts
@@ -1,10 +1,10 @@
 import { txMonitor } from 'src/logic/safe/transactions/txMonitor'
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 
 jest.mock('src/logic/wallets/getWeb3', () => ({
-  web3ReadOnly: {
+  getWeb3ReadOnly: jest.fn(() => ({
     eth: {},
-  },
+  })),
 }))
 
 const params = {
@@ -21,6 +21,7 @@ const options = {
 }
 
 describe('txMonitor', () => {
+  const web3ReadOnly = getWeb3ReadOnly()
   beforeEach(() => {
     web3ReadOnly.eth.getTransaction = jest.fn(() => Promise.reject('getTransaction')) as any
     web3ReadOnly.eth.getTransactionReceipt = jest.fn(() => Promise.reject('getTransactionReceipt')) as any

--- a/src/logic/safe/transactions/__tests__/txMonitor.test.ts
+++ b/src/logic/safe/transactions/__tests__/txMonitor.test.ts
@@ -1,10 +1,17 @@
 import { txMonitor } from 'src/logic/safe/transactions/txMonitor'
 import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 
+// We need to have it defined as const to ensure we return the same instance in mock
+const mockWeb3 = {
+  eth: {
+    getTransaction: jest.fn(() => Promise.reject('getTransaction')) as any,
+    getTransactionReceipt: jest.fn(() => Promise.reject('getTransactionReceipt')) as any,
+    getBlock: jest.fn(() => Promise.reject('getBlock')) as any,
+  },
+}
+
 jest.mock('src/logic/wallets/getWeb3', () => ({
-  getWeb3ReadOnly: jest.fn(() => ({
-    eth: {},
-  })),
+  getWeb3ReadOnly: () => mockWeb3,
 }))
 
 const params = {
@@ -22,11 +29,6 @@ const options = {
 
 describe('txMonitor', () => {
   const web3ReadOnly = getWeb3ReadOnly()
-  beforeEach(() => {
-    web3ReadOnly.eth.getTransaction = jest.fn(() => Promise.reject('getTransaction')) as any
-    web3ReadOnly.eth.getTransactionReceipt = jest.fn(() => Promise.reject('getTransactionReceipt')) as any
-    web3ReadOnly.eth.getBlock = jest.fn(() => Promise.reject('getBlock')) as any
-  })
 
   it('should reject when max retries are reached', async () => {
     try {

--- a/src/logic/safe/utils/spendingLimits.ts
+++ b/src/logic/safe/utils/spendingLimits.ts
@@ -11,7 +11,7 @@ import { getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
 import { getSpendingLimitContract } from 'src/logic/contracts/spendingLimitContracts'
 import { SpendingLimit } from 'src/logic/safe/store/models/safe'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { SPENDING_LIMIT_MODULE_ADDRESS } from 'src/utils/constants'
 import { encodeMultiSendCall, MultiSendTx } from 'src/logic/safe/transactions/multisend'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
@@ -25,7 +25,8 @@ const requestTokensByDelegate = async (
   safeAddress: string,
   delegates: string[],
 ): Promise<[string, string[] | undefined][]> => {
-  const batch = new web3ReadOnly.BatchRequest()
+  const web3 = getWeb3ReadOnly()
+  const batch = new web3.BatchRequest()
 
   const whenRequestValues = delegates.map((delegateAddress: string) =>
     generateBatchRequests<[string, string[] | undefined]>({
@@ -75,7 +76,8 @@ const requestAllowancesByDelegatesAndTokens = async (
   safeAddress: string,
   tokensByDelegate: [string, string[] | undefined][],
 ): Promise<SpendingLimitRow[]> => {
-  const batch = new web3ReadOnly.BatchRequest()
+  const web3 = getWeb3ReadOnly()
+  const batch = new web3.BatchRequest()
 
   const whenRequestValues: Promise<TokenSpendingLimitRequest>[] = []
 

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -4,7 +4,7 @@ import { ContentHash } from 'web3-eth-ens'
 import { sameAddress } from './ethAddresses'
 import { EMPTY_DATA } from './ethTransactions'
 import { ProviderProps } from './store/model/provider'
-import { getRpcServiceUrl } from 'src/config'
+import { getRpcServiceUrl, getNetworkId } from 'src/config'
 import { isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { getAddressFromUnstoppableDomain } from './utils/unstoppableDomains'
 import { ETHEREUM_NETWORK } from 'src/config/networks/network'
@@ -33,17 +33,27 @@ export enum WALLET_PROVIDER {
 const httpProviderOptions = {
   timeout: 10_000,
 }
-export const web3ReadOnly = new Web3(
-  process.env.NODE_ENV !== 'test'
-    ? new Web3.providers.HttpProvider(getRpcServiceUrl(), httpProviderOptions)
-    : 'ws://localhost:8545',
-)
 
-let web3 = web3ReadOnly
+const web3ReadOnly: Web3[] = []
+export const getWeb3ReadOnly = (): Web3 => {
+  if (!web3ReadOnly[getNetworkId()]) {
+    web3ReadOnly[getNetworkId()] = new Web3(
+      process.env.NODE_ENV !== 'test'
+        ? new Web3.providers.HttpProvider(getRpcServiceUrl(), httpProviderOptions)
+        : 'ws://localhost:8545',
+    )
+  }
+
+  return web3ReadOnly[getNetworkId()]
+}
+
+let web3 = getWeb3ReadOnly()
 export const getWeb3 = (): Web3 => web3
-
+export const setWeb3 = (provider: Provider): void => {
+  web3 = new Web3(provider)
+}
 export const resetWeb3 = (): void => {
-  web3 = web3ReadOnly
+  web3 = web3ReadOnly[getNetworkId()]
 }
 
 export const getAccountFrom = async (web3Provider: Web3): Promise<string | null> => {
@@ -95,10 +105,6 @@ export const getAddressFromDomain = (name: string): Promise<string> => {
 }
 
 export const getContentFromENS = (name: string): Promise<ContentHash> => web3.eth.ens.getContenthash(name)
-
-export const setWeb3 = (provider: Provider): void => {
-  web3 = new Web3(provider)
-}
 
 export const isTxPendingError = (err: Error): boolean => {
   const WEB3_TX_NOT_MINED_ERROR = 'Transaction was not mined within'

--- a/src/routes/load/Load.test.tsx
+++ b/src/routes/load/Load.test.tsx
@@ -1,10 +1,10 @@
 import { getClientGatewayUrl } from 'src/config'
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { mockedEndpoints } from 'src/setupTests'
 import { render, fireEvent, screen, waitFor, act } from 'src/utils/test-utils'
 import Load from './container/Load'
 
-const getENSAddressSpy = jest.spyOn(web3ReadOnly.eth.ens, 'getAddress')
+const getENSAddressSpy = jest.spyOn(getWeb3ReadOnly().eth.ens, 'getAddress')
 
 const networkId = '4'
 const inValidSafeAddress = 'this-is–a-invalid-safe-address-value'

--- a/src/routes/new-load/Load.test.tsx
+++ b/src/routes/new-load/Load.test.tsx
@@ -1,4 +1,4 @@
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 
 import { getClientGatewayUrl } from 'src/config'
 import { mockedEndpoints } from 'src/setupTests'
@@ -9,7 +9,7 @@ import { generatePath } from 'react-router-dom'
 import { SAFE_ROUTES } from '../routes'
 import * as safeVersion from 'src/logic/safe/utils/safeVersion'
 
-const getENSAddressSpy = jest.spyOn(web3ReadOnly.eth.ens, 'getAddress')
+const getENSAddressSpy = jest.spyOn(getWeb3ReadOnly().eth.ens, 'getAddress')
 
 jest.spyOn(safeVersion, 'getSafeVersionInfo').mockImplementation(async () => ({
   current: '1.3.0',

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -3,13 +3,13 @@ import { EthHashInfo, Text } from '@gnosis.pm/safe-react-components'
 import { ReactElement, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
+import { toBN } from 'web3-utils'
 
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
 import { getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { encodeMultiSendCall } from 'src/logic/safe/transactions/multisend'
 import { getExplorerInfo, getNetworkInfo } from 'src/config'
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import { TransactionFees } from 'src/components/TransactionsFees'
@@ -63,7 +63,7 @@ type Props = ConfirmTxModalProps & {
 }
 
 const parseTxValue = (value: string | number): string => {
-  return web3ReadOnly.utils.toBN(value).toString()
+  return toBN(value).toString()
 }
 
 export const ReviewConfirm = ({

--- a/src/routes/safe/components/Apps/components/SignMessageModal/SignMessageModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/SignMessageModal.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from 'src/utils/test-utils'
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 
 import { SignMessageModal } from './'
 import { getEmptySafeApp } from '../../utils'
@@ -21,6 +21,7 @@ jest.mock('src/logic/hooks/useEstimateTransactionGas', () => ({
 }))
 
 describe('SignMessageModal Component', () => {
+  const web3ReadOnly = getWeb3ReadOnly()
   test('Converts message from HEX to UTF-8', () => {
     const hexMessage = '0x74657374206d657373616765'
     const utf8Message = web3ReadOnly.utils.hexToUtf8(hexMessage)

--- a/src/routes/safe/components/Apps/components/SignMessageModal/index.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/index.tsx
@@ -1,7 +1,7 @@
-import { ReactElement } from 'react'
 import { RequestId, calculateMessageHash } from '@gnosis.pm/safe-apps-sdk'
+import { ReactElement } from 'react'
 
-import { web3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { getSignMessageLibContractInstance, getSignMessageLibAddress } from 'src/logic/contracts/safeContracts'
 import Modal from 'src/components/Modal'
@@ -25,12 +25,13 @@ export type SignMessageModalProps = {
 const networkId = getNetworkId()
 
 const convertToHumanReadableMessage = (message: string): string => {
-  const isHex = web3ReadOnly.utils.isHexStrict(message.toString())
+  const web3 = getWeb3ReadOnly()
+  const isHex = web3.utils.isHexStrict(message.toString())
 
   let humanReadableMessage = message
   if (isHex) {
     try {
-      humanReadableMessage = web3ReadOnly.utils.hexToUtf8(message)
+      humanReadableMessage = web3.utils.hexToUtf8(message)
     } catch (e) {
       // do nothing
     }
@@ -40,8 +41,9 @@ const convertToHumanReadableMessage = (message: string): string => {
 }
 
 export const SignMessageModal = ({ message, isOpen, ...rest }: SignMessageModalProps): ReactElement => {
+  const web3 = getWeb3ReadOnly()
   const txRecipient = getSignMessageLibAddress(networkId) || ZERO_ADDRESS
-  const txData = getSignMessageLibContractInstance(web3ReadOnly, networkId)
+  const txData = getSignMessageLibContractInstance(web3, networkId)
     .methods.signMessage(calculateMessageHash(message))
     .encodeABI()
 

--- a/src/routes/safe/container/hooks/useTransactionParameters.ts
+++ b/src/routes/safe/container/hooks/useTransactionParameters.ts
@@ -6,7 +6,7 @@ import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { getLastTx, getNewTxNonce } from 'src/logic/safe/store/actions/utils'
 import { getGnosisSafeInstanceAt } from 'src/logic/contracts/safeContracts'
 import { currentSafeCurrentVersion, safeAddressFromUrl } from 'src/logic/safe/store/selectors'
-import { web3ReadOnly as web3 } from 'src/logic/wallets/getWeb3'
+import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { ParametersStatus } from 'src/routes/safe/components/Transactions/helpers/utils'
 import { sameString } from 'src/utils/strings'
 
@@ -37,6 +37,7 @@ type Props = {
  * It needs to be initialized calling setGasEstimation.
  */
 export const useTransactionParameters = (props?: Props): TxParameters => {
+  const web3 = getWeb3ReadOnly()
   const isCancelTransaction = sameString(props?.parameterStatus || 'ENABLED', 'CANCEL_TRANSACTION')
   const connectedWalletAddress = useSelector(userAccountSelector)
   const safeAddress = useSelector(safeAddressFromUrl)
@@ -76,7 +77,7 @@ export const useTransactionParameters = (props?: Props): TxParameters => {
       return
     }
     setEthGasPriceInGWei(web3.utils.toWei(ethGasPrice, 'Gwei'))
-  }, [ethGasPrice, isCancelTransaction])
+  }, [ethGasPrice, isCancelTransaction, web3])
 
   // Calc safe nonce
   useEffect(() => {


### PR DESCRIPTION
## What it solves
Fixes the issue reported in this comment:
https://github.com/gnosis/safe-react/pull/2720#issuecomment-926118202
It wasn't only related to the create safe step, but in many places we were using a readOnly instance of web3. Most of the cases didn't had issues because it was not used to do queries to the blockchain but just for the unit conversion or parsing. But in those cases where we launch a query to the blockchain it was still initialized with the default chain RPC, so wrong RPC query was send in other chains

## How this PR fixes it
We create a new instance of web3ReadOnly for each network, but we cache them as singleton instance in order to avoid creating many new objects

## How to test it
Try to create a safe in a chain different than the default one and check that is correctly detected. Also RPC calls can be check in network console, validating that they are done to the correct chain RPC

