### PR TITLE
Fix unified li nesting error

### DIFF
--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -90,11 +90,12 @@ export const SafeList = ({ onSafeClick }: Props): ReactElement => {
                   onSafeClick={onSafeClick}
                   loadedSafes={loadedSafes}
                   shouldScrollToSafe
+                  //component="div"
                   {...safe}
                 />
               ))}
               {isCurrentNetwork && ownedSafes.length > 0 && (
-                <ListItem classes={{ root: classes.listItemCollapse }}>
+                <ListItem classes={{ root: classes.listItemCollapse }} component="div">
                   <Collapse
                     title={`Safes owned on ${label} (${ownedSafes.length})`}
                     defaultExpanded={shouldExpandOwnedSafes}

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -90,7 +90,6 @@ export const SafeList = ({ onSafeClick }: Props): ReactElement => {
                   onSafeClick={onSafeClick}
                   loadedSafes={loadedSafes}
                   shouldScrollToSafe
-                  //component="div"
                   {...safe}
                 />
               ))}


### PR DESCRIPTION
## What it solves
Resolves console warning regarding `<li>` descendants:

![image](https://user-images.githubusercontent.com/20442784/135420181-60ee61e9-495e-448d-965a-8db40a4f965f.png)

## How this PR fixes it
Instead of using an `<li>` element, a `<div>` is used instead.

## How to test it
Open `Safes owned on ${network}` collapsed menu and check console that no warning is there.
