### PR TITLE
Fix small typo "fullfil" in error message displayed in UI

### DIFF
--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -74,9 +74,9 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
     throw Error('Failed to fetch app manifest')
   }
 
-  // verify imported app fulfil safe requirements
+  // verify imported app fulfill safe requirements
   if (!appInfo?.data || !isAppManifestValid(appInfo.data)) {
-    throw Error('App manifest does not fulfil the required structure.')
+    throw Error('App manifest does not fulfill the required structure.')
   }
 
   // the DB origin field has a limit of 100 characters


### PR DESCRIPTION
## What it solves
Resolves #

Came across a small typo while working on getting our `manifest.json` file up to spec.

![image](https://user-images.githubusercontent.com/4524175/135527293-78fadbbb-46b8-46c5-a0e9-7f3bacdc12d8.png)


## How this PR fixes it

## How to test it

## Screenshots
