### PR TITLE
Add a warning in the Safe upgrade modal

### DIFF
--- a/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
@@ -113,7 +113,7 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
                 to confirm the update in case more than one confirmation is required for this Safe.
               </Paragraph>
 
-              {/* A warning for 1.1.1 -> 1.3.0 upgrades */}
+              {/* A warning for 1.x.x -> 1.3.0 upgrades */}
               <Paragraph>
                 <b>Warning</b>: this upgrade will invalidate all unexecuted transactions. This means you will be unable
                 to access or execute them after the upgrade. Please make sure to execute any remaining transactions

--- a/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
@@ -1,6 +1,4 @@
 import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
-import IconButton from '@material-ui/core/IconButton'
-import Close from '@material-ui/icons/Close'
 import { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 
@@ -9,7 +7,6 @@ import { useStyles } from './style'
 import { LATEST_SAFE_VERSION } from 'src/utils/constants'
 import Link from 'src/components/layout/Link'
 import Block from 'src/components/layout/Block'
-import Hairline from 'src/components/layout/Hairline'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { getUpgradeSafeTransactionHash } from 'src/logic/safe/utils/upgradeSafe'
@@ -91,21 +88,18 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
     >
       {(txParameters, toggleEditMode) => (
         <>
-          <Row align="center" className={classes.heading} grow>
-            <Paragraph className={classes.headingText} noMargin weight="bolder">
+          <Modal.Header onClose={onClose}>
+            <Modal.Header.Title size="xs" withoutMargin>
               Update to new Safe version
-            </Paragraph>
-            <IconButton disableRipple onClick={onClose}>
-              <Close className={classes.close} />
-            </IconButton>
-          </Row>
-          <Hairline />
+            </Modal.Header.Title>
+          </Modal.Header>
+
           <Block className={classes.modalContent}>
             <Row>
-              <Paragraph>
+              <Paragraph noMargin>
                 Update now to take advantage of new features and the highest security standards available.
               </Paragraph>
-              <Block>
+              <Paragraph>
                 To check details about updates added by this smart contract version please visit{' '}
                 <Link
                   target="_blank"
@@ -113,10 +107,17 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
                 >
                   latest Gnosis Safe contracts changelog
                 </Link>
-              </Block>
-              <Paragraph>
+              </Paragraph>
+              <Paragraph noMargin>
                 You will need to confirm this update just like any other transaction. This means other owners will have
                 to confirm the update in case more than one confirmation is required for this Safe.
+              </Paragraph>
+
+              {/* A warning for 1.1.1 -> 1.3.0 upgrades */}
+              <Paragraph>
+                <b>Warning</b>: this upgrade will invalidate all unexecuted transactions. This means you will be unable
+                to access or execute them after the upgrade. Please make sure to execute any remaining transactions
+                before upgrading.
               </Paragraph>
             </Row>
             {/* Tx Parameters */}


### PR DESCRIPTION
## What it solves
Resolves #2787

## How this PR fixes it
Adds a piece of text in the upgrade popup

## How to test it
* Go to settings
* Click on upgrade safe

## Screenshots
<img width="856" alt="Screenshot 2021-10-04 at 11 06 49" src="https://user-images.githubusercontent.com/381895/135824404-dcce043f-6cad-4f2f-be6c-2c070313dbf3.png">


