### PR TITLE
Fix collectibles being cached across safes

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -67,20 +67,14 @@ const App: React.FC = ({ children }) => {
   const { toggleSidebar } = useContext(SafeListSidebarContext)
   const matchSafe = useRouteMatch({ path: `${SAFELIST_ADDRESS}`, strict: false })
   const history = useHistory()
-  const {
-    address: safeAddress,
-    name: safeName,
-    totalFiatBalance: currentSafeBalance,
-  } = useSelector(currentSafeWithNames)
+  const { name: safeName, totalFiatBalance: currentSafeBalance } = useSelector(currentSafeWithNames)
   const addressFromUrl = useSelector(safeAddressFromUrl)
   const { safeActionsState, onShow, onHide, showSendFunds, hideSendFunds } = useSafeActions()
   const currentCurrency = useSelector(currentCurrencySelector)
   const granted = useSelector(grantedSelector)
   const sidebarItems = useSidebarItems()
-  // if safe is loaded via URL, `safeAddress` won't be available until store is populated with temp information
-  // Temp information will be built from `addressFromUrl`
-  const safeLoaded = useLoadSafe(safeAddress || addressFromUrl)
-  useSafeScheduledUpdates(safeLoaded, safeAddress)
+  const safeLoaded = useLoadSafe(addressFromUrl)
+  useSafeScheduledUpdates(safeLoaded, addressFromUrl)
   useAddressBookSync()
 
   const sendFunds = safeActionsState.sendFunds
@@ -122,7 +116,7 @@ const App: React.FC = ({ children }) => {
 
           <AppLayout
             sidebarItems={sidebarItems}
-            safeAddress={safeAddress}
+            safeAddress={addressFromUrl}
             safeName={safeName}
             balance={balance}
             granted={granted}
@@ -140,7 +134,7 @@ const App: React.FC = ({ children }) => {
             selectedToken={sendFunds.selectedToken}
           />
 
-          {safeAddress && (
+          {addressFromUrl && (
             <Modal
               description="Receive Tokens Form"
               handleClose={onReceiveHide}
@@ -148,7 +142,7 @@ const App: React.FC = ({ children }) => {
               paperClassName="receive-modal"
               title="Receive Tokens"
             >
-              <ReceiveModal onClose={onReceiveHide} safeAddress={safeAddress} safeName={safeName} />
+              <ReceiveModal onClose={onReceiveHide} safeAddress={addressFromUrl} safeName={safeName} />
             </Modal>
           )}
         </>

--- a/src/logic/safe/hooks/useLoadSafe.tsx
+++ b/src/logic/safe/hooks/useLoadSafe.tsx
@@ -14,6 +14,12 @@ export const useLoadSafe = (safeAddress?: string): boolean => {
   const [isSafeLoaded, setIsSafeLoaded] = useState(false)
 
   useEffect(() => {
+    if (isSafeLoaded) {
+      setIsSafeLoaded(false)
+    }
+  }, [safeAddress])
+
+  useEffect(() => {
     const fetchData = async () => {
       if (safeAddress) {
         await dispatch(fetchSelectedCurrency())
@@ -23,8 +29,6 @@ export const useLoadSafe = (safeAddress?: string): boolean => {
         await dispatch(updateAvailableCurrencies())
         await dispatch(fetchTransactions(safeAddress))
         dispatch(addViewedSafe(safeAddress))
-      } else {
-        setIsSafeLoaded(false)
       }
     }
     fetchData()

--- a/src/logic/safe/hooks/useLoadSafe.tsx
+++ b/src/logic/safe/hooks/useLoadSafe.tsx
@@ -14,9 +14,7 @@ export const useLoadSafe = (safeAddress?: string): boolean => {
   const [isSafeLoaded, setIsSafeLoaded] = useState(false)
 
   useEffect(() => {
-    if (isSafeLoaded) {
-      setIsSafeLoaded(false)
-    }
+    setIsSafeLoaded(false)
   }, [safeAddress])
 
   useEffect(() => {

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -8,11 +8,9 @@ import { checksumAddress } from 'src/utils/checksumAddress'
 import { buildSafeOwners, extractRemoteSafeInfo } from './utils'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { store } from 'src/store'
-import { currentSafe } from '../selectors'
+import { currentSafeWithNames } from '../selectors'
 import fetchTransactions from './transactions/fetchTransactions'
 import { fetchCollectibles } from 'src/logic/collectibles/store/actions/fetchCollectibles'
-import { matchPath } from 'react-router-dom'
-import { SAFE_ROUTES } from 'src/routes/routes'
 
 /**
  * Builds a Safe Record that will be added to the app's store
@@ -83,13 +81,9 @@ export const fetchSafe =
       const state = store.getState()
 
       // If these polling timestamps have changed, fetch again
-      const { collectiblesTag, txQueuedTag, txHistoryTag } = currentSafe(state)
+      const { collectiblesTag, txQueuedTag, txHistoryTag } = currentSafeWithNames(state)
 
-      const isCollectiblesPage = !!matchPath<{ safeAddress: string }>(state.router.location.pathname, {
-        path: SAFE_ROUTES.ASSETS_COLLECTIBLES,
-      })
-
-      const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag && isCollectiblesPage
+      const shouldUpdateCollectibles = collectiblesTag !== safeInfo.collectiblesTag
       const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag
       const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag
 


### PR DESCRIPTION
## What it solves
Resolves #2786

## How this PR fixes it
As with the upcoming `l2-ux`, the safe address from the URL is now the source for safe loading. The `isSafeLoaded` flag now depends on this changing address and the removal the fetching `isCollectiblesPage` flag has been removed.

## How to test it
Open a safe that has collectibles, then switch to one that has none. The second one should not display collectibles from the first. Switching back to the first should also not show none.