### PR TITLE
Don't deploy Rinkeby on dev

### DIFF
--- a/.github/workflows/deploy-rinkeby.yml
+++ b/.github/workflows/deploy-rinkeby.yml
@@ -112,11 +112,6 @@ jobs:
         env:
           REVIEW_FEATURE_URL: https://pr${{ github.event.number }}--${{ env.REPO_NAME_ALPHANUMERIC }}.review.gnosisdev.com
 
-      # Script to deploy to the dev environment
-      - name: 'Deploy to S3: Dev'
-        if: github.ref == 'refs/heads/dev'
-        run: aws s3 sync build s3://${{ secrets.AWS_DEV_BUCKET_NAME }}/app --delete
-
       # Script to deploy to staging environment
       - name: 'Deploy to S3: Staging'
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## What it solves
We're going to use the dev site for l2-ux instead of the dev branch temporarily.
See https://github.com/gnosis/safe-react/commit/9d3d172a64a4bb46a05cea4b4c9fb8fd5972c846#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R125