### PR TITLE
Chore: remove toString from gas params

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
@@ -87,7 +87,7 @@ const useTxInfo = (transaction: Props['transaction']) => {
   const baseGas = useMemo(
     () =>
       isMultiSigExecutionDetails(t.current.txDetails.detailedExecutionInfo)
-        ? t.current.txDetails.detailedExecutionInfo.baseGas.toString()
+        ? t.current.txDetails.detailedExecutionInfo.baseGas
         : '0',
     [],
   )
@@ -103,7 +103,7 @@ const useTxInfo = (transaction: Props['transaction']) => {
   const safeTxGas = useMemo(
     () =>
       isMultiSigExecutionDetails(t.current.txDetails.detailedExecutionInfo)
-        ? t.current.txDetails.detailedExecutionInfo.safeTxGas.toString()
+        ? t.current.txDetails.detailedExecutionInfo.safeTxGas
         : '0',
     [],
   )


### PR DESCRIPTION
## What it solves
Resolves #2719

The API was deployed to prod, so we can safely remove this backwards-compatible casting.

## How to test it
Case 1:
* Create and approve a transaction
* Make sure the gas is passed to metamask

Case 2:
* Create a transaction
* Edit the gas in Advanced settings
* Make sure the gas is passed to metamask
