### PR TITLE
[L2-UX] GA: set the chainId as a custom dimension

### DIFF
--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import ReactGA, { EventArgs } from 'react-ga'
-import { getCurrentEnvironment, getNetworkInfo } from 'src/config'
+import { getCurrentEnvironment, getNetworkId, getNetworkInfo } from 'src/config'
 
 import { getGoogleAnalyticsTrackingID } from 'src/config'
 import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
@@ -30,12 +30,23 @@ export const trackAnalyticsEvent = (event: Parameters<typeof ReactGA.event>[0]):
     { hitType: 'event', chainName },
   )
 
-  return shouldUseGoogleAnalytics
-    ? ReactGA.ga('send', fieldsObject)
-    : console.info('[GA] - Event:', { ...event, chainName })
+  if (!shouldUseGoogleAnalytics) {
+    console.info('[GA] - Event:', { ...event, chainName })
+    return
+  }
+
+  ReactGA.set({ dimension1: getNetworkId() })
+  ReactGA.ga('send', fieldsObject)
 }
+
 const trackAnalyticsPage: typeof ReactGA.pageview = (...args) => {
-  return shouldUseGoogleAnalytics ? ReactGA.pageview(...args) : console.info('[GA] - Page:', ...args)
+  if (!shouldUseGoogleAnalytics) {
+    console.info('[GA] - Page:', ...args)
+    return
+  }
+
+  ReactGA.set({ dimension1: getNetworkId() })
+  ReactGA.pageview(...args)
 }
 
 let analyticsLoaded = false
@@ -56,6 +67,7 @@ export const loadGoogleAnalytics = (): void => {
     anonymizeIp: true,
     appName: `Gnosis Safe Web`,
     appVersion: process.env.REACT_APP_APP_VERSION,
+    dimension1: getNetworkId(),
   }
 
   if (shouldUseGoogleAnalytics) {


### PR DESCRIPTION
## What it solves
Resolves #2703

## How this PR fixes it
Sets the chain id initially and when it changes.

## How to test it
I've tested it locally by providing the GA id in an env variable. It correctly sends the `cd1` query param depending in the network.

## Screenshots
Rinkeby:

<img width="671" alt="Screenshot 2021-10-07 at 13 41 22" src="https://user-images.githubusercontent.com/381895/136378654-470b09c3-b0dd-4cfe-811c-3b05ee5ab5a5.png">

After switching to Polygon:

<img width="1088" alt="Screenshot 2021-10-07 at 13 51 46" src="https://user-images.githubusercontent.com/381895/136378795-8e44ddca-364e-4e49-86d3-98b55dc7812a.png">
