### PR TITLE
[L2-UX] Sidebar: owned safes padding only when there are added safes

### DIFF
--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -36,9 +36,14 @@ const StyledList = styled(MuiList)`
 
 const useStyles = makeStyles({
   listItemCollapse: {
+    '&:not(:first-child)': {
+      paddingTop: '10px',
+    },
+
     padding: '0 0 0 0',
     '& > div > div:first-child': {
       paddingLeft: '44px',
+      paddingTop: '0',
     },
   },
 })


### PR DESCRIPTION
## What it solves
A small CSS fix for the Owned Safes to not have a top padding when it's a single element in the network section.
<img width="502" alt="Screenshot 2021-10-12 at 11 38 47" src="https://user-images.githubusercontent.com/381895/136932257-b4dbacf1-6d95-4823-8ed6-57720b0f4ebc.png">

But it gets a padding when there are added safes:
<img width="458" alt="Screenshot 2021-10-12 at 11 38 34" src="https://user-images.githubusercontent.com/381895/136932272-a5801adf-e084-45c8-abf1-38abf4e2ba44.png">


