### PR TITLE
Create shortName enum

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,7 @@ import networks from 'src/config/networks'
 import {
   EnvironmentSettings,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   FEATURES,
   GasPriceOracle,
   NetworkConfig,
@@ -70,7 +71,7 @@ export const usesInfuraRPC = [ETHEREUM_NETWORK.MAINNET, ETHEREUM_NETWORK.RINKEBY
   getNetworkId(),
 )
 
-export const getCurrentShortChainName = (): string => getConfig().network.shortName
+export const getCurrentShortChainName = (): SHORT_NAME => getConfig().network.shortName
 
 export const getShortChainNameById = (networkId = getNetworkId()): string =>
   getNetworkConfigById(networkId)?.network?.shortName || getCurrentShortChainName()

--- a/src/config/networks/arbitrum.ts
+++ b/src/config/networks/arbitrum.ts
@@ -3,6 +3,7 @@ import {
   EnvironmentSettings,
   ETHEREUM_LAYER,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   FEATURES,
   NetworkConfig,
   WALLETS,
@@ -33,7 +34,7 @@ const arbitrum: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.ARBITRUM,
-    shortName: 'arb',
+    shortName: SHORT_NAME.ARBITRUM,
     backgroundColor: '#2A3245',
     textColor: '#ffffff',
     label: 'Arbitrum',

--- a/src/config/networks/bsc.ts
+++ b/src/config/networks/bsc.ts
@@ -3,6 +3,7 @@ import {
   EnvironmentSettings,
   ETHEREUM_LAYER,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   FEATURES,
   NetworkConfig,
   WALLETS,
@@ -28,7 +29,7 @@ const bsc: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.BSC,
-    shortName: 'bnb',
+    shortName: SHORT_NAME.BSC,
     backgroundColor: '#d0980b',
     textColor: '#ffffff',
     label: 'BSC',

--- a/src/config/networks/energy_web_chain.ts
+++ b/src/config/networks/energy_web_chain.ts
@@ -3,6 +3,7 @@ import {
   EnvironmentSettings,
   ETHEREUM_LAYER,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   NetworkConfig,
   WALLETS,
 } from 'src/config/networks/network.d'
@@ -36,7 +37,7 @@ const mainnet: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.ENERGY_WEB_CHAIN,
-    shortName: 'ewt',
+    shortName: SHORT_NAME.ENERGY_WEB_CHAIN,
     backgroundColor: '#A566FF',
     textColor: '#ffffff',
     label: 'EWC',

--- a/src/config/networks/local.ts
+++ b/src/config/networks/local.ts
@@ -1,5 +1,11 @@
 import EtherLogo from 'src/config/assets/token_eth.svg'
-import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, NetworkConfig } from 'src/config/networks/network.d'
+import {
+  EnvironmentSettings,
+  ETHEREUM_LAYER,
+  ETHEREUM_NETWORK,
+  SHORT_NAME,
+  NetworkConfig,
+} from 'src/config/networks/network.d'
 
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'http://localhost:8001/v1',
@@ -30,7 +36,7 @@ const local: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.LOCAL,
-    shortName: 'local',
+    shortName: SHORT_NAME.LOCAL,
     backgroundColor: '#E8673C',
     textColor: '#ffffff',
     label: 'LocalRPC',

--- a/src/config/networks/mainnet.ts
+++ b/src/config/networks/mainnet.ts
@@ -1,5 +1,11 @@
 import EtherLogo from 'src/config/assets/token_eth.svg'
-import { EnvironmentSettings, ETHEREUM_LAYER, ETHEREUM_NETWORK, NetworkConfig } from 'src/config/networks/network.d'
+import {
+  EnvironmentSettings,
+  ETHEREUM_LAYER,
+  ETHEREUM_NETWORK,
+  SHORT_NAME,
+  NetworkConfig,
+} from 'src/config/networks/network.d'
 import { WALLETS } from 'src/config/networks/network.d'
 
 const baseConfig: EnvironmentSettings = {
@@ -37,7 +43,7 @@ const mainnet: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.MAINNET,
-    shortName: 'eth',
+    shortName: SHORT_NAME.MAINNET,
     backgroundColor: '#E8E7E6',
     textColor: '#001428',
     label: 'Mainnet',

--- a/src/config/networks/network.d.ts
+++ b/src/config/networks/network.d.ts
@@ -57,9 +57,23 @@ export enum ETHEREUM_NETWORK {
   VOLTA = '73799',
 }
 
+// Take from: https://chainid.network/shortNameMapping.json
+// Reference shortName here: https://github.com/ethereum-lists/chains
+export enum SHORT_NAME {
+  MAINNET = 'eth',
+  RINKEBY = 'rin',
+  BSC = 'bnb',
+  XDAI = 'xdai',
+  POLYGON = 'matic',
+  ENERGY_WEB_CHAIN = 'ewt',
+  LOCAL = 'local',
+  ARBITRUM = 'arb1',
+  VOLTA = 'vt',
+}
+
 export type NetworkSettings = {
   id: ETHEREUM_NETWORK
-  shortName: string
+  shortName: SHORT_NAME
   backgroundColor: string
   textColor: string
   label: string

--- a/src/config/networks/polygon.ts
+++ b/src/config/networks/polygon.ts
@@ -3,6 +3,7 @@ import {
   EnvironmentSettings,
   ETHEREUM_LAYER,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   FEATURES,
   NetworkConfig,
   WALLETS,
@@ -38,7 +39,7 @@ const polygon: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.POLYGON,
-    shortName: 'matic',
+    shortName: SHORT_NAME.POLYGON,
     backgroundColor: '#8B50ED',
     textColor: '#ffffff',
     label: 'Polygon',

--- a/src/config/networks/rinkeby.ts
+++ b/src/config/networks/rinkeby.ts
@@ -3,6 +3,7 @@ import {
   EnvironmentSettings,
   ETHEREUM_LAYER,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   NetworkConfig,
   WALLETS,
 } from 'src/config/networks/network.d'
@@ -42,7 +43,7 @@ const rinkeby: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.RINKEBY,
-    shortName: 'rin',
+    shortName: SHORT_NAME.RINKEBY,
     backgroundColor: '#E8673C',
     textColor: '#ffffff',
     label: 'Rinkeby',

--- a/src/config/networks/volta.ts
+++ b/src/config/networks/volta.ts
@@ -3,6 +3,7 @@ import {
   EnvironmentSettings,
   ETHEREUM_LAYER,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   NetworkConfig,
   WALLETS,
 } from 'src/config/networks/network.d'
@@ -33,7 +34,7 @@ const mainnet: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.VOLTA,
-    shortName: 'vt',
+    shortName: SHORT_NAME.VOLTA,
     backgroundColor: '#514989',
     textColor: '#ffffff',
     label: 'Volta',

--- a/src/config/networks/xdai.ts
+++ b/src/config/networks/xdai.ts
@@ -3,6 +3,7 @@ import {
   EnvironmentSettings,
   ETHEREUM_LAYER,
   ETHEREUM_NETWORK,
+  SHORT_NAME,
   FEATURES,
   NetworkConfig,
   WALLETS,
@@ -28,7 +29,7 @@ const xDai: NetworkConfig = {
   },
   network: {
     id: ETHEREUM_NETWORK.XDAI,
-    shortName: 'xdai',
+    shortName: SHORT_NAME.XDAI,
     backgroundColor: '#48A8A6',
     textColor: '#ffffff',
     label: 'xDai',

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,7 +1,8 @@
 import { createBrowserHistory } from 'history'
 import { generatePath, matchPath } from 'react-router-dom'
 
-import { getCurrentShortChainName, getNetworks } from 'src/config'
+import { getCurrentShortChainName } from 'src/config'
+import { SHORT_NAME } from 'src/config/networks/network.d'
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { PUBLIC_URL } from 'src/utils/constants'
 
@@ -56,8 +57,7 @@ export const SAFE_ROUTES = {
 export type SafeRouteParams = { shortName: string; safeAddress: string }
 
 const isValidShortChainName = (shortName: string): boolean => {
-  if (!shortName) return false
-  const shortNames = getNetworks().map(({ shortName }) => shortName)
+  const shortNames: string[] = Object.values(SHORT_NAME)
   return shortNames.includes(shortName)
 }
 


### PR DESCRIPTION
## Description
All `shortName`s are now centralised in a `SHORT_NAME` enum and the Arbitrum `shortName` was changed to match the EIP-3770 standard.