### PR TITLE
Fix network not setting via route

### DIFF
--- a/src/logic/config/utils/index.ts
+++ b/src/logic/config/utils/index.ts
@@ -1,4 +1,4 @@
-import { setNetworkId, getNetworkName, getConfig } from 'src/config'
+import { setNetworkId, getConfig } from 'src/config'
 import { ETHEREUM_NETWORK } from 'src/config/networks/network'
 import { makeNetworkConfig } from 'src/logic/config/model/networkConfig'
 import { configStore } from 'src/logic/config/store/actions'

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,7 +19,8 @@ import {
   ROOT_ROUTE,
   LOAD_SAFE_ROUTE,
 } from './routes'
-import { getCurrentShortChainName, getNetworks, setNetworkId } from 'src/config'
+import { getCurrentShortChainName, getNetworks } from 'src/config'
+import { setNetwork } from 'src/logic/config/utils'
 
 const Welcome = React.lazy(() => import('./welcome/Welcome'))
 const CreateSafePage = React.lazy(() => import('./CreateSafePage/CreateSafePage'))
@@ -56,7 +57,7 @@ const Routes = (): React.ReactElement => {
             key={id}
             path={`/${label.toLowerCase()}`}
             render={() => {
-              setNetworkId(id)
+              setNetwork(id)
               // Last viewed safe logic will be handled with defaultSafe below
               return <Redirect to={ROOT_ROUTE} />
             }}


### PR DESCRIPTION
## What it solves
Network not being set when accessing the safe via a `/app/<chain>` URL.

## How this PR fixes it
Calls the correct function.

## How to test it
Open a network via its route and check that the suggested network to connect to matches.