### PR TITLE
[L2-UX] Make NetworkSelector buttons actual links

### DIFF
--- a/src/components/AppLayout/Header/components/Layout.tsx
+++ b/src/components/AppLayout/Header/components/Layout.tsx
@@ -14,7 +14,6 @@ import Row from 'src/components/layout/Row'
 import { headerHeight, md, screenSm, sm } from 'src/theme/variables'
 import { useStateHandler } from 'src/logic/hooks/useStateHandler'
 import SafeLogo from '../assets/gnosis-safe-multisig-logo.svg'
-import { getNetworks } from 'src/config'
 import { WELCOME_ROUTE } from 'src/routes/routes'
 
 const styles = () => ({
@@ -88,7 +87,6 @@ const WalletPopup = ({ anchorEl, providerDetails, classes, open, onClose }) => {
 const Layout = ({ classes, providerDetails, providerInfo, shouldSwitchChain }) => {
   const { clickAway, open, toggle } = useStateHandler()
   const { clickAway: clickAwayNetworks, open: openNetworks, toggle: toggleNetworks } = useStateHandler()
-  const networks = getNetworks()
   const { isDesktop } = window
   const isOpen = open || shouldSwitchChain
 
@@ -116,14 +114,7 @@ const Layout = ({ classes, providerDetails, providerInfo, shouldSwitchChain }) =
           )
         }
       />
-      {!isDesktop && (
-        <NetworkSelector
-          open={openNetworks}
-          networks={networks}
-          toggle={toggleNetworks}
-          clickAway={clickAwayNetworks}
-        />
-      )}
+      {!isDesktop && <NetworkSelector open={openNetworks} toggle={toggleNetworks} clickAway={clickAwayNetworks} />}
     </Row>
   )
 }

--- a/src/components/AppLayout/Header/components/NetworkSelector.tsx
+++ b/src/components/AppLayout/Header/components/NetworkSelector.tsx
@@ -14,12 +14,13 @@ import { Divider, Icon } from '@gnosis.pm/safe-react-components'
 import NetworkLabel from './NetworkLabel'
 import Col from 'src/components/layout/Col'
 import { screenSm, sm } from 'src/theme/variables'
-import { sameString } from 'src/utils/strings'
-import { getNetworkName } from 'src/config'
+import { getNetworkConfigById } from 'src/config'
 import { ReturnValue } from 'src/logic/hooks/useStateHandler'
-import { NetworkInfo } from 'src/config/networks/network'
+import { ETHEREUM_NETWORK } from 'src/config/networks/network'
 import { setNetwork } from 'src/logic/config/utils'
-import { ROOT_ROUTE } from 'src/routes/routes'
+import { NETWORK_ROOT_ROUTES, ROOT_ROUTE } from 'src/routes/routes'
+import { useSelector } from 'react-redux'
+import { currentChainId } from 'src/logic/config/store/selectors'
 
 const styles = {
   root: {
@@ -76,20 +77,19 @@ const StyledDivider = styled(Divider)`
   margin: 0;
 `
 
-type NetworkSelectorProps = ReturnValue & {
-  networks: NetworkInfo[]
-}
+type NetworkSelectorProps = ReturnValue
 
-const NetworkSelector = ({ open, toggle, networks, clickAway }: NetworkSelectorProps): ReactElement => {
+const NetworkSelector = ({ open, toggle, clickAway }: NetworkSelectorProps): ReactElement => {
   const networkRef = useRef(null)
   const history = useHistory()
   const classes = useStyles()
-  const networkName = getNetworkName().toLowerCase()
+  const chainId = useSelector(currentChainId)
 
   const onNetworkSwitch = useCallback(
-    (network: NetworkInfo) => {
+    (e: React.SyntheticEvent, networkId: ETHEREUM_NETWORK) => {
+      e.preventDefault()
       clickAway()
-      setNetwork(network.id)
+      setNetwork(networkId)
       history.push(ROOT_ROUTE)
     },
     [clickAway, history],
@@ -118,13 +118,12 @@ const NetworkSelector = ({ open, toggle, networks, clickAway }: NetworkSelectorP
             <>
               <ClickAwayListener mouseEvent="onClick" onClickAway={clickAway} touchEvent={false}>
                 <List className={classes.network} component="div">
-                  {networks.map((network) => (
-                    <Fragment key={network.id}>
-                      <StyledLink onClick={() => onNetworkSwitch(network)}>
-                        <NetworkLabel networkInfo={network} />
-                        {sameString(networkName, network.label?.toLowerCase()) && (
-                          <Icon type="check" size="md" color="primary" />
-                        )}
+                  {NETWORK_ROOT_ROUTES.map(({ id, route }) => (
+                    <Fragment key={id}>
+                      <StyledLink onClick={(e) => onNetworkSwitch(e, id)} href={route}>
+                        <NetworkLabel networkInfo={getNetworkConfigById(id)?.network} />
+
+                        {chainId === id && <Icon type="check" size="md" color="primary" />}
                       </StyledLink>
                       <StyledDivider />
                     </Fragment>

--- a/src/routes/CreateSafePage/steps/SelectWalletAndNetworkStep.tsx
+++ b/src/routes/CreateSafePage/steps/SelectWalletAndNetworkStep.tsx
@@ -79,7 +79,7 @@ function SelectWalletAndNetworkStep(): ReactElement {
         <StyledDialogContent dividers>
           <List component="div">
             {networks.map((network) => (
-              <NetworkLabelItem key={network.id} role={'button'} onClick={() => onNetworkSwitch(network.id)}>
+              <NetworkLabelItem key={network.id} role="button" onClick={() => onNetworkSwitch(network.id)}>
                 <NetworkLabel networkInfo={network} flexGrow />
               </NetworkLabelItem>
             ))}
@@ -114,6 +114,10 @@ const NetworkLabelItem = styled.div`
   margin: ${lg} auto;
   cursor: pointer;
   max-width: 50%;
+
+  & > span {
+    font-size: 13px;
+  }
 `
 
 export default SelectWalletAndNetworkStep

--- a/src/routes/LoadSafePage/steps/SelectNetworkStep.tsx
+++ b/src/routes/LoadSafePage/steps/SelectNetworkStep.tsx
@@ -58,7 +58,7 @@ function SelectNetworkStep(): ReactElement {
         <StyledDialogContent dividers>
           <List component="div">
             {networks.map((network) => (
-              <NetworkLabelItem key={network.id} role={'button'} onClick={() => onNetworkSwitch(network.id)}>
+              <NetworkLabelItem key={network.id} role="button" onClick={() => onNetworkSwitch(network.id)}>
                 <NetworkLabel networkInfo={network} flexGrow />
               </NetworkLabelItem>
             ))}
@@ -94,4 +94,8 @@ const NetworkLabelItem = styled.div`
   margin: ${lg} auto;
   cursor: pointer;
   max-width: 50%;
+
+  & > span {
+    font-size: 13px;
+  }
 `

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -18,8 +18,9 @@ import {
   hasPrefixedSafeAddressInUrl,
   ROOT_ROUTE,
   LOAD_SAFE_ROUTE,
+  NETWORK_ROOT_ROUTES,
 } from './routes'
-import { getCurrentShortChainName, getNetworks } from 'src/config'
+import { getCurrentShortChainName } from 'src/config'
 import { setNetwork } from 'src/logic/config/utils'
 
 const Welcome = React.lazy(() => import('./welcome/Welcome'))
@@ -52,10 +53,10 @@ const Routes = (): React.ReactElement => {
     <Switch>
       {
         // Redirection to open network specific welcome pages
-        getNetworks().map(({ id, label }) => (
+        NETWORK_ROOT_ROUTES.map(({ id, route }) => (
           <Route
             key={id}
-            path={`/${label.toLowerCase()}`}
+            path={route}
             render={() => {
               setNetwork(id)
               // Last viewed safe logic will be handled with defaultSafe below

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,8 +1,8 @@
 import { createBrowserHistory } from 'history'
 import { generatePath, matchPath } from 'react-router-dom'
 
-import { getCurrentShortChainName } from 'src/config'
-import { SHORT_NAME } from 'src/config/networks/network.d'
+import { getCurrentShortChainName, getNetworks } from 'src/config'
+import { ETHEREUM_NETWORK, SHORT_NAME } from 'src/config/networks/network.d'
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { PUBLIC_URL } from 'src/utils/constants'
 
@@ -53,6 +53,14 @@ export const SAFE_ROUTES = {
   SETTINGS_SPENDING_LIMIT: `${ADDRESSED_ROUTE}/settings/spending-limit`,
   SETTINGS_ADVANCED: `${ADDRESSED_ROUTE}/settings/advanced`,
 }
+
+// [{ id: '4', route: '/rinkeby'}]
+export const NETWORK_ROOT_ROUTES: Array<{ id: ETHEREUM_NETWORK; route: string }> = getNetworks().map(
+  ({ id, label }) => ({
+    id,
+    route: `/${label.toLowerCase()}`,
+  }),
+)
 
 export type SafeRouteParams = { shortName: string; safeAddress: string }
 


### PR DESCRIPTION
I've adjusted the look & feel of our two network selectors a bit:

* In the site-wide menu, the buttons are now actual links (so the cursor is hand, and Open in New Tab works)
* Bigger font-size of buttons in the onboarding Network Selection step

<img width="763" alt="Screenshot 2021-10-12 at 16 39 29" src="https://user-images.githubusercontent.com/381895/136977230-50e80824-8856-4d92-a120-bfd5a69a7255.png">
