### PR TITLE
[L2-UX] Fix Settings breadcrumbs; add ChainIndicator in Safe Details

### DIFF
--- a/src/routes/safe/components/Settings/Advanced/index.tsx
+++ b/src/routes/safe/components/Settings/Advanced/index.tsx
@@ -83,7 +83,7 @@ const Advanced = (): ReactElement => {
       {/* Transaction guard */}
       <Block className={classes.container}>
         <Title size="xs" withoutMargin>
-          Transaction guard
+          Transaction Guard
         </Title>
         <InfoText size="lg">
           Transaction guards impose additional constraints that are checked prior to executing a Safe transaction.

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -35,6 +35,8 @@ import {
 import { useAnalytics, SAFE_NAVIGATION_EVENT } from 'src/utils/googleAnalytics'
 import { fetchMasterCopies, MasterCopy, MasterCopyDeployer } from 'src/logic/contracts/api/masterCopies'
 import { getMasterCopyAddressFromProxyAddress } from 'src/logic/contracts/safeContracts'
+import { currentChainId } from 'src/logic/config/store/selectors'
+import ChainIndicator from 'src/components/ChainIndicator'
 
 export const SAFE_NAME_INPUT_TEST_ID = 'safe-name-input'
 export const SAFE_NAME_SUBMIT_BTN_TEST_ID = 'change-safe-name-btn'
@@ -50,6 +52,9 @@ const StyledIcon = styled(Icon)`
   top: 3px;
   left: 6px;
 `
+const StyledParagraph = styled(Paragraph)`
+  margin-bottom: 0;
+`
 
 const SafeDetails = (): ReactElement => {
   const classes = useStyles()
@@ -60,6 +65,7 @@ const SafeDetails = (): ReactElement => {
     needsUpdate: safeNeedsUpdate,
     currentVersion: safeCurrentVersion,
   } = useSelector(currentSafe)
+  const chainId = useSelector(currentChainId)
   const safeNamesMap = useSelector(safesWithNamesAsMap)
   const safeName = safeNamesMap[safeAddress]?.name
 
@@ -153,9 +159,17 @@ const SafeDetails = (): ReactElement => {
               </Row>
             ) : null}
           </Block>
+
+          <Block className={classes.formContainer}>
+            <Heading tag="h2">Blockchain Network</Heading>
+            <StyledParagraph>
+              <ChainIndicator chainId={chainId} />
+            </StyledParagraph>
+          </Block>
+
           {safeName != null && (
             <Block className={classes.formContainer}>
-              <Heading tag="h2">Modify Safe name</Heading>
+              <Heading tag="h2">Modify Safe Name</Heading>
               <Paragraph>
                 You can change the name of this Safe. This name is only stored locally and never shared with Gnosis or
                 any third parties.
@@ -174,6 +188,7 @@ const SafeDetails = (): ReactElement => {
               </Block>
             </Block>
           )}
+
           <Row align="end" className={classes.controlsRow} grow>
             <Col end="xs">
               <Button

--- a/src/routes/safe/components/Settings/ThresholdSettings/index.tsx
+++ b/src/routes/safe/components/Settings/ThresholdSettings/index.tsx
@@ -37,7 +37,7 @@ const ThresholdSettings = (): React.ReactElement => {
   return (
     <>
       <Block className={classes.container}>
-        <Heading tag="h2">Required confirmations</Heading>
+        <Heading tag="h2">Required Confirmations</Heading>
         <Paragraph>Any transaction requires the confirmation of:</Paragraph>
         <Paragraph className={classes.ownersText} size="lg">
           <Bold>{threshold}</Bold> out of <Bold>{owners?.length || 0}</Bold> owners

--- a/src/routes/safe/components/Settings/index.tsx
+++ b/src/routes/safe/components/Settings/index.tsx
@@ -12,7 +12,7 @@ import Col from 'src/components/layout/Col'
 import Span from 'src/components/layout/Span'
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
-import { generatePrefixedAddressRoutes, SAFE_ROUTES, SAFE_SUBSECTION_SLUG } from 'src/routes/routes'
+import { generatePrefixedAddressRoutes, SAFE_ROUTES, SAFE_SUBSECTION_ROUTE } from 'src/routes/routes'
 import { getCurrentShortChainName } from 'src/config'
 
 const Advanced = lazy(() => import('./Advanced'))
@@ -37,7 +37,7 @@ const Settings = (): React.ReactElement => {
   const granted = useSelector(grantedSelector)
 
   // Question mark makes matching [SAFE_SUBSECTION_SLUG] optional
-  const matchSafeWithSettingSection = useRouteMatch(`${SAFE_SUBSECTION_SLUG}?`)
+  const matchSafeWithSettingSection = useRouteMatch(`${SAFE_SUBSECTION_ROUTE}?`)
 
   const currentSafeRoutes = generatePrefixedAddressRoutes({
     shortName: getCurrentShortChainName(),


### PR DESCRIPTION
## What it solves
* Fixed the missing breadcrumbs text was missing
* Added an indication of the Safe's network in the settings
* Fixed title spelling (capitalized nouns) in the Settings

## Screenshot
<img width="885" alt="Screenshot 2021-10-13 at 16 18 37" src="https://user-images.githubusercontent.com/381895/137152274-af064c79-f86e-4390-9465-51f38603a150.png">