### PR TITLE
Fix: address book import validation

### DIFF
--- a/src/routes/safe/components/AddressBook/__tests__/utils.test.ts
+++ b/src/routes/safe/components/AddressBook/__tests__/utils.test.ts
@@ -1,7 +1,6 @@
 import {
   WRONG_FILE_EXTENSION_ERROR,
   FILE_SIZE_TOO_BIG_ERROR,
-  IMPORT_SUPPORTED_FORMATS,
   validateFile,
   validateCsvData,
   CsvDataType,
@@ -9,26 +8,32 @@ import {
 
 describe('Address Book file validations', () => {
   it('Should return wrong file extension error if file type is not allowed', () => {
-    const file = new File([''], 'file.txt', { type: 'text/plain' })
+    const file = new File([''], 'file.txt', { type: 'audio/wav' })
     const result = validateFile(file)
     expect(result).toBe(WRONG_FILE_EXTENSION_ERROR)
   })
 
   it('Should return wrong file extension error if file extension is not valid', () => {
-    const file = new File([''], 'file.txt', { type: IMPORT_SUPPORTED_FORMATS[0] })
+    const file = new File([''], 'file.doc', { type: 'text/csv' })
     const result = validateFile(file)
     expect(result).toBe(WRONG_FILE_EXTENSION_ERROR)
   })
 
   it('Should return file size error if file size is over the allowed', () => {
-    const file = new File([''], 'file.csv', { type: IMPORT_SUPPORTED_FORMATS[0] })
+    const file = new File([''], 'file.csv', { type: 'text/csv' })
     Object.defineProperty(file, 'size', { value: 1024 * 1024 + 1 })
     const result = validateFile(file)
     expect(result).toBe(FILE_SIZE_TOO_BIG_ERROR)
   })
 
   it('Should return undefined if extension and file size are valid', () => {
-    const file = new File([''], 'file.csv', { type: IMPORT_SUPPORTED_FORMATS[0] })
+    const file = new File([''], 'file.csv', { type: 'text/csv' })
+    const result = validateFile(file)
+    expect(result).toBe(undefined)
+  })
+
+  it('Should accept valid file names', () => {
+    const file = new File([''], 'file (1).txt', { type: 'text/plain' })
     const result = validateFile(file)
     expect(result).toBe(undefined)
   })

--- a/src/routes/safe/components/AddressBook/utils.ts
+++ b/src/routes/safe/components/AddressBook/utils.ts
@@ -3,15 +3,16 @@ import { ETHEREUM_NETWORK } from 'src/config/networks/network.d'
 
 export const WRONG_FILE_EXTENSION_ERROR = 'Only CSV files are allowed'
 export const FILE_SIZE_TOO_BIG_ERROR = 'The size of the file is over 1 MB'
-export const FILE_BYTES_LIMIT = 1000000
-export const IMPORT_SUPPORTED_FORMATS = [
+
+const FILE_BYTES_LIMIT = 1000000
+const IMPORT_SUPPORTED_FORMATS = [
   '',
   'text/csv',
+  'text/plain',
   'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ]
-
-const CSV_EXTENSION_REGEX = /([a-zA-Z0-9\s_\\.\-:])+(.csv|.ods|.xls|.xlsx)$/
+const CSV_EXTENSION_REGEX = /[^.]+\.(txt|csv|tsv|ods|xls|xlsx)$/
 
 export type CsvDataType = { data: string[] }[]
 
@@ -27,9 +28,9 @@ export const validateFile = (file: File): string | undefined => {
   return
 }
 
-const isValidChainId = (chainId) => {
+const isValidChainId = (chainId: string | number): boolean => {
   return Object.keys(ETHEREUM_NETWORK).some((network) => {
-    return ETHEREUM_NETWORK[network] == chainId
+    return ETHEREUM_NETWORK[network] === chainId.toString()
   })
 }
 


### PR DESCRIPTION
## What it solves
Resolves #2861

File names can now contain parens.

## How this PR fixes it
* Adjusts the regex to accept any symbols in the file name
* Also allows plain text files in addition to CSV files

## How to test it
* Try importing a file with `(1)` in its name such as typical for downloaded files on Mac

## Screenshots
<img width="547" alt="Screenshot 2021-10-21 at 12 33 00" src="https://user-images.githubusercontent.com/381895/138260838-a5b05c6a-fc9d-473c-b5d5-e5f6da5aa519.png">

