### PR TITLE
Send correct chainId via walletconnect

### DIFF
--- a/src/logic/wallets/utils/walletList.ts
+++ b/src/logic/wallets/utils/walletList.ts
@@ -19,6 +19,7 @@ const wallets = (): Wallet[] => {
       preferred: true,
       // as stated in the documentation, `infuraKey` is not mandatory if rpc is provided
       rpc: { [getNetworkId()]: rpcUrl },
+      networkId: parseInt(getNetworkId(), 10),
       desktop: true,
       bridge: 'https://safe-walletconnect.gnosis.io/',
     },


### PR DESCRIPTION
Fix what was started with #2815

## What it solves
Up until now walletconnect didn't work for chains with a chainId other than 1.