### PR TITLE
Fix: wrong padding value in TableHead

### DIFF
--- a/src/components/Table/TableHead.tsx
+++ b/src/components/Table/TableHead.tsx
@@ -35,7 +35,7 @@ class GnoTableHead extends React.PureComponent<any> {
             <TableCell
               align={column.align}
               key={column.id}
-              padding={column.disablePadding ? 'none' : 'default'}
+              padding={column.disablePadding ? 'none' : 'normal'}
               sortDirection={orderBy === column.id ? order : false}
             >
               {column.static ? (


### PR DESCRIPTION
## What it solves
Fixes the value of a padding and removes the annoying warning.