### PR TITLE
Update migration URLs; hide QR code prefix settings on prod

### DIFF
--- a/public/migrate-local-storage.html
+++ b/public/migrate-local-storage.html
@@ -7,7 +7,7 @@
         const parentHostnames = [
           'https://gnosis-safe.io',
           'https://safe-team.staging.gnosisdev.com',
-          'https://pr2695--safereact.review-safe.gnosisdev.com',
+          'https://safe-team.dev.gnosisdev.com',
           'http://localhost:3000',
         ]
 
@@ -18,7 +18,7 @@
           messageTargetOrigin = parentHostnames[0]
         } else if (hostname.includes('staging.gnosisdev.com')) {
           messageTargetOrigin = parentHostnames[1]
-        } else if (hostname.includes('.gnosisdev.com')) {
+        } else if (hostname.includes('dev.gnosisdev.com')) {
           messageTargetOrigin = parentHostnames[2]
         } else if (hostname.includes('localhost')) {
           messageTargetOrigin = parentHostnames[3]

--- a/src/components/App/ReceiveModal.tsx
+++ b/src/components/App/ReceiveModal.tsx
@@ -19,6 +19,7 @@ import { getExplorerInfo, getNetworkInfo } from 'src/config'
 import { NetworkSettings } from 'src/config/networks/network'
 import { copyShortNameSelector } from 'src/logic/appearance/selectors'
 import { getPrefixedSafeAddressSlug } from 'src/routes/routes'
+import { IS_PRODUCTION } from 'src/utils/constants'
 
 const useStyles = (networkInfo: NetworkSettings) =>
   makeStyles(
@@ -85,7 +86,7 @@ const ReceiveModal = ({ onClose, safeAddress, safeName }: Props): ReactElement =
   const classes = useStyles(networkInfo)
 
   const copyShortName = useSelector(copyShortNameSelector)
-  const [shouldCopyShortName, setShouldCopyShortName] = useState<boolean>(copyShortName)
+  const [shouldCopyShortName, setShouldCopyShortName] = useState<boolean>(IS_PRODUCTION ? false : copyShortName)
 
   // Does not update store
   const handleCopyChange = (_: ChangeEvent<HTMLInputElement>, checked: boolean) => setShouldCopyShortName(checked)
@@ -116,10 +117,12 @@ const ReceiveModal = ({ onClose, safeAddress, safeName }: Props): ReactElement =
         <Block className={classes.qrContainer}>
           <QRCode size={135} value={qrCodeString} />
         </Block>
-        <FormControlLabel
-          control={<Checkbox checked={shouldCopyShortName} onChange={handleCopyChange} name="shouldCopyShortName" />}
-          label="Copy addresses with chain prefix."
-        />
+        {!IS_PRODUCTION && (
+          <FormControlLabel
+            control={<Checkbox checked={shouldCopyShortName} onChange={handleCopyChange} name="shouldCopyShortName" />}
+            label="Copy addresses with chain prefix."
+          />
+        )}
         <Block className={classes.addressContainer} justify="center">
           <EthHashInfo hash={safeAddress} showAvatar showCopyBtn explorerUrl={getExplorerInfo(safeAddress)} />
         </Block>

--- a/src/components/StoreMigrator/utils.ts
+++ b/src/components/StoreMigrator/utils.ts
@@ -16,8 +16,8 @@ export function getSubdomainUrl(network: NETWORK_TO_MIGRATE): string {
     return `https://${network}.gnosis-safe.io/app`
   } else if (hostname.includes('staging.gnosisdev.com')) {
     return `https://safe-team-${network}.staging.gnosisdev.com/app`
-  } else if (hostname.includes('.gnosisdev.com')) {
-    return `https://pr2778--safereact.review.gnosisdev.com/${network}/app`
+  } else if (hostname.includes('dev.gnosisdev.com')) {
+    return `https://safe-team.dev.gnosisdev.com/app`
   } else if (hostname.includes('localhost')) {
     return 'http://localhost:3001/app'
   } else {


### PR DESCRIPTION
## What it solves
Hides the QR code prefix checkbox for prod.
Updates migration URLs so that we don't log an error on PR deployments.