### PR TITLE
Fix: always connect to the wallet in addition to switching a network

### DIFF
--- a/src/components/ConnectButton/index.tsx
+++ b/src/components/ConnectButton/index.tsx
@@ -7,12 +7,7 @@ import { shouldSwitchNetwork, switchNetwork } from 'src/logic/wallets/utils/netw
 
 const checkWallet = async (): Promise<boolean> => {
   if (shouldSwitchNetwork()) {
-    try {
-      await switchNetwork(onboard().getState().wallet, getNetworkId())
-      return true
-    } catch (e) {
-      e.log()
-    }
+    switchNetwork(onboard().getState().wallet, getNetworkId()).catch((e) => e.log())
   }
 
   return await onboard().walletCheck()


### PR DESCRIPTION
## What it solves
Resolves #2890

## How this PR fixes it
In the [pre L2-UX code](https://github.com/gnosis/safe-react/blob/main/src/components/ConnectButton/index.tsx#L60-L74), we were always calling `walletCheck` which ensured that web3 re-connected to a disconnected wallet. It shows un unnecessary popup but it's fine.

## How to test it
* Fully disconnect your wallet from the app (as per Franco's comment in #2890)
* Switch your wallet to some other network
* Connect to the app again
