### PR TITLE
Fix: checksummed address still shown as invalid

### DIFF
--- a/src/routes/LoadSafePage/LoadSafePage.test.tsx
+++ b/src/routes/LoadSafePage/LoadSafePage.test.tsx
@@ -18,7 +18,7 @@ jest.spyOn(safeVersion, 'getSafeVersionInfo').mockImplementation(async () => ({
 
 const rinkebyNetworkId = '4'
 const validSafeAddress = '0x57CB13cbef735FbDD65f5f2866638c546464E45F'
-const inValidSafeAddress = 'this-is–a-invalid-safe-address-value'
+const invalidSafeAddress = 'this-is–a-invalid-safe-address-value'
 const validSafeENSNameDomain = 'testENSDomain.eth'
 
 describe('<LoadSafePage>', () => {
@@ -192,6 +192,20 @@ describe('<LoadSafePage>', () => {
       })
     })
 
+    it('Checksums valid addresses', async () => {
+      render(<LoadSafePage />)
+
+      fireEvent.click(screen.getByText('Continue'))
+
+      const safeAddressInputNode: HTMLInputElement = screen.getByTestId('load-safe-address-field')
+
+      await waitFor(() => {
+        fireEvent.change(safeAddressInputNode, { target: { value: '0X9913B9180C20C6B0F21B6480C84422F6EBC4B808' } })
+      })
+
+      expect(safeAddressInputNode.value).toBe('0x9913B9180C20C6b0F21B6480c84422F6ebc4B808')
+    })
+
     it('Shows an error if the Safe Address is an invalid Safe Address', () => {
       render(<LoadSafePage />)
 
@@ -199,7 +213,7 @@ describe('<LoadSafePage>', () => {
 
       const safeAddressInputNode = screen.getByTestId('load-safe-address-field')
 
-      fireEvent.change(safeAddressInputNode, { target: { value: inValidSafeAddress } })
+      fireEvent.change(safeAddressInputNode, { target: { value: invalidSafeAddress } })
 
       expect(mockedEndpoints.getSafeInfo).toBeCalledTimes(0)
 
@@ -208,7 +222,7 @@ describe('<LoadSafePage>', () => {
       expect(screen.getByText(errorText)).toBeInTheDocument()
     })
 
-    it('Shows an error if the Safe Address is not found', async () => {
+    it('Shows an error if the Safe with a given address is not found', async () => {
       // simulating a 404 error by returning a rejected promise
       mockedEndpoints.getSafeInfo.mockImplementation(() =>
         Promise.reject({
@@ -260,7 +274,7 @@ describe('<LoadSafePage>', () => {
       })
     })
 
-    it('Shows an error if it the ENS Name Domain is not registered', () => {
+    it('Shows an error if a given ENS name is not registered', () => {
       const notExistingENSNameDomain = 'notExistingENSDomain.eth'
 
       // we do not want annoying warnings in the console caused by our mock in getENSAddress
@@ -292,7 +306,7 @@ describe('<LoadSafePage>', () => {
       getENSAddressSpy.mockClear()
     })
 
-    it('Shows an error if a NO valid Safe Address is registered in the ENS Name Domain', async () => {
+    it('Shows an error if NO valid Safe Address is registered as an ENS name', async () => {
       // simulating a 404 error by returning a rejected promise
       mockedEndpoints.getSafeInfo.mockImplementation(() =>
         Promise.reject({

--- a/src/routes/LoadSafePage/steps/LoadSafeAddressStep.tsx
+++ b/src/routes/LoadSafePage/steps/LoadSafeAddressStep.tsx
@@ -12,7 +12,7 @@ import Field from 'src/components/forms/Field'
 import TextField from 'src/components/forms/TextField'
 import AddressInput from 'src/components/forms/AddressInput'
 import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
-import { mustBeEthereumAddress } from 'src/components/forms/validator'
+import { isValidAddress } from 'src/utils/isValidAddress'
 import { getSafeInfo } from 'src/logic/safe/utils/safeInformation'
 import { lg, secondary } from 'src/theme/variables'
 import { AddressBookEntry, makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
@@ -52,11 +52,12 @@ function LoadSafeAddressStep(): ReactElement {
 
   useEffect(() => {
     const checkSafeAddress = async () => {
-      const isValidSafeAddress = safeAddress && !mustBeEthereumAddress(safeAddress)
+      const isValidSafeAddress = isValidAddress(safeAddress)
       if (isValidSafeAddress) {
         try {
           setIsSafeInfoLoading(true)
           const { owners, threshold } = await getSafeInfo(safeAddress)
+          setIsSafeInfoLoading(false)
           const ownersWithName = owners.map(({ value: address }) =>
             makeAddressBookEntry(addressBook[address] || { address, name: '' }),
           )
@@ -68,7 +69,6 @@ function LoadSafeAddressStep(): ReactElement {
           setThreshold(undefined)
           setIsValidSafeAddress(false)
         }
-        setIsSafeInfoLoading(false)
       }
     }
 
@@ -187,7 +187,6 @@ export const loadSafeAddressStepValidations = (values: {
   let errors = {}
 
   const safeAddress = values[FIELD_LOAD_SAFE_ADDRESS]
-  const ownerList = values[FIELD_SAFE_OWNER_LIST]
 
   if (!safeAddress) {
     errors = {
@@ -197,13 +196,8 @@ export const loadSafeAddressStepValidations = (values: {
     return errors
   }
 
-  const hasOwners = ownerList.length > 0
-
-  const isValidSafeAddress = safeAddress && !mustBeEthereumAddress(safeAddress) && hasOwners
-
-  const isLoadingSafeAddress = values[FIELD_LOAD_IS_LOADING_SAFE_ADDRESS]
-
   // this is to prevent show and error in the safe address field while is loading...
+  const isLoadingSafeAddress = values[FIELD_LOAD_IS_LOADING_SAFE_ADDRESS]
   if (isLoadingSafeAddress) {
     return {
       ...errors,
@@ -211,6 +205,9 @@ export const loadSafeAddressStepValidations = (values: {
     }
   }
 
+  // check that the address is actually a Safe (must have owners)
+  const ownerList = values[FIELD_SAFE_OWNER_LIST]
+  const isValidSafeAddress = ownerList.length > 0 && isValidAddress(safeAddress)
   if (!isValidSafeAddress) {
     errors = {
       ...errors,

--- a/src/routes/LoadSafePage/steps/LoadSafeAddressStep.tsx
+++ b/src/routes/LoadSafePage/steps/LoadSafeAddressStep.tsx
@@ -13,6 +13,7 @@ import TextField from 'src/components/forms/TextField'
 import AddressInput from 'src/components/forms/AddressInput'
 import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
 import { isValidAddress } from 'src/utils/isValidAddress'
+import { isChecksumAddress } from 'src/utils/checksumAddress'
 import { getSafeInfo } from 'src/logic/safe/utils/safeInformation'
 import { lg, secondary } from 'src/theme/variables'
 import { AddressBookEntry, makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
@@ -52,24 +53,27 @@ function LoadSafeAddressStep(): ReactElement {
 
   useEffect(() => {
     const checkSafeAddress = async () => {
-      const isValidSafeAddress = isValidAddress(safeAddress)
-      if (isValidSafeAddress) {
-        try {
-          setIsSafeInfoLoading(true)
-          const { owners, threshold } = await getSafeInfo(safeAddress)
-          setIsSafeInfoLoading(false)
-          const ownersWithName = owners.map(({ value: address }) =>
-            makeAddressBookEntry(addressBook[address] || { address, name: '' }),
-          )
-          setOwnersWithName(ownersWithName)
-          setThreshold(threshold)
-          setIsValidSafeAddress(true)
-        } catch (error) {
-          setOwnersWithName([])
-          setThreshold(undefined)
-          setIsValidSafeAddress(false)
-        }
+      const isValidSafeAddress = isValidAddress(safeAddress) && isChecksumAddress(safeAddress)
+      if (!isValidSafeAddress) {
+        return
       }
+
+      setIsSafeInfoLoading(true)
+      try {
+        const { owners, threshold } = await getSafeInfo(safeAddress)
+        setIsSafeInfoLoading(false)
+        const ownersWithName = owners.map(({ value: address }) =>
+          makeAddressBookEntry(addressBook[address] || { address, name: '' }),
+        )
+        setOwnersWithName(ownersWithName)
+        setThreshold(threshold)
+        setIsValidSafeAddress(true)
+      } catch (error) {
+        setOwnersWithName([])
+        setThreshold(undefined)
+        setIsValidSafeAddress(false)
+      }
+      setIsSafeInfoLoading(false)
     }
 
     checkSafeAddress()


### PR DESCRIPTION
## What it solves
Resolves #2920

## How this PR fixes it
The root cause was an async race condition when loading Safe info.
User first enters an un-checksummed address, it fetches Safe info. Then the address is automatically checksummed and fetched again. If the first request arrives _after_ the second request, it will mark the field as invalid.

## How to test it
Follow the steps from the linked issue.
