### PR TITLE
Fix: set REACT_APP_ENV=production on staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,12 @@ jobs:
         run: echo "REACT_APP_ENV=dev" >> $GITHUB_ENV
         if: github.ref != 'refs/heads/main'
 
-      # Set production flag
+      # Set production flag on staging
+      - name: Set production flag for staging
+        run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/main'
+
+      # Set production flag on prod
       - name: Set production flag for release PR or tagged build
         run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'main'


### PR DESCRIPTION
## What it solves
We treat the "staging" env as an env that is as close to prod as possible. That includes GA tracking, using production services etc.

## How this PR fixes it
This PR sets the production build flag for staging.

Alternatively, we could introduce a proper `staging` environment, but I don't see any value in this atm.

## How to test it
It can be tested only when pushed to the main branch.
