### PR TITLE
Fix: hide Execute tx checkbox when there are pending txns

### DIFF
--- a/src/components/ExecuteCheckbox/index.test.tsx
+++ b/src/components/ExecuteCheckbox/index.test.tsx
@@ -1,12 +1,31 @@
-import { fireEvent, render, screen } from 'src/utils/test-utils'
+import { fireEvent, render, screen, waitFor, act } from 'src/utils/test-utils'
 import ExecuteCheckbox from '.'
 
+jest.mock('src/logic/safe/store/actions/utils', () => {
+  const originalModule = jest.requireActual('src/logic/safe/store/actions/utils')
+
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    getLastTx: jest.fn(() => Promise.resolve({ isExecuted: true })),
+  }
+})
+
 describe('ExecuteCheckbox', () => {
-  it('should call onChange when checked/unchecked', () => {
+  it('should call onChange when checked/unchecked', async () => {
     const onChange = jest.fn()
-    render(<ExecuteCheckbox onChange={onChange} />)
+
+    await act(async () => {
+      render(<ExecuteCheckbox onChange={onChange} />)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('execute-checkbox')).toBeInTheDocument()
+    })
+
     fireEvent.click(screen.getByTestId('execute-checkbox'))
     expect(onChange).toHaveBeenCalledWith(false)
+
     fireEvent.click(screen.getByTestId('execute-checkbox'))
     expect(onChange).toHaveBeenCalledWith(true)
   })

--- a/src/components/ExecuteCheckbox/index.tsx
+++ b/src/components/ExecuteCheckbox/index.tsx
@@ -1,25 +1,38 @@
-import { ReactElement } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { Checkbox, FormControlLabel } from '@material-ui/core'
+import { getLastTx } from 'src/logic/safe/store/actions/utils'
 import Row from 'src/components/layout/Row'
+import { extractSafeAddress } from 'src/routes/routes'
 
 interface ExecuteCheckboxProps {
   onChange: (val: boolean) => unknown
 }
 
-const ExecuteCheckbox = ({ onChange }: ExecuteCheckboxProps): ReactElement => {
+const ExecuteCheckbox = ({ onChange }: ExecuteCheckboxProps): ReactElement | null => {
+  const [isVisible, setVisible] = useState<boolean>(false)
+  const safeAddress = extractSafeAddress()
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     onChange(e.target.checked)
   }
 
-  return (
+  useEffect(() => {
+    const checkLastTx = async () => {
+      const lastTx = await getLastTx(safeAddress)
+      setVisible(!lastTx || lastTx.isExecuted)
+    }
+    checkLastTx()
+  }, [safeAddress, setVisible])
+
+  return isVisible ? (
     <Row margin="md">
       <FormControlLabel
-        control={<Checkbox defaultChecked={true} color="primary" onChange={handleChange} />}
+        control={<Checkbox defaultChecked color="primary" onChange={handleChange} />}
         label="Execute transaction"
         data-testid="execute-checkbox"
       />
     </Row>
-  )
+  ) : null
 }
 
 export default ExecuteCheckbox


### PR DESCRIPTION
## What it solves
Resolves #2918

## How this PR fixes it
The checkbox won't be shown if there are unexecuted txns in the queue.
It makes a request to get the last tx and checks `isExecuted`.

## How to test it
* Create a tx but don't execute it
* Create another tx – the "Execute tx" checkbox shouldn't appear