### PR TITLE
Fix: use manual gas limit to calculate the gas cost estimation

### DIFF
--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -198,7 +198,7 @@ export const useEstimateTransactionGas = ({
 
         const gasPrice = manualGasPrice ? web3.utils.toWei(manualGasPrice, 'gwei') : await calculateGasPrice()
         const gasPriceFormatted = web3.utils.fromWei(gasPrice, 'gwei')
-        const estimatedGasCosts = ethGasLimitEstimation * parseInt(gasPrice, 10)
+        const estimatedGasCosts = (manualGasLimit ? +manualGasLimit : ethGasLimitEstimation) * parseInt(gasPrice, 10)
         const gasCost = fromTokenUnit(estimatedGasCosts, nativeCoin.decimals)
         const gasCostFormatted = formatAmount(gasCost)
         const extraGasMult = EXTRA_GAS_FACTOR[getNetworkId()] || 1

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -198,11 +198,11 @@ export const useEstimateTransactionGas = ({
 
         const gasPrice = manualGasPrice ? web3.utils.toWei(manualGasPrice, 'gwei') : await calculateGasPrice()
         const gasPriceFormatted = web3.utils.fromWei(gasPrice, 'gwei')
-        const estimatedGasCosts = (manualGasLimit ? +manualGasLimit : ethGasLimitEstimation) * parseInt(gasPrice, 10)
-        const gasCost = fromTokenUnit(estimatedGasCosts, nativeCoin.decimals)
-        const gasCostFormatted = formatAmount(gasCost)
         const extraGasMult = EXTRA_GAS_FACTOR[getNetworkId()] || 1
         const gasLimit = manualGasLimit || Math.round(ethGasLimitEstimation * extraGasMult).toString()
+        const estimatedGasCosts = parseInt(gasLimit, 10) * parseInt(gasPrice, 10)
+        const gasCost = fromTokenUnit(estimatedGasCosts, nativeCoin.decimals)
+        const gasCostFormatted = formatAmount(gasCost)
 
         if (isExecution) {
           transactionCallSuccess = await checkTransactionExecution({


### PR DESCRIPTION
## What it solves
Resolves #2862

## How this PR fixes it
The gas limit set in the "Advanced options" is used to calculate the tx gas cost, aligning with the value displayed in Metamask

## How to test it
Set a new transaction and tweak the Gas Limit in the "Advanced options". The _fee price_ shall be the _Gas price_ * _Gas limit_ that you see in the "Advanced options"

## Screenshots
![Screen Shot 2021-11-03 at 12 29 45](https://user-images.githubusercontent.com/32431609/140052649-62be071c-b81d-4594-b390-34b336d7770b.png)

