### PR TITLE
Add a redirect from old subdomains

### DIFF
--- a/src/components/ExecuteCheckbox/index.test.tsx
+++ b/src/components/ExecuteCheckbox/index.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, act } from 'src/utils/test-utils'
+import { history } from 'src/routes/routes'
 import ExecuteCheckbox from '.'
 
 jest.mock('src/logic/safe/store/actions/utils', () => {
@@ -14,6 +15,7 @@ jest.mock('src/logic/safe/store/actions/utils', () => {
 describe('ExecuteCheckbox', () => {
   it('should call onChange when checked/unchecked', async () => {
     const onChange = jest.fn()
+    history.push('/rin:0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/balances')
 
     await act(async () => {
       render(<ExecuteCheckbox onChange={onChange} />)

--- a/src/components/ExecuteCheckbox/index.tsx
+++ b/src/components/ExecuteCheckbox/index.tsx
@@ -17,6 +17,8 @@ const ExecuteCheckbox = ({ onChange }: ExecuteCheckboxProps): ReactElement | nul
   }
 
   useEffect(() => {
+    if (!safeAddress) return
+
     const checkLastTx = async () => {
       const lastTx = await getLastTx(safeAddress)
       setVisible(!lastTx || lastTx.isExecuted)

--- a/src/components/Root/LegacyRouteRedirection.tsx
+++ b/src/components/Root/LegacyRouteRedirection.tsx
@@ -10,9 +10,17 @@ type Props = {
 }
 
 const LEGACY_SAFE_ADDRESS_SLUG = 'safeAddress'
+const LEGACY_HOST_RE = /-?(rinkeby|xdai|arbitrum|ewc|volta|polygon|bsc)(?=\.)/
 
 const LegacyRouteRedirection = ({ history }: Props): ReactElement | null => {
-  const { pathname, hash, search } = window.location
+  const { href, host, pathname, hash, search } = window.location
+
+  // Redirect https://xdai.gnosis-safe.io to https://gnosis-safe.io
+  if (LEGACY_HOST_RE.test(host)) {
+    const newUrl = href.replace(LEGACY_HOST_RE, '')
+    window.location.replace(newUrl)
+    return null
+  }
 
   const isLegacyRoute = pathname === `${PUBLIC_URL}/` && hash.startsWith('#/')
 

--- a/src/components/Root/__tests__/LegacyRouteRedirection.test.tsx
+++ b/src/components/Root/__tests__/LegacyRouteRedirection.test.tsx
@@ -11,6 +11,7 @@ describe('LegacyRouteRedirection', () => {
 
     expect(window.location.pathname).toBe(`/rin:${ZERO_ADDRESS}`)
   })
+
   it('redirects (addressed) legacy load links and prepends the short chain name', () => {
     history.push(`/#/load/${ZERO_ADDRESS}`)
 
@@ -18,6 +19,7 @@ describe('LegacyRouteRedirection', () => {
 
     expect(window.location.pathname).toBe(`/load/rin:${ZERO_ADDRESS}`)
   })
+
   it('redirects (non-addressed) legacy links without alteration', () => {
     //TODO:
     history.push(`/#/welcome`)
@@ -26,6 +28,7 @@ describe('LegacyRouteRedirection', () => {
 
     expect(window.location.pathname).toBe(`/welcome`)
   })
+
   it('does not redirect new links', () => {
     history.push(`/rin:${ZERO_ADDRESS}`)
 
@@ -34,5 +37,53 @@ describe('LegacyRouteRedirection', () => {
     // Window location should not have been touched, but test in case
     expect(window.location.pathname).toBe(`/rin:${ZERO_ADDRESS}`)
     expect(history.location.pathname).toBe(`/rin:${ZERO_ADDRESS}`)
+  })
+
+  it('redirects to the unified host on staging', () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        hash: '#/safes/0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/address-book',
+        host: 'safe-team-xdai.staging.gnosisdev.com',
+        hostname: 'safe-team-xdai.staging.gnosisdev.com',
+        href: 'https://safe-team-xdai.staging.gnosisdev.com/app/#/safes/0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/address-book',
+        origin: 'https://safe-team-xdai.staging.gnosisdev.com',
+        pathname: '/app/',
+        port: '',
+        protocol: 'https:',
+        replace: jest.fn(),
+        search: '',
+      },
+    })
+
+    render(<LegacyRouteRedirection history={history} />)
+
+    expect(window.location.replace).toHaveBeenCalledWith(
+      'https://safe-team.staging.gnosisdev.com/app/#/safes/0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/address-book',
+    )
+  })
+
+  it('redirects to the unified host on production', () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        hash: '#/safes/0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/balances',
+        host: 'rinkeby.gnosis-safe.io',
+        hostname: 'rinkeby.gnosis-safe.io',
+        href: 'https://rinkeby.gnosis-safe.io/app/#/safes/0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/balances',
+        origin: 'https://rinkeby.gnosis-safe.io',
+        pathname: '/app/',
+        port: '',
+        protocol: 'https:',
+        replace: jest.fn(),
+        search: '',
+      },
+    })
+
+    render(<LegacyRouteRedirection history={history} />)
+
+    expect(window.location.replace).toHaveBeenCalledWith(
+      'https://.gnosis-safe.io/app/#/safes/0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/balances',
+    )
   })
 })


### PR DESCRIPTION
## What it solves
Resolves #2950.
When the user goes to one of the old subdomains, they'll be redirected to the unified app (root domain).

## How this PR fixes it
Adds a regex check and a JS redirect using `location.replace`.

## How to test it
We can test it on staging, otherwise there are unit tests.

I've also adjusted the ExecuteCheckbox tests to not log an error in some cases.
