### PR TITLE
Enable allowance module for BSC

### DIFF
--- a/src/config/networks/bsc.ts
+++ b/src/config/networks/bsc.ts
@@ -58,7 +58,7 @@ const bsc: NetworkConfig = {
     WALLETS.LATTICE,
     WALLETS.KEYSTONE,
   ],
-  disabledFeatures: [FEATURES.DOMAIN_LOOKUP, FEATURES.SPENDING_LIMIT],
+  disabledFeatures: [FEATURES.DOMAIN_LOOKUP],
 }
 
 export default bsc


### PR DESCRIPTION
## What it solves
It partially solves #2571 as we finally deployed allowances smart contracts on BSC

## How this PR fixes it
After deploying smart contracts to BSC we can safely enable this feature

## How to test it
Just enable a spending limit on BSC and try to use it
