### PR TITLE
Chore: adjust ExecuteCheckbox tests to not log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ src/types/gateway/
 tsconfig.tsbuildinfo
 public/**/*.js
 jest.results.json
+*.#*

--- a/src/components/ExecuteCheckbox/index.test.tsx
+++ b/src/components/ExecuteCheckbox/index.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, act } from 'src/utils/test-utils'
+import { history } from 'src/routes/routes'
 import ExecuteCheckbox from '.'
 
 jest.mock('src/logic/safe/store/actions/utils', () => {
@@ -14,6 +15,7 @@ jest.mock('src/logic/safe/store/actions/utils', () => {
 describe('ExecuteCheckbox', () => {
   it('should call onChange when checked/unchecked', async () => {
     const onChange = jest.fn()
+    history.push('/rin:0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/balances')
 
     await act(async () => {
       render(<ExecuteCheckbox onChange={onChange} />)

--- a/src/components/ExecuteCheckbox/index.tsx
+++ b/src/components/ExecuteCheckbox/index.tsx
@@ -17,6 +17,8 @@ const ExecuteCheckbox = ({ onChange }: ExecuteCheckboxProps): ReactElement | nul
   }
 
   useEffect(() => {
+    if (!safeAddress) return
+
     const checkLastTx = async () => {
       const lastTx = await getLastTx(safeAddress)
       setVisible(!lastTx || lastTx.isExecuted)


### PR DESCRIPTION
## What it solves
The tests that use ExecuteCheckbox were logging an error due to a missing mock.
I've added a check so that they don't do that.