### PR TITLE
[Drain Safe] Loading spinner still visible in drain safe app when user close ConfirmTxModal

### DIFF
--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -59,6 +59,7 @@ const StyledBlock = styled(Block)`
 `
 
 type Props = ConfirmTxModalProps & {
+  onReject: () => void
   showDecodedTxData: (decodedTxDetails: DecodedTxDetail) => void
   hidden: boolean // used to prevent re-rendering the modal each time a tx is inspected
 }
@@ -77,7 +78,7 @@ export const ReviewConfirm = ({
   hidden,
   onUserConfirm,
   onClose,
-  onTxReject,
+  onReject,
   requestId,
   showDecodedTxData,
 }: Props): ReactElement => {
@@ -138,11 +139,6 @@ export const ReviewConfirm = ({
     decodeTxData()
   }, [txData])
 
-  const handleTxRejection = () => {
-    onTxReject(requestId)
-    onClose()
-  }
-
   const handleUserConfirmation = (safeTxHash: string): void => {
     onUserConfirm(safeTxHash, requestId)
     onClose()
@@ -168,7 +164,7 @@ export const ReviewConfirm = ({
           delayExecution: !executionApproved,
         },
         handleUserConfirmation,
-        handleTxRejection,
+        onReject,
       ),
     )
 
@@ -205,7 +201,7 @@ export const ReviewConfirm = ({
     >
       {(txParameters, toggleEditMode) => (
         <div hidden={hidden}>
-          <ModalHeader title={app.name} iconUrl={app.iconUrl} onClose={handleTxRejection} />
+          <ModalHeader title={app.name} iconUrl={app.iconUrl} onClose={onReject} />
 
           <Hairline />
 
@@ -260,7 +256,7 @@ export const ReviewConfirm = ({
           {/* Buttons */}
           <Modal.Footer withoutBorder={txEstimationExecutionStatus !== EstimationStatus.LOADING}>
             <Modal.Footer.Buttons
-              cancelButtonProps={{ onClick: handleTxRejection }}
+              cancelButtonProps={{ onClick: onReject }}
               confirmButtonProps={{
                 onClick: () => confirmTransactions(txParameters),
                 disabled: !isOwner,

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/index.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/index.tsx
@@ -47,10 +47,14 @@ export const ConfirmTxModal = (props: ConfirmTxModalProps): ReactElement => {
   const showDecodedTxData = setDecodedTxDetails
   const hideDecodedTxData = () => setDecodedTxDetails(undefined)
 
-  const closeDecodedTxDetail = () => {
-    hideDecodedTxData()
+  const rejectTransaction = () => {
     props.onClose()
     props.onTxReject(props.requestId)
+  }
+
+  const closeDecodedTxDetail = () => {
+    hideDecodedTxData()
+    rejectTransaction()
   }
 
   if (invalidTransactions) {
@@ -71,7 +75,12 @@ export const ConfirmTxModal = (props: ConfirmTxModalProps): ReactElement => {
         />
       )}
 
-      <ReviewConfirm {...props} showDecodedTxData={showDecodedTxData} hidden={!!decodedTxDetails} />
+      <ReviewConfirm
+        {...props}
+        onReject={rejectTransaction}
+        showDecodedTxData={showDecodedTxData}
+        hidden={!!decodedTxDetails}
+      />
     </Modal>
   )
 }

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/index.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/index.tsx
@@ -50,6 +50,7 @@ export const ConfirmTxModal = (props: ConfirmTxModalProps): ReactElement => {
   const closeDecodedTxDetail = () => {
     hideDecodedTxData()
     props.onClose()
+    props.onTxReject(props.requestId)
   }
 
   if (invalidTransactions) {


### PR DESCRIPTION
## What it solves
Resolves #2178 

## How this PR fixes it
Drain Safe app needs a message being sent to the iframe in order to dismiss the loading spinner representing the app is waiting for the transactions to be processed. Safe Web is sending it when the main `<ReviewConfirm />` is closed but don't in the case we are in `<DecodedTxDetail />`

## How to test it
1) Add the deployed Drain Safe in this PR as a custom app in a Safe Web
2) Drain the account and see how the confirmation modal is being showed from main Safe Web
3) Navigate to any transaction detail and click the close button ('X'). The loading spinner in Drain Safe should disappear

