### PR TITLE
Fix: init network early; don't set default network in SafeInfo.chainId

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,12 @@ import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStor
 import { store } from 'src/store'
 import { SENTRY_DSN } from './utils/constants'
 import { disableMMAutoRefreshWarning } from './utils/mm_warnings'
+import { switchNetworkWithUrl } from './utils/history'
+
+// Set the initial network id from the URL
+if (typeof window !== 'undefined') {
+  switchNetworkWithUrl({ pathname: window.location.pathname })
+}
 
 disableMMAutoRefreshWarning()
 

--- a/src/logic/safe/store/models/safe.ts
+++ b/src/logic/safe/store/models/safe.ts
@@ -1,7 +1,6 @@
 import { Record, RecordOf } from 'immutable'
 
 import { ETHEREUM_NETWORK, FEATURES } from 'src/config/networks/network.d'
-import { getNetworkId } from 'src/config'
 import { BalanceRecord } from 'src/logic/tokens/store/actions/fetchSafeTokens'
 
 export type SafeOwner = string
@@ -25,7 +24,7 @@ export type SpendingLimit = {
 
 export type SafeRecordProps = {
   address: string
-  chainId: ETHEREUM_NETWORK
+  chainId?: ETHEREUM_NETWORK
   threshold: number
   ethBalance: string
   totalFiatBalance: string
@@ -50,7 +49,7 @@ export type SafeRecordProps = {
  */
 const makeSafe = Record<SafeRecordProps>({
   address: '',
-  chainId: getNetworkId(),
+  chainId: undefined,
   threshold: 0,
   ethBalance: '0',
   totalFiatBalance: '0',

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -36,6 +36,7 @@ import { useAnalytics, SAFE_NAVIGATION_EVENT } from 'src/utils/googleAnalytics'
 import { fetchMasterCopies, MasterCopy, MasterCopyDeployer } from 'src/logic/contracts/api/masterCopies'
 import { getMasterCopyAddressFromProxyAddress } from 'src/logic/contracts/safeContracts'
 import ChainIndicator from 'src/components/ChainIndicator'
+import { getNetworkId } from 'src/config'
 
 export const SAFE_NAME_INPUT_TEST_ID = 'safe-name-input'
 export const SAFE_NAME_SUBMIT_BTN_TEST_ID = 'change-safe-name-btn'
@@ -63,7 +64,7 @@ const SafeDetails = (): ReactElement => {
     address: safeAddress,
     needsUpdate: safeNeedsUpdate,
     currentVersion: safeCurrentVersion,
-    chainId,
+    chainId = getNetworkId(),
   } = useSelector(currentSafe)
   const safeNamesMap = useSelector(safesWithNamesAsMap)
   const safeName = safeNamesMap[safeAddress]?.name


### PR DESCRIPTION
## What it solves
During the migration from non-unified subdomains, the SAFES storage won't have `chainId` in its SafeInfo's.

`chainId` is a new field that has been added recently. It comes from the Gateway.

Since right now we can't guarantee that `chainId` is set on all safes, it should be optional.

## How this PR fixes it
Makes `chainId` optional and in the only place where it was used (Settings -> Safe Details), falls back to the current chain.

## How to test it
* Everything should work like before.
* Migrated Safes should _not_ have any `chainId` in the localStorage.
