### PR TITLE
Truncate safe names in sidebar

### DIFF
--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -76,6 +76,13 @@ const StyledTextLabel = styled(Text)`
   color: ${(props: StyledTextLabelProps) => props.networkInfo?.textColor ?? fontColor};
   background-color: ${(props: StyledTextLabelProps) => props.networkInfo?.backgroundColor ?? border};
 `
+
+const StyldTextSafeName = styled(Text)`
+  width: 90%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
 const StyledEthHashInfo = styled(EthHashInfo)`
   p {
     color: ${({ theme }) => theme.colors.placeHolder};
@@ -150,9 +157,9 @@ const SafeHeader = ({
         </IdenticonContainer>
 
         {/* SafeInfo */}
-        <Text size="lg" center>
+        <StyldTextSafeName size="lg" center>
           {safeName}
-        </Text>
+        </StyldTextSafeName>
         <StyledEthHashInfo hash={address} shortenHash={4} textSize="sm" />
         <IconContainer>
           <ButtonHelper onClick={onReceiveClick}>

--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -26,6 +26,15 @@ const StyledIcon = styled(Icon)<{ checked: boolean }>`
   ${({ checked }) => (checked ? { marginRight: '4px' } : { visibility: 'hidden', width: '28px' })}
 `
 
+const StyledEthHashInfo = styled(EthHashInfo)`
+  & > div > p:first-of-type {
+    width: 210px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`
+
 type Props = {
   onSafeClick: () => void
   onNetworkSwitch?: () => void
@@ -77,7 +86,7 @@ const SafeListItem = ({
   return (
     <ListItem button onClick={handleOpenSafe} ref={safeRef}>
       <StyledIcon type="check" size="md" color="primary" checked={isCurrentSafe} />
-      <EthHashInfo hash={address} name={safeName} showAvatar shortenHash={4} />
+      <StyledEthHashInfo hash={address} name={safeName} showAvatar shortenHash={4} />
       <ListItemSecondaryAction>
         {ethBalance ? (
           `${formatAmount(ethBalance)} ${nativeCoinSymbol}`


### PR DESCRIPTION
## What it solves
Resolves #2956

## How this PR fixes it
Safe names in the unified sidebar, as well as the current loaded safe name are now truncated with an ellipsis overflow.

## How to test it
1. Open the unified sidebar and expect long-named safes to be truncated.
2. Load said long-named safe and expect the name to be truncated.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/140910615-498f59bd-db08-45be-a1b7-fe5f6e483ea1.png)

![image](https://user-images.githubusercontent.com/20442784/140910634-6a7acd66-fca0-4361-8b38-daea32ba9638.png)
