### PR TITLE
Adapt TxParametersDetail to display a future safeNonce

### DIFF
--- a/src/components/ReviewInfoText/ReviewInfoText.test.tsx
+++ b/src/components/ReviewInfoText/ReviewInfoText.test.tsx
@@ -1,0 +1,66 @@
+import { useSelector } from 'react-redux'
+import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
+import { render, screen } from 'src/utils/test-utils'
+import { ReviewInfoText } from './index'
+import { history } from 'src/routes/routes'
+
+const safeAddress = '0xC245cb45B044d66fbE8Fb33C26c0b28B4fc367B2'
+const url = `/rin:${safeAddress}/settings/advanced`
+history.location.pathname = url
+
+describe('<ReviewInfoText>', () => {
+  const initialData = {
+    gasCostFormatted: '0',
+    isExecution: true,
+    isCreation: false,
+    isOffChainSignature: false,
+    txEstimationExecutionStatus: EstimationStatus.SUCCESS,
+  }
+  const customState = {
+    safes: {
+      safes: {
+        [safeAddress]: {
+          address: safeAddress,
+          nonce: 8,
+          modules: null,
+          guard: '',
+          currentVersion: '1.3.0',
+        },
+      },
+    },
+  }
+  const testId = 'reviewInfoText-component'
+  const warningCommonCopy =
+    'will need to be created and executed before this transaction, are you sure you want to do this?'
+
+  it('Renders ReviewInfoText with safeNonce being one transaction in the future', () => {
+    const safeNonce = '9'
+    const expectedCopy = 'transaction ' + warningCommonCopy
+
+    render(<ReviewInfoText {...initialData} safeNonce={safeNonce} testId={testId} />, customState)
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.queryByText(expectedCopy)).toBeInTheDocument()
+  })
+
+  it('Renders ReviewInfoText with nonce more than one transaction in the future', () => {
+    const safeNonce = '10'
+    const expectedCopy = 'transactions ' + warningCommonCopy
+
+    render(<ReviewInfoText {...initialData} safeNonce={safeNonce} testId={testId} />, customState)
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.queryByText(expectedCopy)).toBeInTheDocument()
+  })
+
+  it('Renders ReviewInfoText not showing the nonce warning copy', () => {
+    const safeNonce = '10'
+
+    render(<ReviewInfoText {...initialData} safeNonce={safeNonce} testId={testId} />, customState)
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
+    expect(screen.queryByText(warningCommonCopy)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -19,12 +19,12 @@ export const ReviewInfoText = ({
   isCreation,
   isExecution,
   isOffChainSignature,
-  safeNonce,
+  safeNonce = '',
   txEstimationExecutionStatus,
   testId,
 }: ReviewInfoTextProps): React.ReactElement => {
   const { nonce } = useSelector(currentSafe)
-  const transactionsToGo = parseInt(safeNonce || '', 10) - nonce
+  const transactionsToGo = parseInt(safeNonce, 10) - nonce
 
   return (
     <ReviewInfoTextWrapper data-testid={testId}>

--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -5,9 +5,9 @@ import { useSelector } from 'react-redux'
 import Paragraph from 'src/components/layout/Paragraph'
 import { currentSafe } from 'src/logic/safe/store/selectors'
 import { lg, sm } from 'src/theme/variables'
-import { TransactionFailTextProps, TransactionFees } from '../TransactionsFees'
+import { TransactionFees } from '../TransactionsFees'
 
-type ReviewInfoTextProps = TransactionFailTextProps & { safeNonce?: string; testId?: string }
+type ReviewInfoTextProps = Parameters<typeof TransactionFees>[0] & { safeNonce?: string; testId?: string }
 
 const ReviewInfoTextWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.background};

--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components'
+import { Text } from '@gnosis.pm/safe-react-components'
+import { useSelector } from 'react-redux'
+
+import Paragraph from 'src/components/layout/Paragraph'
+import { currentSafe } from 'src/logic/safe/store/selectors'
+import { lg, sm } from 'src/theme/variables'
+import { TransactionFailTextProps, TransactionFees } from '../TransactionsFees'
+
+type ReviewInfoTextProps = TransactionFailTextProps & { safeNonce?: string }
+
+const ReviewInfoTextWrapper = styled.div`
+  background-color: ${({ theme }) => theme.colors.background};
+  padding: ${sm} ${lg};
+`
+
+export const ReviewInfoText = ({
+  gasCostFormatted,
+  isExecution,
+  isCreation,
+  isOffChainSignature,
+  txEstimationExecutionStatus,
+  safeNonce,
+}: ReviewInfoTextProps): React.ReactElement => {
+  const { nonce } = useSelector(currentSafe)
+  const transactionsToGo = parseInt(safeNonce || '', 10) - nonce
+
+  return (
+    <ReviewInfoTextWrapper>
+      {transactionsToGo > 0 ? (
+        <Paragraph size="lg" align="center">
+          <Text size="lg" as="span" color="text" strong>
+            {transactionsToGo}
+          </Text>
+          {` transaction${
+            transactionsToGo > 1 ? 's' : ''
+          } will need to be created and executed before this transaction, are you
+                sure you want to do this?`}
+        </Paragraph>
+      ) : (
+        <TransactionFees
+          gasCostFormatted={gasCostFormatted}
+          isExecution={isExecution}
+          isCreation={isCreation}
+          isOffChainSignature={isOffChainSignature}
+          txEstimationExecutionStatus={txEstimationExecutionStatus}
+        />
+      )}
+    </ReviewInfoTextWrapper>
+  )
+}

--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -7,7 +7,7 @@ import { currentSafe } from 'src/logic/safe/store/selectors'
 import { lg, sm } from 'src/theme/variables'
 import { TransactionFailTextProps, TransactionFees } from '../TransactionsFees'
 
-type ReviewInfoTextProps = TransactionFailTextProps & { safeNonce?: string }
+type ReviewInfoTextProps = TransactionFailTextProps & { safeNonce?: string; testId?: string }
 
 const ReviewInfoTextWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.background};
@@ -21,12 +21,13 @@ export const ReviewInfoText = ({
   isOffChainSignature,
   safeNonce,
   txEstimationExecutionStatus,
+  testId,
 }: ReviewInfoTextProps): React.ReactElement => {
   const { nonce } = useSelector(currentSafe)
   const transactionsToGo = parseInt(safeNonce || '', 10) - nonce
 
   return (
-    <ReviewInfoTextWrapper>
+    <ReviewInfoTextWrapper data-testid={testId}>
       {transactionsToGo > 0 ? (
         <Paragraph size="lg" align="center">
           <Text size="lg" as="span" color="text" strong>

--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -16,11 +16,11 @@ const ReviewInfoTextWrapper = styled.div`
 
 export const ReviewInfoText = ({
   gasCostFormatted,
-  isExecution,
   isCreation,
+  isExecution,
   isOffChainSignature,
-  txEstimationExecutionStatus,
   safeNonce,
+  txEstimationExecutionStatus,
 }: ReviewInfoTextProps): React.ReactElement => {
   const { nonce } = useSelector(currentSafe)
   const transactionsToGo = parseInt(safeNonce || '', 10) - nonce
@@ -40,8 +40,8 @@ export const ReviewInfoText = ({
       ) : (
         <TransactionFees
           gasCostFormatted={gasCostFormatted}
-          isExecution={isExecution}
           isCreation={isCreation}
+          isExecution={isExecution}
           isOffChainSignature={isOffChainSignature}
           txEstimationExecutionStatus={txEstimationExecutionStatus}
         />

--- a/src/components/TransactionsFees/index.tsx
+++ b/src/components/TransactionsFees/index.tsx
@@ -4,7 +4,7 @@ import { getNetworkInfo } from 'src/config'
 import { TransactionFailText } from 'src/components/TransactionFailText'
 import { Text } from '@gnosis.pm/safe-react-components'
 
-type TransactionFailTextProps = {
+export type TransactionFailTextProps = {
   txEstimationExecutionStatus: EstimationStatus
   gasCostFormatted?: string
   isExecution: boolean

--- a/src/components/TransactionsFees/index.tsx
+++ b/src/components/TransactionsFees/index.tsx
@@ -4,7 +4,7 @@ import { getNetworkInfo } from 'src/config'
 import { TransactionFailText } from 'src/components/TransactionFailText'
 import { Text } from '@gnosis.pm/safe-react-components'
 
-export type TransactionFailTextProps = {
+type TransactionFailTextProps = {
   txEstimationExecutionStatus: EstimationStatus
   gasCostFormatted?: string
   isExecution: boolean

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -12,10 +12,9 @@ import { encodeMultiSendCall } from 'src/logic/safe/transactions/multisend'
 import { getExplorerInfo, getNetworkInfo } from 'src/config'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
-import { TransactionFees } from 'src/components/TransactionsFees'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
-import { lg, md, sm } from 'src/theme/variables'
+import { lg, md } from 'src/theme/variables'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { BasicTxInfo, DecodeTxs } from 'src/components/DecodeTxs'
@@ -26,6 +25,7 @@ import Block from 'src/components/layout/Block'
 import Hairline from 'src/components/layout/Hairline'
 import Divider from 'src/components/Divider'
 import { ButtonStatus, Modal } from 'src/components/Modal'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 
 import { ConfirmTxModalProps, DecodedTxDetail } from '.'
 import { grantedSelector } from 'src/routes/safe/container/selector'
@@ -34,10 +34,6 @@ import ExecuteCheckbox from 'src/components/ExecuteCheckbox'
 const Container = styled.div`
   max-width: 480px;
   padding: ${md} ${lg} 0;
-`
-const TransactionFeesWrapper = styled.div`
-  background-color: ${({ theme }) => theme.colors.background};
-  padding: ${sm} ${lg};
 `
 
 const DecodeTxsWrapper = styled.div`
@@ -242,15 +238,13 @@ export const ReviewConfirm = ({
 
           {/* Gas info */}
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
-            <TransactionFeesWrapper>
-              <TransactionFees
-                gasCostFormatted={isOwner ? gasCostFormatted : undefined}
-                isExecution={doExecute}
-                isCreation={isCreation}
-                isOffChainSignature={isOffChainSignature}
-                txEstimationExecutionStatus={txEstimationExecutionStatus}
-              />
-            </TransactionFeesWrapper>
+            <ReviewInfoText
+              gasCostFormatted={isOwner ? gasCostFormatted : undefined}
+              isExecution={doExecute}
+              isCreation={isCreation}
+              isOffChainSignature={isOffChainSignature}
+              txEstimationExecutionStatus={txEstimationExecutionStatus}
+            />
           )}
 
           {/* Buttons */}

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -240,9 +240,10 @@ export const ReviewConfirm = ({
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
             <ReviewInfoText
               gasCostFormatted={isOwner ? gasCostFormatted : undefined}
-              isExecution={doExecute}
               isCreation={isCreation}
+              isExecution={doExecute}
               isOffChainSignature={isOffChainSignature}
+              safeNonce={txParameters.safeNonce}
               txEstimationExecutionStatus={txEstimationExecutionStatus}
             />
           )}

--- a/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
@@ -229,9 +229,10 @@ export const ReviewMessage = ({
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
             <ReviewInfoText
               gasCostFormatted={isOwner ? gasCostFormatted : undefined}
-              isExecution={isExecution}
               isCreation={isCreation}
+              isExecution={isExecution}
               isOffChainSignature={isOffChainSignature}
+              safeNonce={txParameters.safeNonce}
               txEstimationExecutionStatus={txEstimationExecutionStatus}
             />
           )}

--- a/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/ReviewMessage.tsx
@@ -10,10 +10,9 @@ import { createTransaction } from 'src/logic/safe/store/actions/createTransactio
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { getExplorerInfo, getNetworkInfo } from 'src/config'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
-import { TransactionFees } from 'src/components/TransactionsFees'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
-import { lg, md, sm } from 'src/theme/variables'
+import { lg, md } from 'src/theme/variables'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { BasicTxInfo } from 'src/components/DecodeTxs'
@@ -22,6 +21,7 @@ import Divider from 'src/components/Divider'
 import { SignMessageModalProps } from '.'
 import Hairline from 'src/components/layout/Hairline'
 import { ButtonStatus, Modal } from 'src/components/Modal'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import Paragraph from 'src/components/layout/Paragraph'
 
@@ -30,10 +30,6 @@ const { nativeCoin } = getNetworkInfo()
 const Container = styled.div`
   max-width: 480px;
   padding: ${md} ${lg} 0;
-`
-const TransactionFeesWrapper = styled.div`
-  background-color: ${({ theme }) => theme.colors.background};
-  padding: ${sm} ${lg};
 `
 
 const StyledBlock = styled(Block)`
@@ -231,15 +227,13 @@ export const ReviewMessage = ({
 
           {/* Gas info */}
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
-            <TransactionFeesWrapper>
-              <TransactionFees
-                gasCostFormatted={isOwner ? gasCostFormatted : undefined}
-                isExecution={isExecution}
-                isCreation={isCreation}
-                isOffChainSignature={isOffChainSignature}
-                txEstimationExecutionStatus={txEstimationExecutionStatus}
-              />
-            </TransactionFeesWrapper>
+            <ReviewInfoText
+              gasCostFormatted={isOwner ? gasCostFormatted : undefined}
+              isExecution={isExecution}
+              isCreation={isCreation}
+              isOffChainSignature={isOffChainSignature}
+              txEstimationExecutionStatus={txEstimationExecutionStatus}
+            />
           )}
 
           {/* Buttons */}

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
@@ -27,7 +27,7 @@ import { useEstimateTransactionGas, EstimationStatus } from 'src/logic/hooks/use
 import { addressBookEntryName } from 'src/logic/addressBook/store/selectors'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { ButtonStatus, Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import { extractSafeAddress } from 'src/routes/routes'
@@ -237,15 +237,13 @@ const ContractInteractionReview = ({ onClose, onPrev, tx }: Props): React.ReactE
               isOffChainSignature={isOffChainSignature}
             />
           </Block>
-          <div className={classes.gasCostsContainer}>
-            <TransactionFees
-              gasCostFormatted={gasCostFormatted}
-              isExecution={doExecute}
-              isCreation={isCreation}
-              isOffChainSignature={isOffChainSignature}
-              txEstimationExecutionStatus={txEstimationExecutionStatus}
-            />
-          </div>
+          <ReviewInfoText
+            gasCostFormatted={gasCostFormatted}
+            isExecution={doExecute}
+            isCreation={isCreation}
+            isOffChainSignature={isOffChainSignature}
+            txEstimationExecutionStatus={txEstimationExecutionStatus}
+          />
 
           <Modal.Footer withoutBorder={buttonStatus !== ButtonStatus.LOADING}>
             <Modal.Footer.Buttons

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/Review/index.tsx
@@ -239,9 +239,10 @@ const ContractInteractionReview = ({ onClose, onPrev, tx }: Props): React.ReactE
           </Block>
           <ReviewInfoText
             gasCostFormatted={gasCostFormatted}
-            isExecution={doExecute}
             isCreation={isCreation}
+            isExecution={doExecute}
             isOffChainSignature={isOffChainSignature}
+            safeNonce={txParameters.safeNonce}
             txEstimationExecutionStatus={txEstimationExecutionStatus}
           />
 

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
@@ -165,9 +165,10 @@ const ReviewCustomTx = ({ onClose, onPrev, tx }: Props): ReactElement => {
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
             <ReviewInfoText
               gasCostFormatted={gasCostFormatted}
-              isExecution={doExecute}
               isCreation={isCreation}
+              isExecution={doExecute}
               isOffChainSignature={isOffChainSignature}
+              safeNonce={txParameters.safeNonce}
               txEstimationExecutionStatus={txEstimationExecutionStatus}
             />
           )}

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/index.tsx
@@ -21,7 +21,7 @@ import { TxParametersDetail } from 'src/routes/safe/components/Transactions/help
 import { useEstimateTransactionGas, EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { ButtonStatus, Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { styles } from './style'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
@@ -163,15 +163,13 @@ const ReviewCustomTx = ({ onClose, onPrev, tx }: Props): ReactElement => {
             />
           </Block>
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
-            <Block className={classes.gasCostsContainer}>
-              <TransactionFees
-                gasCostFormatted={gasCostFormatted}
-                isExecution={doExecute}
-                isCreation={isCreation}
-                isOffChainSignature={isOffChainSignature}
-                txEstimationExecutionStatus={txEstimationExecutionStatus}
-              />
-            </Block>
+            <ReviewInfoText
+              gasCostFormatted={gasCostFormatted}
+              isExecution={doExecute}
+              isCreation={isCreation}
+              isOffChainSignature={isOffChainSignature}
+              txEstimationExecutionStatus={txEstimationExecutionStatus}
+            />
           )}
           <Modal.Footer withoutBorder={buttonStatus !== ButtonStatus.LOADING}>
             <Modal.Footer.Buttons

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/ReviewCustomTx/style.ts
@@ -1,4 +1,4 @@
-import { background, border, lg, md, sm } from 'src/theme/variables'
+import { border, lg, md, sm } from 'src/theme/variables'
 import { createStyles } from '@material-ui/core'
 
 export const styles = createStyles({
@@ -28,9 +28,5 @@ export const styles = createStyles({
     height: '84px',
     justifyContent: 'center',
     gap: '16px',
-  },
-  gasCostsContainer: {
-    backgroundColor: background,
-    padding: `${sm} ${lg}`,
   },
 })

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/style.ts
@@ -1,4 +1,4 @@
-import { lg, md, sm, border, background } from 'src/theme/variables'
+import { lg, md, sm, border } from 'src/theme/variables'
 import { createStyles } from '@material-ui/core'
 
 export const styles = createStyles({
@@ -44,9 +44,5 @@ export const styles = createStyles({
   },
   fullWidth: {
     justifyContent: 'space-between',
-  },
-  gasCostsContainer: {
-    backgroundColor: background,
-    padding: `0 ${lg}`,
   },
 })

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
@@ -23,7 +23,7 @@ import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { ButtonStatus, Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
@@ -205,15 +205,13 @@ const ReviewCollectible = ({ onClose, onPrev, tx }: Props): React.ReactElement =
               isOffChainSignature={isOffChainSignature}
             />
           </Block>
-          <div className={classes.gasCostsContainer}>
-            <TransactionFees
-              gasCostFormatted={gasCostFormatted}
-              isExecution={doExecute}
-              isCreation={isCreation}
-              isOffChainSignature={isOffChainSignature}
-              txEstimationExecutionStatus={txEstimationExecutionStatus}
-            />
-          </div>
+          <ReviewInfoText
+            gasCostFormatted={gasCostFormatted}
+            isExecution={doExecute}
+            isCreation={isCreation}
+            isOffChainSignature={isOffChainSignature}
+            txEstimationExecutionStatus={txEstimationExecutionStatus}
+          />
           <Modal.Footer withoutBorder={buttonStatus !== ButtonStatus.LOADING}>
             <Modal.Footer.Buttons
               cancelButtonProps={{ onClick: onPrev, text: 'Back' }}

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
@@ -207,9 +207,10 @@ const ReviewCollectible = ({ onClose, onPrev, tx }: Props): React.ReactElement =
           </Block>
           <ReviewInfoText
             gasCostFormatted={gasCostFormatted}
-            isExecution={doExecute}
             isCreation={isCreation}
+            isExecution={doExecute}
             isOffChainSignature={isOffChainSignature}
+            safeNonce={txParameters.safeNonce}
             txEstimationExecutionStatus={txEstimationExecutionStatus}
           />
           <Modal.Footer withoutBorder={buttonStatus !== ButtonStatus.LOADING}>

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/style.ts
@@ -1,4 +1,4 @@
-import { background, lg, md, sm } from 'src/theme/variables'
+import { lg, md, sm } from 'src/theme/variables'
 import { createStyles } from '@material-ui/core'
 
 export const styles = createStyles({
@@ -12,9 +12,5 @@ export const styles = createStyles({
     height: '84px',
     justifyContent: 'center',
     gap: '16px',
-  },
-  gasCostsContainer: {
-    backgroundColor: background,
-    padding: `0 ${lg}`,
   },
 })

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
@@ -273,11 +273,11 @@ const ReviewSendFundsTx = ({ onClose, onPrev, tx }: ReviewTxProps): React.ReactE
           {!isSpendingLimit && txEstimationExecutionStatus !== EstimationStatus.LOADING && (
             <ReviewInfoText
               gasCostFormatted={gasCostFormatted}
-              isExecution={doExecute}
               isCreation={isCreation}
+              isExecution={doExecute}
               isOffChainSignature={isOffChainSignature}
-              txEstimationExecutionStatus={txEstimationExecutionStatus}
               safeNonce={txParameters.safeNonce}
+              txEstimationExecutionStatus={txEstimationExecutionStatus}
             />
           )}
 

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
@@ -28,7 +28,7 @@ import { RecordOf } from 'immutable'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { ButtonStatus, Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 
 import { styles } from './style'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
@@ -271,15 +271,14 @@ const ReviewSendFundsTx = ({ onClose, onPrev, tx }: ReviewTxProps): React.ReactE
           {/* Disclaimer */}
           {/* FIXME Estimation should be fixed to be used with spending limits */}
           {!isSpendingLimit && txEstimationExecutionStatus !== EstimationStatus.LOADING && (
-            <div className={classes.gasCostsContainer}>
-              <TransactionFees
-                gasCostFormatted={gasCostFormatted}
-                isExecution={doExecute}
-                isCreation={isCreation}
-                isOffChainSignature={isOffChainSignature}
-                txEstimationExecutionStatus={txEstimationExecutionStatus}
-              />
-            </div>
+            <ReviewInfoText
+              gasCostFormatted={gasCostFormatted}
+              isExecution={doExecute}
+              isCreation={isCreation}
+              isOffChainSignature={isOffChainSignature}
+              txEstimationExecutionStatus={txEstimationExecutionStatus}
+              safeNonce={txParameters.safeNonce}
+            />
           )}
 
           {/* Footer */}

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/style.ts
@@ -1,4 +1,4 @@
-import { background, lg, md, sm } from 'src/theme/variables'
+import { lg, md, sm } from 'src/theme/variables'
 import { createStyles } from '@material-ui/core'
 
 export const styles = createStyles({
@@ -12,9 +12,5 @@ export const styles = createStyles({
     height: '84px',
     justifyContent: 'center',
     gap: '16px',
-  },
-  gasCostsContainer: {
-    backgroundColor: background,
-    padding: `0 ${lg}`,
   },
 })

--- a/src/routes/safe/components/Settings/Advanced/Advanced.test.tsx
+++ b/src/routes/safe/components/Settings/Advanced/Advanced.test.tsx
@@ -9,21 +9,26 @@ const safeAddress = '0xC245cb45B044d66fbE8Fb33C26c0b28B4fc367B2'
 const url = `/rin:${safeAddress}/settings/advanced`
 history.location.pathname = url
 
-jest.mock('src/logic/hooks/useEstimateTransactionGas', () => ({
-  useEstimateTransactionGas: () => ({
-    txEstimationExecutionStatus: 'SUCCESS',
-    gasEstimation: 0,
-    gasCost: '0',
-    gasCostFormatted: '0',
-    gasPrice: '0',
-    gasPriceFormatted: '0',
-    gasLimit: '0',
-    isExecution: true,
-    isCreation: false,
-    isOffChainSignature: false,
-  }),
-  EstimationStatus: { LOADING: 'LOADING' },
-}))
+jest.mock('src/logic/hooks/useEstimateTransactionGas', () => {
+  const originalModule = jest.requireActual('src/logic/hooks/useEstimateTransactionGas')
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    useEstimateTransactionGas: () => ({
+      txEstimationExecutionStatus: 'SUCCESS',
+      gasEstimation: 0,
+      gasCost: '0',
+      gasCostFormatted: '0',
+      gasPrice: '0',
+      gasPriceFormatted: '0',
+      gasLimit: '0',
+      isExecution: true,
+      isCreation: false,
+      isOffChainSignature: false,
+    }),
+    EstimationStatus: { LOADING: 'LOADING' },
+  }
+})
 
 describe('Advanced Settings Component', () => {
   it('Renders Advanced Settings Component', () => {

--- a/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
@@ -156,9 +156,10 @@ export const RemoveGuardModal = ({ onClose, guardAddress }: RemoveGuardModalProp
               <Row className={classes.modalDescription}>
                 <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
-                  isExecution={isExecution}
                   isCreation={isCreation}
+                  isExecution={isExecution}
                   isOffChainSignature={isOffChainSignature}
+                  safeNonce={txParameters.safeNonce}
                   txEstimationExecutionStatus={txEstimationExecutionStatus}
                 />
               </Row>

--- a/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveGuardModal.tsx
@@ -1,5 +1,4 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import cn from 'classnames'
 import { ReactElement, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -9,6 +8,7 @@ import Hairline from 'src/components/layout/Hairline'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import Modal, { ButtonStatus, Modal as GenericModal } from 'src/components/Modal'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { getExplorerInfo } from 'src/config'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
 
@@ -18,7 +18,6 @@ import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { useStyles } from './style'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
-import { TransactionFees } from 'src/components/TransactionsFees'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
@@ -154,8 +153,8 @@ export const RemoveGuardModal = ({ onClose, guardAddress }: RemoveGuardModalProp
                   isOffChainSignature={isOffChainSignature}
                 />
               </Block>
-              <Row className={cn(classes.modalDescription, classes.gasCostsContainer)}>
-                <TransactionFees
+              <Row className={classes.modalDescription}>
+                <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
                   isExecution={isExecution}
                   isCreation={isCreation}

--- a/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
@@ -1,5 +1,4 @@
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
-import cn from 'classnames'
 import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -9,6 +8,7 @@ import Hairline from 'src/components/layout/Hairline'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import Modal, { ButtonStatus, Modal as GenericModal } from 'src/components/Modal'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { getExplorerInfo } from 'src/config'
 import { getDisableModuleTxData } from 'src/logic/safe/utils/modules'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
@@ -21,7 +21,6 @@ import { useStyles } from './style'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
-import { TransactionFees } from 'src/components/TransactionsFees'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
@@ -162,8 +161,8 @@ export const RemoveModuleModal = ({ onClose, selectedModulePair }: RemoveModuleM
                   isOffChainSignature={isOffChainSignature}
                 />
               </Block>
-              <Row className={cn(classes.modalDescription, classes.gasCostsContainer)}>
-                <TransactionFees
+              <Row className={classes.modalDescription}>
+                <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
                   isExecution={isExecution}
                   isCreation={isCreation}

--- a/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
+++ b/src/routes/safe/components/Settings/Advanced/RemoveModuleModal.tsx
@@ -164,9 +164,10 @@ export const RemoveModuleModal = ({ onClose, selectedModulePair }: RemoveModuleM
               <Row className={classes.modalDescription}>
                 <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
-                  isExecution={isExecution}
                   isCreation={isCreation}
+                  isExecution={isExecution}
                   isOffChainSignature={isOffChainSignature}
+                  safeNonce={txParameters.safeNonce}
                   txEstimationExecutionStatus={txEstimationExecutionStatus}
                 />
               </Row>

--- a/src/routes/safe/components/Settings/Advanced/style.ts
+++ b/src/routes/safe/components/Settings/Advanced/style.ts
@@ -1,6 +1,6 @@
 import { createStyles, makeStyles } from '@material-ui/core'
 
-import { background, lg, md } from 'src/theme/variables'
+import { lg, md } from 'src/theme/variables'
 
 export const useStyles = makeStyles(
   createStyles({
@@ -34,10 +34,6 @@ export const useStyles = makeStyles(
     },
     accordionContainer: {
       margin: `0 ${md}`,
-    },
-    gasCostsContainer: {
-      backgroundColor: background,
-      padding: `0 ${lg}`,
     },
   }),
 )

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
@@ -205,9 +205,10 @@ export const ReviewAddOwner = ({ onClickBack, onClose, onSubmit, values }: Revie
 
           <ReviewInfoText
             gasCostFormatted={gasCostFormatted}
-            isExecution={isExecution}
             isCreation={isCreation}
+            isExecution={isExecution}
             isOffChainSignature={isOffChainSignature}
+            safeNonce={txParameters.safeNonce}
             txEstimationExecutionStatus={txEstimationExecutionStatus}
           />
           <Hairline />

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/index.tsx
@@ -16,7 +16,7 @@ import { TxParametersDetail } from 'src/routes/safe/components/Transactions/help
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 
 import { OwnerValues } from '../..'
 import { styles } from './style'
@@ -203,15 +203,13 @@ export const ReviewAddOwner = ({ onClickBack, onClose, onSubmit, values }: Revie
             isOffChainSignature={isOffChainSignature}
           />
 
-          <Block className={classes.gasCostsContainer}>
-            <TransactionFees
-              gasCostFormatted={gasCostFormatted}
-              isExecution={isExecution}
-              isCreation={isCreation}
-              isOffChainSignature={isOffChainSignature}
-              txEstimationExecutionStatus={txEstimationExecutionStatus}
-            />
-          </Block>
+          <ReviewInfoText
+            gasCostFormatted={gasCostFormatted}
+            isExecution={isExecution}
+            isCreation={isCreation}
+            isOffChainSignature={isOffChainSignature}
+            txEstimationExecutionStatus={txEstimationExecutionStatus}
+          />
           <Hairline />
           <Row align="center" className={classes.buttonRow}>
             <Modal.Footer.Buttons

--- a/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/style.ts
+++ b/src/routes/safe/components/Settings/ManageOwners/AddOwnerModal/screens/Review/style.ts
@@ -49,12 +49,4 @@ export const styles = createStyles({
       cursor: 'pointer',
     },
   },
-  gasCostsContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    textAlign: 'center',
-    width: '100%',
-    backgroundColor: background,
-  },
 })

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
@@ -227,9 +227,10 @@ export const ReviewRemoveOwnerModal = ({
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
             <ReviewInfoText
               gasCostFormatted={gasCostFormatted}
-              isExecution={isExecution}
               isCreation={isCreation}
+              isExecution={isExecution}
               isOffChainSignature={isOffChainSignature}
+              safeNonce={txParameters.safeNonce}
               txEstimationExecutionStatus={txEstimationExecutionStatus}
             />
           )}

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/index.tsx
@@ -17,7 +17,7 @@ import { OwnerData } from 'src/routes/safe/components/Settings/ManageOwners/data
 
 import { useStyles } from './style'
 import { Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
@@ -225,15 +225,13 @@ export const ReviewRemoveOwnerModal = ({
           />
 
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
-            <Block className={classes.gasCostsContainer}>
-              <TransactionFees
-                gasCostFormatted={gasCostFormatted}
-                isExecution={isExecution}
-                isCreation={isCreation}
-                isOffChainSignature={isOffChainSignature}
-                txEstimationExecutionStatus={txEstimationExecutionStatus}
-              />
-            </Block>
+            <ReviewInfoText
+              gasCostFormatted={gasCostFormatted}
+              isExecution={isExecution}
+              isCreation={isCreation}
+              isOffChainSignature={isOffChainSignature}
+              txEstimationExecutionStatus={txEstimationExecutionStatus}
+            />
           )}
           <Modal.Footer withoutBorder>
             <Modal.Footer.Buttons

--- a/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/style.ts
+++ b/src/routes/safe/components/Settings/ManageOwners/RemoveOwnerModal/screens/Review/style.ts
@@ -39,13 +39,5 @@ export const useStyles = makeStyles(
       alignItems: 'center',
       backgroundColor: '#ffe6ea',
     },
-    gasCostsContainer: {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      textAlign: 'center',
-      width: '100%',
-      backgroundColor: background,
-    },
   }),
 )

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
@@ -15,7 +15,7 @@ import { TxParametersDetail } from 'src/routes/safe/components/Transactions/help
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { OwnerData } from 'src/routes/safe/components/Settings/ManageOwners/dataFetcher'
@@ -229,15 +229,13 @@ export const ReviewReplaceOwnerModal = ({
             isOffChainSignature={isOffChainSignature}
           />
 
-          <Block className={classes.gasCostsContainer}>
-            <TransactionFees
-              gasCostFormatted={gasCostFormatted}
-              isExecution={isExecution}
-              isCreation={isCreation}
-              isOffChainSignature={isOffChainSignature}
-              txEstimationExecutionStatus={txEstimationExecutionStatus}
-            />
-          </Block>
+          <ReviewInfoText
+            gasCostFormatted={gasCostFormatted}
+            isExecution={isExecution}
+            isCreation={isCreation}
+            isOffChainSignature={isOffChainSignature}
+            txEstimationExecutionStatus={txEstimationExecutionStatus}
+          />
           <Modal.Footer withoutBorder>
             <Modal.Footer.Buttons
               cancelButtonProps={{ onClick: onClickBack, text: 'Back' }}

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/index.tsx
@@ -231,9 +231,10 @@ export const ReviewReplaceOwnerModal = ({
 
           <ReviewInfoText
             gasCostFormatted={gasCostFormatted}
-            isExecution={isExecution}
             isCreation={isCreation}
+            isExecution={isExecution}
             isOffChainSignature={isOffChainSignature}
+            safeNonce={txParameters.safeNonce}
             txEstimationExecutionStatus={txEstimationExecutionStatus}
           />
           <Modal.Footer withoutBorder>

--- a/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/style.ts
+++ b/src/routes/safe/components/Settings/ManageOwners/ReplaceOwnerModal/screens/Review/style.ts
@@ -43,13 +43,5 @@ export const useStyles = makeStyles(
       alignItems: 'center',
       backgroundColor: '#f7f5f5',
     },
-    gasCostsContainer: {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      textAlign: 'center',
-      width: '100%',
-      backgroundColor: background,
-    },
   }),
 )

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import Col from 'src/components/layout/Col'
 import Row from 'src/components/layout/Row'
 import { ButtonStatus, Modal } from 'src/components/Modal'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { createTransaction, CreateTransactionArgs } from 'src/logic/safe/store/actions/createTransaction'
 import { SafeRecordProps, SpendingLimit } from 'src/logic/safe/store/models/safe'
 import {
@@ -23,12 +24,10 @@ import { fromTokenUnit, toTokenUnit } from 'src/logic/tokens/utils/humanReadable
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { getResetTimeOptions } from 'src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime'
 import { AddressInfo, ResetTimeInfo, TokenInfo } from 'src/routes/safe/components/Settings/SpendingLimit/InfoDisplay'
-import { useStyles } from 'src/routes/safe/components/Settings/SpendingLimit/style'
 import { currentSafe } from 'src/logic/safe/store/selectors'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
-import { TransactionFees } from 'src/components/TransactionsFees'
 import Hairline from 'src/components/layout/Hairline'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
@@ -153,7 +152,6 @@ interface ReviewSpendingLimitProps {
 }
 
 export const ReviewSpendingLimits = ({ onBack, onClose, txToken, values }: ReviewSpendingLimitProps): ReactElement => {
-  const classes = useStyles()
   const dispatch = useDispatch()
 
   const {
@@ -322,15 +320,13 @@ export const ReviewSpendingLimits = ({ onBack, onClose, txToken, values }: Revie
               isOffChainSignature={isOffChainSignature}
             />
           </Modal.Body>
-          <div className={classes.gasCostsContainer}>
-            <TransactionFees
-              gasCostFormatted={gasCostFormatted}
-              isExecution={isExecution}
-              isCreation={isCreation}
-              isOffChainSignature={isOffChainSignature}
-              txEstimationExecutionStatus={txEstimationExecutionStatus}
-            />
-          </div>
+          <ReviewInfoText
+            gasCostFormatted={gasCostFormatted}
+            isExecution={isExecution}
+            isCreation={isCreation}
+            isOffChainSignature={isOffChainSignature}
+            txEstimationExecutionStatus={txEstimationExecutionStatus}
+          />
 
           <Modal.Footer withoutBorder={buttonStatus !== ButtonStatus.LOADING}>
             <Modal.Footer.Buttons

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -322,9 +322,10 @@ export const ReviewSpendingLimits = ({ onBack, onClose, txToken, values }: Revie
           </Modal.Body>
           <ReviewInfoText
             gasCostFormatted={gasCostFormatted}
-            isExecution={isExecution}
             isCreation={isCreation}
+            isExecution={isExecution}
             isOffChainSignature={isOffChainSignature}
+            safeNonce={txParameters.safeNonce}
             txEstimationExecutionStatus={txEstimationExecutionStatus}
           />
 

--- a/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
@@ -170,9 +170,10 @@ export const RemoveLimitModal = ({ onClose, spendingLimit, open }: RemoveSpendin
               <Row className={classes.modalDescription}>
                 <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
-                  isExecution={isExecution}
                   isCreation={isCreation}
+                  isExecution={isExecution}
                   isOffChainSignature={isOffChainSignature}
+                  safeNonce={txParameters.safeNonce}
                   txEstimationExecutionStatus={txEstimationExecutionStatus}
                 />
               </Row>

--- a/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/RemoveLimitModal.tsx
@@ -1,4 +1,3 @@
-import cn from 'classnames'
 import { ReactElement, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 
@@ -6,7 +5,7 @@ import Col from 'src/components/layout/Col'
 import Row from 'src/components/layout/Row'
 import Hairline from 'src/components/layout/Hairline'
 import { ButtonStatus, Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
@@ -168,8 +167,8 @@ export const RemoveLimitModal = ({ onClose, spendingLimit, open }: RemoveSpendin
                 />
               </Modal.Body>
 
-              <Row className={cn(classes.modalDescription, classes.gasCostsContainer)}>
-                <TransactionFees
+              <Row className={classes.modalDescription}>
+                <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
                   isExecution={isExecution}
                   isCreation={isCreation}

--- a/src/routes/safe/components/Settings/SpendingLimit/style.ts
+++ b/src/routes/safe/components/Settings/SpendingLimit/style.ts
@@ -122,9 +122,5 @@ export const useStyles = makeStyles(
     amountInput: {
       width: '100% !important',
     },
-    gasCostsContainer: {
-      backgroundColor: background,
-      padding: `0 ${lg}`,
-    },
   }),
 )

--- a/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
+++ b/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
@@ -186,9 +186,10 @@ export const ChangeThresholdModal = ({
                 {txEstimationExecutionStatus !== EstimationStatus.LOADING && (
                   <ReviewInfoText
                     gasCostFormatted={gasCostFormatted}
-                    isExecution={isExecution}
                     isCreation={isCreation}
+                    isExecution={isExecution}
                     isOffChainSignature={isOffChainSignature}
+                    safeNonce={txParameters.safeNonce}
                     txEstimationExecutionStatus={txEstimationExecutionStatus}
                   />
                 )}

--- a/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
+++ b/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/index.tsx
@@ -19,7 +19,7 @@ import { getGnosisSafeInstanceAt } from 'src/logic/contracts/safeContracts'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { ButtonStatus, Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
@@ -184,15 +184,13 @@ export const ChangeThresholdModal = ({
                   />
                 </Block>
                 {txEstimationExecutionStatus !== EstimationStatus.LOADING && (
-                  <div className={classes.gasCostsContainer}>
-                    <TransactionFees
-                      gasCostFormatted={gasCostFormatted}
-                      isExecution={isExecution}
-                      isCreation={isCreation}
-                      isOffChainSignature={isOffChainSignature}
-                      txEstimationExecutionStatus={txEstimationExecutionStatus}
-                    />
-                  </div>
+                  <ReviewInfoText
+                    gasCostFormatted={gasCostFormatted}
+                    isExecution={isExecution}
+                    isCreation={isCreation}
+                    isOffChainSignature={isOffChainSignature}
+                    txEstimationExecutionStatus={txEstimationExecutionStatus}
+                  />
                 )}
 
                 <Modal.Footer withoutBorder={buttonStatus !== ButtonStatus.LOADING}>

--- a/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/style.ts
+++ b/src/routes/safe/components/Settings/ThresholdSettings/ChangeThreshold/style.ts
@@ -1,6 +1,6 @@
 import { createStyles, makeStyles } from '@material-ui/core'
 
-import { background, lg, md, sm } from 'src/theme/variables'
+import { lg, md, sm } from 'src/theme/variables'
 
 export const useStyles = makeStyles(
   createStyles({
@@ -12,10 +12,6 @@ export const useStyles = makeStyles(
     },
     inputRow: {
       position: 'relative',
-    },
-    gasCostsContainer: {
-      backgroundColor: background,
-      padding: `${sm} ${lg}`,
     },
   }),
 )

--- a/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
@@ -129,9 +129,10 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
             <ReviewInfoText
               gasCostFormatted={gasCostFormatted}
-              isExecution={isExecution}
               isCreation={isCreation}
+              isExecution={isExecution}
               isOffChainSignature={isOffChainSignature}
+              safeNonce={txParameters.safeNonce}
               txEstimationExecutionStatus={txEstimationExecutionStatus}
             />
           )}

--- a/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
@@ -12,7 +12,7 @@ import Row from 'src/components/layout/Row'
 import { getUpgradeSafeTransactionHash } from 'src/logic/safe/utils/upgradeSafe'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
 import { ButtonStatus, Modal } from 'src/components/Modal'
-import { TransactionFees } from 'src/components/TransactionsFees'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
 import { getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
@@ -127,15 +127,13 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
             />
           </Block>
           {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
-            <Block className={classes.gasCostsContainer}>
-              <TransactionFees
-                gasCostFormatted={gasCostFormatted}
-                isExecution={isExecution}
-                isCreation={isCreation}
-                isOffChainSignature={isOffChainSignature}
-                txEstimationExecutionStatus={txEstimationExecutionStatus}
-              />
-            </Block>
+            <ReviewInfoText
+              gasCostFormatted={gasCostFormatted}
+              isExecution={isExecution}
+              isCreation={isCreation}
+              isOffChainSignature={isOffChainSignature}
+              txEstimationExecutionStatus={txEstimationExecutionStatus}
+            />
           )}
           {/* Footer */}
           <Modal.Footer withoutBorder={buttonStatus !== ButtonStatus.LOADING}>

--- a/src/routes/safe/components/Settings/UpdateSafeModal/style.ts
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/style.ts
@@ -1,14 +1,10 @@
-import { background, lg, md } from 'src/theme/variables'
+import { lg, md } from 'src/theme/variables'
 import { createStyles, makeStyles } from '@material-ui/core'
 
 export const useStyles = makeStyles(
   createStyles({
     modalContent: {
       padding: `${md} ${lg}`,
-    },
-    gasCostsContainer: {
-      backgroundColor: background,
-      padding: `0 ${lg}`,
     },
   }),
 )

--- a/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useStyles } from './style'
 
 import Modal, { ButtonStatus, Modal as GenericModal } from 'src/components/Modal'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import Block from 'src/components/layout/Block'
 import Bold from 'src/components/layout/Bold'
 import Hairline from 'src/components/layout/Hairline'
@@ -21,7 +22,6 @@ import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { processTransaction } from 'src/logic/safe/store/actions/processTransaction'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEstimationStatus } from 'src/logic/hooks/useEstimationStatus'
-import { TransactionFees } from 'src/components/TransactionsFees'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
@@ -368,15 +368,13 @@ export const ApproveTxModal = ({
               </Block>
 
               {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
-                <Block className={classes.gasCostsContainer}>
-                  <TransactionFees
-                    gasCostFormatted={gasCostFormatted}
-                    isExecution={doExecute}
-                    isCreation={isCreation}
-                    isOffChainSignature={isOffChainSignature}
-                    txEstimationExecutionStatus={txEstimationExecutionStatus}
-                  />
-                </Block>
+                <ReviewInfoText
+                  gasCostFormatted={gasCostFormatted}
+                  isExecution={doExecute}
+                  isCreation={isCreation}
+                  isOffChainSignature={isOffChainSignature}
+                  txEstimationExecutionStatus={txEstimationExecutionStatus}
+                />
               )}
 
               {/* Footer */}

--- a/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
@@ -370,9 +370,10 @@ export const ApproveTxModal = ({
               {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
                 <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
-                  isExecution={doExecute}
                   isCreation={isCreation}
+                  isExecution={doExecute}
                   isOffChainSignature={isOffChainSignature}
+                  safeNonce={txParameters.safeNonce}
                   txEstimationExecutionStatus={txEstimationExecutionStatus}
                 />
               )}

--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -3,6 +3,7 @@ import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useDispatch } from 'react-redux'
 import { useStyles } from './style'
 import Modal, { ButtonStatus, Modal as GenericModal } from 'src/components/Modal'
+import { ReviewInfoText } from 'src/components/ReviewInfoText'
 import Block from 'src/components/layout/Block'
 import Bold from 'src/components/layout/Bold'
 import Hairline from 'src/components/layout/Hairline'
@@ -13,7 +14,6 @@ import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
-import { TransactionFees } from 'src/components/TransactionsFees'
 import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
 import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
@@ -119,15 +119,13 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
               </Block>
 
               {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
-                <Block className={classes.gasCostsContainer}>
-                  <TransactionFees
-                    gasCostFormatted={gasCostFormatted}
-                    isExecution={isExecution}
-                    isCreation={isCreation}
-                    isOffChainSignature={isOffChainSignature}
-                    txEstimationExecutionStatus={txEstimationExecutionStatus}
-                  />
-                </Block>
+                <ReviewInfoText
+                  gasCostFormatted={gasCostFormatted}
+                  isExecution={isExecution}
+                  isCreation={isCreation}
+                  isOffChainSignature={isOffChainSignature}
+                  txEstimationExecutionStatus={txEstimationExecutionStatus}
+                />
               )}
               <GenericModal.Footer withoutBorder={confirmButtonStatus !== ButtonStatus.LOADING}>
                 <GenericModal.Footer.Buttons

--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -121,9 +121,10 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
               {txEstimationExecutionStatus === EstimationStatus.LOADING ? null : (
                 <ReviewInfoText
                   gasCostFormatted={gasCostFormatted}
-                  isExecution={isExecution}
                   isCreation={isCreation}
+                  isExecution={isExecution}
                   isOffChainSignature={isOffChainSignature}
+                  safeNonce={txParameters.safeNonce}
                   txEstimationExecutionStatus={txEstimationExecutionStatus}
                 />
               )}

--- a/src/routes/safe/components/Transactions/TxList/modals/style.ts
+++ b/src/routes/safe/components/Transactions/TxList/modals/style.ts
@@ -1,5 +1,5 @@
 import { createStyles, makeStyles } from '@material-ui/core'
-import { background, lg, md, sm } from 'src/theme/variables'
+import { lg, md, sm } from 'src/theme/variables'
 
 export const useStyles = makeStyles(
   createStyles({
@@ -9,10 +9,6 @@ export const useStyles = makeStyles(
     nonceNumber: {
       marginTop: sm,
       fontSize: md,
-    },
-    gasCostsContainer: {
-      backgroundColor: background,
-      padding: `0 ${lg}`,
     },
   }),
 )

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -81,12 +81,13 @@ export const TxParametersDetail = ({
           </StyledText>
 
           <TxParameterWrapper>
-            <Text
+            <ColoredText
               size="lg"
+              isFuture={isSafeNonceFuture}
               color={areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'}
             >
               Safe nonce
-            </Text>
+            </ColoredText>
             <ColoredText
               size="lg"
               isFuture={isSafeNonceFuture}

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { Text, ButtonLink, Accordion, AccordionSummary, AccordionDetails } from '@gnosis.pm/safe-react-components'
@@ -60,6 +60,12 @@ export const TxParametersDetail = ({
   const { safeNonce = '' } = txParameters
   const isSafeNonceFuture = parseInt(safeNonce, 10) > nonce
   const [isAccordionExpanded, setIsAccordionExpanded] = useState(isSafeNonceFuture)
+
+  useEffect(() => {
+    if (parseInt(safeNonce, 10) > nonce) {
+      setIsAccordionExpanded(true)
+    }
+  }, [nonce, safeNonce, txParameters])
 
   if (!isTransactionExecution && !isTransactionCreation && isOffChainSignature) {
     return null

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -57,8 +57,8 @@ export const TxParametersDetail = ({
   const threshold = useSelector(currentSafeThreshold) || 1
   const defaultParameterStatus = isOffChainSignature && threshold > 1 ? 'ETH_HIDDEN' : 'ENABLED'
 
-  const { safeNonce } = txParameters
-  const isSafeNonceFuture = parseInt(safeNonce || '', 10) > nonce
+  const { safeNonce = '' } = txParameters
+  const isSafeNonceFuture = parseInt(safeNonce, 10) > nonce
   const [isAccordionExpanded, setIsAccordionExpanded] = useState(isSafeNonceFuture)
 
   if (!isTransactionExecution && !isTransactionCreation && isOffChainSignature) {

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -1,11 +1,11 @@
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { Text, ButtonLink, Accordion, AccordionSummary, AccordionDetails } from '@gnosis.pm/safe-react-components'
 
+import { currentSafe, currentSafeThreshold } from 'src/logic/safe/store/selectors'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { ParametersStatus, areEthereumParamsVisible, areSafeParamsEnabled, ethereumTxParametersTitle } from '../utils'
-import { useSelector } from 'react-redux'
-import { currentSafeThreshold } from 'src/logic/safe/store/selectors'
 
 const TxParameterWrapper = styled.div`
   display: flex;
@@ -19,6 +19,10 @@ const AccordionDetailsWrapper = styled.div`
 `
 const StyledText = styled(Text)`
   margin: 8px 0 0 0;
+`
+
+const ColoredText = styled(Text)<{ isFuture: boolean }>`
+  color: ${(props) => (props.isFuture ? 'red' : props.color)};
 `
 
 const StyledButtonLink = styled(ButtonLink)`
@@ -49,15 +53,24 @@ export const TxParametersDetail = ({
   isTransactionExecution,
   isOffChainSignature,
 }: Props): ReactElement | null => {
+  const { nonce } = useSelector(currentSafe)
   const threshold = useSelector(currentSafeThreshold) || 1
   const defaultParameterStatus = isOffChainSignature && threshold > 1 ? 'ETH_HIDDEN' : 'ENABLED'
+
+  const { safeNonce } = txParameters
+  const isSafeNonceFuture = parseInt(safeNonce || '', 10) > nonce
+  const [isAccordionExpanded, setIsAccordionExpanded] = useState(isSafeNonceFuture)
 
   if (!isTransactionExecution && !isTransactionCreation && isOffChainSignature) {
     return null
   }
 
+  const onChangeExpand = () => {
+    setIsAccordionExpanded(!isAccordionExpanded)
+  }
+
   return (
-    <Accordion compact={compact}>
+    <Accordion compact={compact} expanded={isAccordionExpanded} onChange={onChangeExpand}>
       <AccordionSummary>
         <Text size="lg">Advanced options</Text>
       </AccordionSummary>
@@ -74,12 +87,13 @@ export const TxParametersDetail = ({
             >
               Safe nonce
             </Text>
-            <Text
+            <ColoredText
               size="lg"
+              isFuture={isSafeNonceFuture}
               color={areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'}
             >
               {txParameters.safeNonce}
-            </Text>
+            </ColoredText>
           </TxParameterWrapper>
 
           <TxParameterWrapper>


### PR DESCRIPTION
## What it solves
Resolves #2904

## How this PR fixes it
When the user edits the transaction params and sets a `safeNonce` greater than the current `nonce`

## How to test it
On creating transaction "Review" step, edit the `safeNonce` to be greater than the current one.
Then:
- the gas estimate area is replaced with error copy
- the advanced menu has been expanded
- the offending nonce is highlighted red.
- _**updated warning copy**_

## Screenshots
![Screen Shot 2021-11-12 at 14 46 51](https://user-images.githubusercontent.com/32431609/141477106-8ae4b21c-b9bc-4739-adec-ab33bd5f81f9.png)

