### PR TITLE
fix: Toggle sidebar when link is clicked

### DIFF
--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -111,7 +111,10 @@ export const SafeList = ({ onSafeClick }: Props): ReactElement => {
 
               {!localSafesOnNetwork.length && !ownedSafesOnNetwork.length && (
                 <PlaceholderText size="lg" color="placeHolder">
-                  <Link to={WELCOME_ROUTE}>Create or add</Link> an existing Safe on this network
+                  <Link to={WELCOME_ROUTE} onClick={onSafeClick}>
+                    Create or add
+                  </Link>{' '}
+                  an existing Safe on this network
                 </PlaceholderText>
               )}
 


### PR DESCRIPTION
## What it solves
Resolves #2987

## How this PR fixes it
When the 'Create or add' sidebar placeholder link is clicked, the sidebar toggle function is called.

## How to test it
Open the sidebar on a network on which the user has no Safes and click on the link. If on the `/welcome` route, the sidebar will close and if on another, the route will change to `/welcome and sidebar close.