### PR TITLE
Fix: use eth_getGasPrice on xDai and Arbitrum

### DIFF
--- a/src/config/networks/arbitrum.ts
+++ b/src/config/networks/arbitrum.ts
@@ -12,7 +12,7 @@ import {
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.gnosis.io/v1',
   txServiceUrl: 'https://safe-transaction.arbitrum.gnosis.io/api/v1',
-  gasPrice: 2e9,
+  gasPriceOracles: [],
   rpcServiceUrl: 'https://arb1.arbitrum.io/rpc',
   safeAppsRpcServiceUrl: 'https://arb1.arbitrum.io/rpc',
   networkExplorerName: 'Arbitrum explorer',

--- a/src/config/networks/rinkeby.ts
+++ b/src/config/networks/rinkeby.ts
@@ -7,7 +7,7 @@ import {
   NetworkConfig,
   WALLETS,
 } from 'src/config/networks/network.d'
-import { ETHGASSTATION_API_KEY, ETHERSCAN_API_KEY } from 'src/utils/constants'
+import { ETHERSCAN_API_KEY } from 'src/utils/constants'
 
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.staging.gnosisdev.com/v1',
@@ -17,11 +17,6 @@ const baseConfig: EnvironmentSettings = {
       url: `https://api-rinkeby.etherscan.io/api?module=gastracker&action=gasoracle&apikey=${ETHERSCAN_API_KEY}`,
       gasParameter: 'FastGasPrice',
       gweiFactor: '1e9',
-    },
-    {
-      url: `https://ethgasstation.info/json/ethgasAPI.json?api-key=${ETHGASSTATION_API_KEY}`,
-      gasParameter: 'fast',
-      gweiFactor: '1e8',
     },
   ],
   rpcServiceUrl: 'https://rinkeby.infura.io:443/v3',

--- a/src/config/networks/xdai.ts
+++ b/src/config/networks/xdai.ts
@@ -12,7 +12,7 @@ import {
 const baseConfig: EnvironmentSettings = {
   clientGatewayUrl: 'https://safe-client.gnosis.io/v1',
   txServiceUrl: 'https://safe-transaction.xdai.gnosis.io/api/v1',
-  gasPrice: 1e9,
+  gasPriceOracles: [],
   rpcServiceUrl: 'https://dai.poa.network/',
   safeAppsRpcServiceUrl: 'https://dai.poa.network/',
   networkExplorerName: 'Blockscout',


### PR DESCRIPTION
## What it solves
Partially resolves #2837
Resolves #2999

## How this PR fixes it
Instead of using a fixed gas price on xDai, request it from the blockchain.

I've done the same for Arbitrum, as it's recommended in their docs.

## How to test it
* Create a tx on xDai
* Check the gasPrice in the advanced settings

Same on Arbitrum.

## Screenshot
<img width="477" alt="Screenshot 2021-11-15 at 17 30 57" src="https://user-images.githubusercontent.com/381895/141818926-c35578e7-0345-41f1-be4f-580c15cef580.png">