### PR TITLE
Filter the AddressBook sorted entries before displaying them

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.2",
+    "lodash.uniqwith": "^4.5.0",
     "notistack": "https://github.com/gnosis/notistack.git#v0.9.5",
     "object-hash": "^2.1.1",
     "qrcode.react": "1.0.1",

--- a/src/logic/addressBook/store/reducer/index.ts
+++ b/src/logic/addressBook/store/reducer/index.ts
@@ -1,8 +1,9 @@
 import { Action, handleActions } from 'redux-actions'
+import uniqwith from 'lodash.uniqwith'
 
 import { AddressBookEntry, AddressBookState } from 'src/logic/addressBook/model/addressBook'
 import { ADDRESS_BOOK_ACTIONS } from 'src/logic/addressBook/store/actions'
-import { getEntryIndex, isValidAddressBookName } from 'src/logic/addressBook/utils'
+import { getEntryIndex, hasSameAddressAndChainId, isValidAddressBookName } from 'src/logic/addressBook/utils'
 import { AppReduxState } from 'src/store'
 
 export const ADDRESS_BOOK_REDUCER_ID = 'addressBook'
@@ -27,7 +28,9 @@ export const batchLoadEntries = (state: AddressBookState, action: Action<Address
         newState.push(addressBookEntry)
       }
     })
-  return newState
+
+  // filter out potential duplicates in the store
+  return uniqwith(newState, hasSameAddressAndChainId)
 }
 export default handleActions<AppReduxState['addressBook'], Payloads>(
   {

--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -61,8 +61,12 @@ export const getEntryIndex = (
   state: AppReduxState['addressBook'],
   addressBookEntry: Overwrite<AddressBookEntry, { name?: string }>,
 ): number =>
-  state.findIndex(
-    ({ address, chainId }) =>
-      chainId.toString() === addressBookEntry.chainId.toString() &&
-      checksumAddress(address) === checksumAddress(addressBookEntry.address),
-  )
+  state.findIndex(({ address, chainId }) => {
+    let hasSameChecksumAddress
+    try {
+      hasSameChecksumAddress = checksumAddress(address) === checksumAddress(addressBookEntry.address)
+    } catch (e) {
+      console.error(e)
+    }
+    return chainId.toString() === addressBookEntry.chainId.toString() && hasSameChecksumAddress
+  })

--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -70,3 +70,6 @@ export const getEntryIndex = (
     }
     return chainId.toString() === addressBookEntry.chainId.toString() && hasSameChecksumAddress
   })
+
+export const hasSameAddressAndChainId = (arrVal: AddressBookEntry, othVal: AddressBookEntry): boolean =>
+  arrVal.address === othVal.address && arrVal.chainId === othVal.chainId

--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -1,8 +1,8 @@
 import { mustBeEthereumContractAddress } from 'src/components/forms/validator'
 import { AddressBookEntry, AddressBookState } from 'src/logic/addressBook/model/addressBook'
-import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { AppReduxState } from 'src/store'
 import { Overwrite } from 'src/types/helpers'
+import { checksumAddress } from 'src/utils/checksumAddress'
 
 export type OldAddressBookEntry = {
   address: string
@@ -62,12 +62,7 @@ export const getEntryIndex = (
   addressBookEntry: Overwrite<AddressBookEntry, { name?: string }>,
 ): number =>
   state.findIndex(
-    ({ address, chainId }) => chainId === addressBookEntry.chainId && sameAddress(address, addressBookEntry.address),
+    ({ address, chainId }) =>
+      chainId.toString() === addressBookEntry.chainId.toString() &&
+      checksumAddress(address) === checksumAddress(addressBookEntry.address),
   )
-
-export const uniqueByKey = (
-  key: keyof AddressBookEntry,
-  addressBookEntries: AddressBookEntry[],
-): AddressBookEntry[] => [
-  ...new Map<string, AddressBookEntry>(addressBookEntries.map((entry) => [entry[key], entry])).values(),
-]

--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -1,8 +1,8 @@
 import { mustBeEthereumContractAddress } from 'src/components/forms/validator'
 import { AddressBookEntry, AddressBookState } from 'src/logic/addressBook/model/addressBook'
+import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { AppReduxState } from 'src/store'
 import { Overwrite } from 'src/types/helpers'
-import { checksumAddress } from 'src/utils/checksumAddress'
 
 export type OldAddressBookEntry = {
   address: string
@@ -61,15 +61,10 @@ export const getEntryIndex = (
   state: AppReduxState['addressBook'],
   addressBookEntry: Overwrite<AddressBookEntry, { name?: string }>,
 ): number =>
-  state.findIndex(({ address, chainId }) => {
-    let hasSameChecksumAddress
-    try {
-      hasSameChecksumAddress = checksumAddress(address) === checksumAddress(addressBookEntry.address)
-    } catch (e) {
-      return false
-    }
-    return chainId.toString() === addressBookEntry.chainId.toString() && hasSameChecksumAddress
-  })
+  state.findIndex(
+    ({ address, chainId }) =>
+      chainId.toString() === addressBookEntry.chainId.toString() && sameAddress(address, addressBookEntry.address),
+  )
 
 export const hasSameAddressAndChainId = (arrVal: AddressBookEntry, othVal: AddressBookEntry): boolean =>
   arrVal.address === othVal.address && arrVal.chainId === othVal.chainId

--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -66,7 +66,7 @@ export const getEntryIndex = (
     try {
       hasSameChecksumAddress = checksumAddress(address) === checksumAddress(addressBookEntry.address)
     } catch (e) {
-      console.error(e)
+      return false
     }
     return chainId.toString() === addressBookEntry.chainId.toString() && hasSameChecksumAddress
   })

--- a/src/logic/addressBook/utils/index.ts
+++ b/src/logic/addressBook/utils/index.ts
@@ -64,3 +64,10 @@ export const getEntryIndex = (
   state.findIndex(
     ({ address, chainId }) => chainId === addressBookEntry.chainId && sameAddress(address, addressBookEntry.address),
   )
+
+export const uniqueByKey = (
+  key: keyof AddressBookEntry,
+  addressBookEntries: AddressBookEntry[],
+): AddressBookEntry[] => [
+  ...new Map<string, AddressBookEntry>(addressBookEntries.map((entry) => [entry[key], entry])).values(),
+]

--- a/src/routes/safe/components/AddressBook/index.tsx
+++ b/src/routes/safe/components/AddressBook/index.tsx
@@ -49,6 +49,7 @@ import ImportEntriesModal from './ImportEntriesModal'
 import { isValidAddress } from 'src/utils/isValidAddress'
 import { useHistory } from 'react-router'
 import { currentChainId } from 'src/logic/config/store/selectors'
+import { uniqueByKey } from 'src/logic/addressBook/utils'
 
 const StyledButton = styled(Button)`
   &&.MuiButton-root {
@@ -216,8 +217,9 @@ const AddressBookTable = (): ReactElement => {
             label="Owners"
             size={addressBook?.length || 0}
           >
-            {(sortedData) =>
-              sortedData.map((row, index) => {
+            {(sortedData) => {
+              const sortedUniqueByAddress = uniqueByKey('address', sortedData)
+              return sortedUniqueByAddress.map((row, index) => {
                 const userOwner = isUserAnOwnerOfAnySafe(safesList, row.address)
                 const hideBorderBottom = index >= 3 && index === sortedData.size - 1 && classes.noBorderBottom
                 return (
@@ -299,7 +301,7 @@ const AddressBookTable = (): ReactElement => {
                   </TableRow>
                 )
               })
-            }
+            }}
           </Table>
         </TableContainer>
       </Block>

--- a/src/routes/safe/components/AddressBook/index.tsx
+++ b/src/routes/safe/components/AddressBook/index.tsx
@@ -49,7 +49,6 @@ import ImportEntriesModal from './ImportEntriesModal'
 import { isValidAddress } from 'src/utils/isValidAddress'
 import { useHistory } from 'react-router'
 import { currentChainId } from 'src/logic/config/store/selectors'
-import { uniqueByKey } from 'src/logic/addressBook/utils'
 
 const StyledButton = styled(Button)`
   &&.MuiButton-root {
@@ -217,9 +216,8 @@ const AddressBookTable = (): ReactElement => {
             label="Owners"
             size={addressBook?.length || 0}
           >
-            {(sortedData) => {
-              const sortedUniqueByAddress = uniqueByKey('address', sortedData)
-              return sortedUniqueByAddress.map((row, index) => {
+            {(sortedData) =>
+              sortedData.map((row, index) => {
                 const userOwner = isUserAnOwnerOfAnySafe(safesList, row.address)
                 const hideBorderBottom = index >= 3 && index === sortedData.size - 1 && classes.noBorderBottom
                 return (
@@ -301,7 +299,7 @@ const AddressBookTable = (): ReactElement => {
                   </TableRow>
                 )
               })
-            }}
+            }
           </Table>
         </TableContainer>
       </Block>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14345,6 +14345,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash.uniqwith@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz#7a0cbf65f43b5928625a9d4d0dc54b18cadc7ef3"
+  integrity sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM=
+
 lodash.unset@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.unset/-/lodash.unset-4.5.2.tgz#370d1d3e85b72a7e1b0cdf2d272121306f23e4ed"


### PR DESCRIPTION
## What it solves
Resolves #2965

## How this PR fixes it
On searching for an existing AB entry we compare now the addresses checksum.
Before updating the Redux store we filter out AB entries with same _address_ and _chainId_

## How to test it
On any conditions, exporting and importing your address book should not generate any duplicated entries in the "Address Book"

## Screenshots
<img width="902" alt="Screen Shot 2021-11-16 at 16 31 13" src="https://user-images.githubusercontent.com/32431609/142015213-a118954c-cb34-416b-bca3-d12e661c712d.png">

