### PR TITLE
Fix: update local safes in sidebar

### DIFF
--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -60,27 +60,31 @@ const SafeListItem = ({
   const safeRef = useRef<HTMLDivElement>(null)
   const nativeCoinSymbol = getNetworkConfigById(networkId)?.network?.nativeCoin?.symbol ?? 'ETH'
 
-  useEffect(() => {
-    if (isCurrentSafe && shouldScrollToSafe) {
-      safeRef?.current?.scrollIntoView({ behavior: 'smooth' })
-    }
-  }, [isCurrentSafe, shouldScrollToSafe])
-
-  const handleLoadSafe = (): void => {
-    onNetworkSwitch?.()
-    setNetwork(networkId)
-    onSafeClick()
-  }
-
   const routesSlug: SafeRouteParams = {
     shortName: getShortChainNameById(networkId),
     safeAddress: address,
   }
 
   const handleOpenSafe = (): void => {
-    handleLoadSafe()
+    onSafeClick()
+    onNetworkSwitch?.()
     history.push(generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, routesSlug))
   }
+
+  const handleLoadSafe = (): void => {
+    onSafeClick()
+    onNetworkSwitch?.()
+    history.push(generateSafeRoute(LOAD_SPECIFIC_SAFE_ROUTE, routesSlug))
+
+    // Navigating to LOAD_SPECIFIC_SAFE_ROUTE doesn't trigger a network switch
+    setNetwork(networkId)
+  }
+
+  useEffect(() => {
+    if (isCurrentSafe && shouldScrollToSafe) {
+      safeRef?.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [isCurrentSafe, shouldScrollToSafe])
 
   return (
     <ListItem button onClick={handleOpenSafe} ref={safeRef}>

--- a/src/logic/safe/hooks/useLocalSafes.tsx
+++ b/src/logic/safe/hooks/useLocalSafes.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { sortedSafeListSelector } from 'src/components/SafeListSidebar/selectors'
 
 import { ETHEREUM_NETWORK } from 'src/config/networks/network.d'
 import { SafeRecordWithNames } from '../store/selectors'
@@ -13,7 +15,10 @@ const getEmptyLocalSafes = (): LocalSafes => {
 
 const useLocalSafes = (): LocalSafes => {
   const [localSafes, setLocalSafes] = useState<LocalSafes>(() => getEmptyLocalSafes())
+  const addedSafes = useSelector(sortedSafeListSelector)
+  const addedAddresses = addedSafes.map(({ address }) => address).join()
 
+  // Reload added Safes from the localStorage when addedAddresses changes
   useEffect(() => {
     const getLocalSafes = () => {
       Object.values(ETHEREUM_NETWORK).forEach(async (id) => {
@@ -26,7 +31,7 @@ const useLocalSafes = (): LocalSafes => {
     }
 
     getLocalSafes()
-  }, [])
+  }, [addedAddresses])
 
   return localSafes
 }

--- a/src/logic/safe/utils/safeInformation.ts
+++ b/src/logic/safe/utils/safeInformation.ts
@@ -2,9 +2,6 @@ import { getSafeInfo as fetchSafeInfo, SafeInfo } from '@gnosis.pm/safe-react-ga
 
 import { Errors, CodedException } from 'src/logic/exceptions/CodedException'
 import { getClientGatewayUrl, getNetworkId } from 'src/config'
-import { sameAddress } from 'src/logic/wallets/ethAddresses'
-import { SafeRecordProps } from '../store/models/safe'
-import { SafeRecordWithNames } from '../store/selectors'
 
 const GATEWAY_ERROR = /1337|42/
 
@@ -16,6 +13,3 @@ export const getSafeInfo = async (safeAddress: string): Promise<SafeInfo> => {
     throw new CodedException(safeNotFound ? Errors._605 : Errors._613, e.message)
   }
 }
-
-export const isSafeAdded = (addedSafes: SafeRecordWithNames[] | SafeRecordProps[], address: string): boolean =>
-  addedSafes.some((safe: SafeRecordWithNames | SafeRecordProps) => sameAddress(safe.address, address))

--- a/src/routes/LoadSafePage/fields/utils.ts
+++ b/src/routes/LoadSafePage/fields/utils.ts
@@ -8,15 +8,12 @@ import {
 } from './loadFields'
 
 export function getLoadSafeName(formValues: LoadSafeFormValues, addressBook: AddressBookMap): string {
-  let safeAddress = formValues[FIELD_LOAD_SAFE_ADDRESS] || ''
-  try {
-    safeAddress = checksumAddress(safeAddress)
-  } catch (e) {
-    // ignore error
-  }
+  let safeAddress = formValues[FIELD_LOAD_SAFE_ADDRESS]
+  safeAddress = safeAddress ? checksumAddress(safeAddress) : ''
+
   return (
     formValues[FIELD_LOAD_CUSTOM_SAFE_NAME] ||
-    addressBook[safeAddress]?.name ||
+    (safeAddress ? addressBook[safeAddress]?.name : '') ||
     formValues[FIELD_LOAD_SUGGESTED_SAFE_NAME]
   )
 }

--- a/src/utils/storage/index.ts
+++ b/src/utils/storage/index.ts
@@ -1,12 +1,9 @@
-import { ImmortalStorage, IndexedDbStore, LocalStorageStore } from 'immortal-db'
+import { ImmortalStorage, LocalStorageStore } from 'immortal-db'
 
 import { getNetworkName } from 'src/config'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
-// Don't use sessionStorage and cookieStorage
-// https://github.com/gruns/ImmortalDB/issues/22
-// https://github.com/gruns/ImmortalDB/issues/6
-const stores = [IndexedDbStore, LocalStorageStore]
+const stores = [LocalStorageStore]
 export const storage = new ImmortalStorage(stores)
 
 // We need this to update on run time depending on selected network name


### PR DESCRIPTION
## What it solves
Resolves Franco's comment here: https://github.com/gnosis/safe-react/pull/3016#issuecomment-971557060

## How this PR fixes it
`addedSafes` and `localSafes` weren't in sync. Now we use only `localSafes` in the sidebar, but update it whenever the Safes store is updated.

## How to test it
Bug:
![11-17-2021_x(3423)](https://user-images.githubusercontent.com/4503659/142205435-20f52596-740e-4c21-9e69-ab3b2e0eacad.gif)
