### PR TITLE
Fix: don't crash on missing wallet icons

### DIFF
--- a/src/components/AppLayout/Header/components/WalletIcon/index.tsx
+++ b/src/components/AppLayout/Header/components/WalletIcon/index.tsx
@@ -23,14 +23,11 @@ interface WalletIconProps {
 
 const WalletIcon = ({ provider }: WalletIconProps): React.ReactElement => {
   const classes = useStyles()
+  const walletIcon = WALLET_ICONS[provider]
+
   return (
     <Col className={classes.container} start="sm">
-      <Img
-        alt={provider}
-        className={classes.icon}
-        height={WALLET_ICONS[provider].height}
-        src={WALLET_ICONS[provider].src}
-      />
+      {walletIcon && <Img alt={provider} className={classes.icon} {...walletIcon} />}
     </Col>
   )
 }


### PR DESCRIPTION
## What it solves
We see people using mystery wallets (the Detected Wallet in onboard?), and having the app crashed on accessing a missing icon.

## How this PR fixes it
Don't display any icon if connected to a mystery wallet. Chances are, this wallet might just work.