### PR TITLE
Fix: remove the redirect on failed safe load

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,7 +1,7 @@
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { SnackbarProvider } from 'notistack'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
 
 import AlertIcon from 'src/assets/icons/alert.svg'
@@ -26,6 +26,8 @@ import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
 import useAddressBookSync from 'src/logic/addressBook/hooks/useAddressBookSync'
 import { extractSafeAddress } from 'src/routes/routes'
+import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStorage'
+import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
 
 const notificationStyles = {
   success: {
@@ -61,6 +63,7 @@ const App: React.FC = ({ children }) => {
   const granted = useSelector(grantedSelector)
   const sidebarItems = useSidebarItems()
   const safeLoaded = useLoadSafe(addressFromUrl)
+  const dispatch = useDispatch()
   useSafeScheduledUpdates(safeLoaded, addressFromUrl)
   useAddressBookSync()
 
@@ -71,6 +74,13 @@ const App: React.FC = ({ children }) => {
 
   const onReceiveShow = () => onShow('Receive')
   const onReceiveHide = () => onHide('Receive')
+
+  // Load the Safes from LS just once,
+  // they'll be reloaded on network change
+  useEffect(() => {
+    dispatch(loadSafesFromStorage())
+    dispatch(loadCurrentSessionFromStorage())
+  }, [dispatch])
 
   return (
     <Frame>

--- a/src/components/StoreMigrator/utils.ts
+++ b/src/components/StoreMigrator/utils.ts
@@ -60,7 +60,7 @@ function parsePayload<T>(entry: string): T | null {
   try {
     return JSON.parse(entry) as T
   } catch (e) {
-    trackError(Errors._703, e.message)
+    trackError(Errors._703, `${e.message} – ${entry}`)
     return null
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,6 @@ import ReactDOM from 'react-dom'
 import * as Sentry from '@sentry/react'
 import { Integrations } from '@sentry/tracing'
 import Root from 'src/components/Root'
-import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
-import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStorage'
-import { store } from 'src/store'
 import { SENTRY_DSN } from './utils/constants'
 import { disableMMAutoRefreshWarning } from './utils/mm_warnings'
 import { switchNetworkWithUrl } from './utils/history'
@@ -18,9 +15,6 @@ if (typeof window !== 'undefined') {
 disableMMAutoRefreshWarning()
 
 BigNumber.set({ EXPONENTIAL_AT: [-7, 255] })
-
-store.dispatch(loadSafesFromStorage())
-store.dispatch(loadCurrentSessionFromStorage())
 
 Sentry.init({
   dsn: SENTRY_DSN,

--- a/src/logic/safe/hooks/useLoadSafe.tsx
+++ b/src/logic/safe/hooks/useLoadSafe.tsx
@@ -8,7 +8,6 @@ import fetchTransactions from 'src/logic/safe/store/actions/transactions/fetchTr
 import { Dispatch } from 'src/logic/safe/store/actions/types.d'
 import { updateAvailableCurrencies } from 'src/logic/currencyValues/store/actions/updateAvailableCurrencies'
 import { currentChainId } from 'src/logic/config/store/selectors'
-import { history, WELCOME_ROUTE } from 'src/routes/routes'
 
 export const useLoadSafe = (safeAddress?: string): boolean => {
   const dispatch = useDispatch<Dispatch>()
@@ -23,13 +22,7 @@ export const useLoadSafe = (safeAddress?: string): boolean => {
     const fetchData = async () => {
       if (safeAddress) {
         await dispatch(fetchLatestMasterContractVersion())
-        const isSuccess = await dispatch(fetchSafe(safeAddress, isSafeLoaded))
-
-        // Redirect to the Welcome page if the Safe wasn't found
-        if (!isSuccess) {
-          history.push(WELCOME_ROUTE)
-          return
-        }
+        await dispatch(fetchSafe(safeAddress, isSafeLoaded))
 
         setIsSafeLoaded(true)
         await dispatch(updateAvailableCurrencies())

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -74,7 +74,6 @@ export const fetchSafe =
       remoteSafeInfo = await getSafeInfo(address)
     } catch (err) {
       err.log()
-      return
     }
 
     // If the network has changed while the safe was being loaded,


### PR DESCRIPTION
## What it solves
Resolves #3023
Resolves #3030

## How this PR fixes it
Removes the redirect that [was added](https://github.com/gnosis/safe-react/pull/2977/files#diff-c7124f4a6d36f8d5ad9e166103fce3bc3c5eb3d40bd5b4ede8a443ceb58733c1R30) in #2977.

## How to test it
Open a Safe that doesn't exist. Observe an infinite loader.
