### PR TITLE
When cancelling the apps disclaimer goback instead showing assets

### DIFF
--- a/src/routes/safe/components/Apps/index.tsx
+++ b/src/routes/safe/components/Apps/index.tsx
@@ -1,10 +1,6 @@
 import { useHistory } from 'react-router-dom'
-import { useSelector } from 'react-redux'
 
 import { useSafeAppUrl } from 'src/logic/hooks/useSafeAppUrl'
-import { generateSafeRoute, SAFE_ROUTES } from 'src/routes/routes'
-import { getCurrentShortChainName } from 'src/config'
-import { currentSafe } from 'src/logic/safe/store/selectors'
 import AppFrame from 'src/routes/safe/components/Apps/components/AppFrame'
 import AppsList from 'src/routes/safe/components/Apps/components/AppsList'
 import LegalDisclaimer from 'src/routes/safe/components/Apps/components/LegalDisclaimer'
@@ -12,17 +8,15 @@ import { useLegalConsent } from 'src/routes/safe/components/Apps/hooks/useLegalC
 
 const Apps = (): React.ReactElement => {
   const history = useHistory()
-  const { address: safeAddress } = useSelector(currentSafe)
   const { getAppUrl } = useSafeAppUrl()
   const url = getAppUrl()
   const { consentReceived, onConsentReceipt } = useLegalConsent()
 
-  const redirectToBalance = () =>
-    history.push(generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, { shortName: getCurrentShortChainName(), safeAddress }))
+  const goBack = () => history.goBack()
 
   if (url) {
     if (!consentReceived) {
-      return <LegalDisclaimer onCancel={redirectToBalance} onConfirm={onConsentReceipt} />
+      return <LegalDisclaimer onCancel={goBack} onConfirm={onConsentReceipt} />
     }
 
     return <AppFrame appUrl={url} />


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/192

## How this PR fixes it
When showing the disclaimer and cancelling then user should be redirected to app list instead showing assets

## How to test it
1) Go to the app list in incognito or with storage initialized
2) Enter an app
3) Press `Cancel`buttons
4) Should redirect to the app list instead showing the safe assets
