### PR TITLE
Fix: ENS name recognition when switch the network

### DIFF
--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -103,7 +103,7 @@ export const getAddressFromDomain = (name: string): Promise<string> => {
   if (isValidCryptoDomainName(name)) {
     return getAddressFromUnstoppableDomain(name)
   }
-  return web3.eth.ens.getAddress(name)
+  return getWeb3ReadOnly().eth.ens.getAddress(name)
 }
 
 export const getContentFromENS = (name: string): Promise<ContentHash> => web3.eth.ens.getContenthash(name)


### PR DESCRIPTION
## What it solves
Resolves #3032

## How this PR fixes it

using `getWeb3ReadOnly().eth.ens.getAddress(name)` instead of ` web3.eth.ens.getAddress(name)` in the `getAddressFromDomain` function to refresh the `web3` object when the user switches the network

## How to test it

Go to [Load Existing Safe in Rinkeby](https://pr3034--safereact.review-safe.gnosisdev.com/app/load) flow and type `alice.eth` in the Safe Address input.
Rinkeby endpoint should be used: `https://rinkeby.infura.io/v3/{API_TOKEN}`

Switch to `Mainnet` network:
Type `alice.eth` in the Safe Address input.
Mainnet endpoint should be used: `https://mainnet.infura.io/v3/{API_TOKEN}`


## Screenshots

![Captura de pantalla 2021-11-22 a las 13 58 22](https://user-images.githubusercontent.com/26763673/142866166-8a660f98-f749-4c76-bea2-cec9461ca484.png)

![Captura de pantalla 2021-11-22 a las 14 01 21](https://user-images.githubusercontent.com/26763673/142866349-7110ba25-385b-46b7-808c-265595545bdf.png)

