### PR TITLE
PoC for transaction memo

### DIFF
--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -34,6 +34,7 @@ import { TextField } from '@material-ui/core'
 import { Transaction } from '@gnosis.pm/safe-apps-sdk-v1'
 import { ethers } from 'ethers'
 
+const SAFE_MEMO_REGISTRY_ADDRESS = '0x5aFE000000000000000000000000000000000001'
 const posterInterface = new ethers.utils.Interface(['function PublicTransactionMemo(string content) public'])
 
 const Container = styled.div`
@@ -95,7 +96,7 @@ export const ReviewConfirm = ({
     finalTxs.push(...txs)
     if (txComment.length > 0)
       finalTxs.push({
-        to: ethers.constants.AddressZero,
+        to: SAFE_MEMO_REGISTRY_ADDRESS,
         value: '0',
         data: posterInterface.encodeFunctionData('PublicTransactionMemo', [txComment]),
       })

--- a/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
@@ -16,6 +16,8 @@ type MultiSendTxGroupProps = {
   txDetails: {
     title: string
     address: string
+    name?: string | undefined
+    avatarUrl?: string | undefined
     dataDecoded: DataDecoded | null
   }
 }
@@ -28,7 +30,12 @@ const MultiSendTxGroup = ({ actionTitle, children, txDetails }: MultiSendTxGroup
       </AccordionSummary>
       <ColumnDisplayAccordionDetails>
         {!isSpendingLimitMethod(txDetails.dataDecoded?.method) && (
-          <TxInfoDetails title={txDetails.title} address={txDetails.address} />
+          <TxInfoDetails
+            title={txDetails.title}
+            address={txDetails.address}
+            name={txDetails.name}
+            avatarUrl={txDetails.avatarUrl}
+          />
         )}
         {children}
       </ColumnDisplayAccordionDetails>
@@ -66,11 +73,15 @@ export const MultiSendDetails = ({ txData }: { txData: TransactionData }): React
           details = data && <HexEncodedData title="Data (hex encoded)" hexData={data} />
         }
 
+        const addressInfo = txData.addressInfoIndex?.[to]
+        const name = addressInfo?.name || undefined
+        const avatarUrl = addressInfo?.logoUri || undefined
+
         return (
           <MultiSendTxGroup
             key={`${data ?? to}-${index}`}
             actionTitle={actionTitle}
-            txDetails={{ title, address: to, dataDecoded }}
+            txDetails={{ title, address: to, dataDecoded, name, avatarUrl }}
           >
             {details}
           </MultiSendTxGroup>


### PR DESCRIPTION
## What it solves
Allows to add a transaction memo when submitting a Safe App transaction

## How to test it
- Create transaction via Transaction Builder
- Add transaction note
- Check that note is present in queued transaction

## Screenshots
![image](https://user-images.githubusercontent.com/2896048/142886471-ebba12d2-82c5-4275-8775-eaa303c165b0.png)
![image](https://user-images.githubusercontent.com/2896048/142886552-613adc93-35fc-41eb-a89d-2b0f7dacf02f.png)
