### PR TITLE
Strip network prefix from the Address when calling EthHashInfo

### DIFF
--- a/src/components/PrefixedEthHashInfo/index.tsx
+++ b/src/components/PrefixedEthHashInfo/index.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 import { copyShortNameSelector, showShortNameSelector } from 'src/logic/appearance/selectors'
 import { extractShortChainName } from 'src/routes/routes'
+import getAddressWithoutNetworkPrefix from 'src/utils/getAddressWithoutNetworkPrefix'
 
 type Props = Omit<Parameters<typeof EthHashInfo>[0], 'shouldShowShortName' | 'shouldCopyShortName'>
 
@@ -12,7 +13,7 @@ const PrefixedEthHashInfo = ({ hash, ...rest }: Props): ReactElement => {
 
   return (
     <EthHashInfo
-      hash={hash}
+      hash={getAddressWithoutNetworkPrefix(hash)}
       shortName={extractShortChainName()}
       shouldShowShortName={showChainPrefix}
       shouldCopyShortName={copyChainPrefix}

--- a/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
@@ -5,7 +5,7 @@ import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { NOT_AVAILABLE } from './utils'
-import { PrefixedInlineEthHashInfo, TxDetailsContainer } from './styled'
+import { InlineEthHashInfo, TxDetailsContainer } from './styled'
 import { Creation } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useKnownAddress } from './hooks/useKnownAddress'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
@@ -34,7 +34,7 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
           <Text size="xl" strong as="span">
             Transaction hash:{' '}
           </Text>
-          <PrefixedInlineEthHashInfo
+          <InlineEthHashInfo
             textSize="xl"
             hash={txInfo.transactionHash}
             shortenHash={8}

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -5,7 +5,7 @@ import { ReactElement } from 'react'
 import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'
 import { ExpandedTxDetails, isMultiSigExecutionDetails } from 'src/logic/safe/store/models/types/gateway.d'
-import { PrefixedInlineEthHashInfo } from './styled'
+import { InlineEthHashInfo } from './styled'
 import { NOT_AVAILABLE } from './utils'
 
 export const TxSummary = ({ txDetails }: { txDetails: ExpandedTxDetails }): ReactElement => {
@@ -22,13 +22,7 @@ export const TxSummary = ({ txDetails }: { txDetails: ExpandedTxDetails }): Reac
           Transaction hash:{' '}
         </Text>
         {txHash ? (
-          <PrefixedInlineEthHashInfo
-            textSize="xl"
-            hash={txHash}
-            shortenHash={8}
-            showCopyBtn
-            explorerUrl={explorerUrl}
-          />
+          <InlineEthHashInfo textSize="xl" hash={txHash} shortenHash={8} showCopyBtn explorerUrl={explorerUrl} />
         ) : (
           <Text size="xl" as="span">
             {NOT_AVAILABLE}
@@ -40,7 +34,7 @@ export const TxSummary = ({ txDetails }: { txDetails: ExpandedTxDetails }): Reac
           <Text size="xl" strong as="span">
             SafeTxHash:{' '}
           </Text>
-          <PrefixedInlineEthHashInfo textSize="xl" hash={safeTxHash} shortenHash={8} showCopyBtn />
+          <InlineEthHashInfo textSize="xl" hash={safeTxHash} shortenHash={8} showCopyBtn />
         </div>
       )}
       {nonce !== undefined && (

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -1,6 +1,5 @@
-import { Text, Accordion, AccordionDetails, AccordionSummary } from '@gnosis.pm/safe-react-components'
+import { Text, Accordion, AccordionDetails, AccordionSummary, EthHashInfo } from '@gnosis.pm/safe-react-components'
 import styled, { css } from 'styled-components'
-import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 
 export const Wrapper = styled.div`
   display: flex;
@@ -467,7 +466,7 @@ export const OwnerListItem = styled.li`
   }
 `
 
-export const PrefixedInlineEthHashInfo = styled(PrefixedEthHashInfo)`
+export const InlineEthHashInfo = styled(EthHashInfo)`
   display: inline-flex;
 
   span {


### PR DESCRIPTION
## What it solves
https://github.com/gnosis/safe-react/pull/3015#issuecomment-975201921 (Bug when uploading a QR code containing a chain prefix in the "Send Collectibles")
Resolves #3036

## How this PR fixes it
- Pass the Address without prefix to `EthHashInfo` and let the appearance settings decide if prefix should be displayed
- Removes the chain prefix from "Transaction hash" and "SafeTxHash" fields in the Tx List

## How to test it
From https://github.com/gnosis/safe-react/pull/3015#issuecomment-975201921
<img width="819" alt="Screen Shot 2021-11-22 at 16 49 42" src="https://user-images.githubusercontent.com/32431609/142892319-b4062e8e-7071-4a6a-b9c0-bdb5767b2896.png">

## Screenshots
![Screen Shot 2021-11-22 at 16 52 39](https://user-images.githubusercontent.com/32431609/142892825-aeade04c-4dd3-4cae-93c9-eb5911b1e6e7.png)

