### PR TITLE
Add get chain info listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     ]
   },
   "dependencies": {
-    "@gnosis.pm/safe-apps-sdk": "4.3.0-next.2",
+    "@gnosis.pm/safe-apps-sdk": "6.1.0",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^0.3.1",
     "@gnosis.pm/safe-deployments": "^1.2.0",

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -242,7 +242,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
       openSignMessageModal(message, msg.data.id)
     })
 
-    communicator?.on(Methods.getChainInfo, () => {
+    communicator?.on(Methods.getChainInfo, async () => {
       const { nativeCoin } = getNetworkInfo()
       const chainId = parseInt(networkId, 10)
       const network = getNetworkName()

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -16,7 +16,13 @@ import { INTERFACE_MESSAGES, Transaction, LowercaseNetworks } from '@gnosis.pm/s
 import Web3 from 'web3'
 
 import { currentSafe } from 'src/logic/safe/store/selectors'
-import { getNetworkName, getSafeAppsRpcServiceUrl, getTxServiceUrl } from 'src/config'
+import {
+  getNetworkName,
+  getSafeAppsRpcServiceUrl,
+  getTxServiceUrl,
+  getShortChainNameById,
+  getNetworkInfo,
+} from 'src/config'
 import { isSameURL } from 'src/utils/url'
 import { useAnalytics, SAFE_EVENTS } from 'src/utils/googleAnalytics'
 import { LoadingContainer } from 'src/components/LoaderContainer/index'
@@ -234,6 +240,19 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
       const { message } = msg.data.params as SignMessageParams
 
       openSignMessageModal(message, msg.data.id)
+    })
+
+    communicator?.on(Methods.getChainInfo, () => {
+      const { nativeCoin } = getNetworkInfo()
+      const chainId = parseInt(networkId, 10)
+      const network = getNetworkName()
+
+      return {
+        chainName: network,
+        chainId,
+        shortName: getShortChainNameById(networkId),
+        nativeCurrency: nativeCoin,
+      }
     })
   }, [communicator, openConfirmationModal, safeAddress, owners, threshold, openSignMessageModal, networkId])
 

--- a/src/routes/safe/components/Apps/components/SignMessageModal/index.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/index.tsx
@@ -1,4 +1,4 @@
-import { RequestId, calculateMessageHash } from '@gnosis.pm/safe-apps-sdk'
+import { RequestId } from '@gnosis.pm/safe-apps-sdk'
 import { ReactElement } from 'react'
 
 import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
@@ -44,7 +44,7 @@ export const SignMessageModal = ({ message, isOpen, ...rest }: SignMessageModalP
   const web3 = getWeb3ReadOnly()
   const txRecipient = getSignMessageLibAddress(networkId) || ZERO_ADDRESS
   const txData = getSignMessageLibContractInstance(web3, networkId)
-    .methods.signMessage(calculateMessageHash(message))
+    .methods.signMessage(web3.eth.accounts.hashMessage(message))
     .encodeABI()
 
   const readableData = convertToHumanReadableMessage(message)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,13 +2127,14 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-3.0.0.tgz#0f90185c3693f2683322d275e796e61ff99ce87d"
   integrity sha512-dLCSlniYnxEqCglx4XdhByvi7KKuSYRWJKm1lVXAc4oJqwwVkoCwp0bFIejLZ/dnf7cQSBUUVsTGWhvSda511w==
 
-"@gnosis.pm/safe-apps-sdk@4.3.0-next.2":
-  version "4.3.0-next.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-4.3.0-next.2.tgz#90cd433c3183cee0f6cb4de5e5337e24f884caf6"
-  integrity sha512-1bNVRh2K5NP0sRj1URU4z6mF4chyeCGdr871yXqLLOv99zBrFQgDv8gBnSzva3hzth46YBb+zSAFGQHkmcpH0Q==
+"@gnosis.pm/safe-apps-sdk@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-6.1.0.tgz#b1b07504ed43d034e0b94c7fe274e908d62988a8"
+  integrity sha512-2NEd1CKoHTSkiQfdw8GJXtc/GfWogNHpRGeRmM2X1kvzlqIAheEhefM4BtyP/Nwo95/vvfwePi3ANuc6S6aUKQ==
   dependencies:
     "@changesets/cli" "^2.16.0"
-    ethers "^5.4.5"
+    "@gnosis.pm/safe-react-gateway-sdk" "^2.5.6"
+    ethers "^5.4.7"
 
 "@gnosis.pm/safe-core-sdk-types@^0.1.1":
   version "0.1.1"
@@ -2164,6 +2165,13 @@
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.5.0.tgz#11a27af6c9b173ed895d80c21527ad463b0b6604"
   integrity sha512-RwUTcya802N/J2AnZHQ6R7ffyOkHKvo6O31abVjJpps7/mh4taelwnMlsgqG8ebaux1R6fLLDu9oykWNAPvb3Q==
+  dependencies:
+    isomorphic-unfetch "^3.1.0"
+
+"@gnosis.pm/safe-react-gateway-sdk@^2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.5.6.tgz#7b8713bb16a542c4af27d6e1f2d8925a21aaeb51"
+  integrity sha512-flM/i80oFwSRlW0U8HE7QurwwPpNTUjBv7gZNAjgOpGhub51r7Uf1LtSm89Mnxnh2mtj4Whl8ZC4RMoXdV3yvw==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 
@@ -10210,7 +10218,7 @@ ethers@4.0.47:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5.0.13, ethers@^5.0.31, ethers@^5.4.5, ethers@^5.4.7:
+ethers@^5.0.13, ethers@^5.0.31, ethers@^5.4.7:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.1.tgz#d3259a95a42557844aa543906c537106c0406fbf"
   integrity sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/185

## How this PR fixes it
We are going to get the chain info from the apps using the SDK (https://github.com/gnosis/safe-apps-sdk/pull/258). So in this PR we are adding the listener for retrieving the required info

## How to test it
1) Open the Transaction Builder app in https://github.com/gnosis/safe-react-apps/pull/215 inside the Gnosis Safe Web
2) Add a contract
3) Check the labels showing the native token are showing the native one and not always ETH

