### PR TITLE
Fix: remove memoize on mustBeEthereumAddress

### DIFF
--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Field } from 'react-final-form'
 import { OnChange } from 'react-final-form-listeners'
 import InputAdornment from '@material-ui/core/InputAdornment'
@@ -53,11 +53,9 @@ const AddressInput = ({
     [validators],
   )
 
-  const allValidators = useCallback(
-    (val: string) => {
-      // Internal validators + externally passed validators
-      return composeValidators(required, mustBeEthereumAddress, sanitizedValidators)(val)
-    },
+  // Internal validators + externally passed validators
+  const allValidators = useMemo(
+    () => composeValidators(required, mustBeEthereumAddress, sanitizedValidators),
     [sanitizedValidators],
   )
 

--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -93,7 +93,7 @@ const mustHaveValidPrefix = (prefix: string): ValidatorReturnType => {
   }
 }
 
-export const mustBeEthereumAddress = memoize((fullAddress: string): ValidatorReturnType => {
+export const mustBeEthereumAddress = (fullAddress: string): ValidatorReturnType => {
   const errorMessage = 'Must be a valid address, ENS or Unstoppable domain'
   const { address, prefix } = parsePrefixedAddress(fullAddress)
 
@@ -105,7 +105,7 @@ export const mustBeEthereumAddress = memoize((fullAddress: string): ValidatorRet
     return errorMessage
   }
   return result
-})
+}
 
 export const mustBeEthereumContractAddress = memoize(async (fullAddress: string): Promise<ValidatorReturnType> => {
   const { address } = parsePrefixedAddress(fullAddress)


### PR DESCRIPTION
`mustBeEthereumAddress` is now checking also the prefix, so it shouldn't be memoized by the address alone. The same address can be valid on one network, but not valid on another.

So I just removed the memoization, it's completely useless. Who would enter the same address repeatedly?