### PR TITLE
Fix: always load Transactions on initial load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.15.4",
+  "version": "3.15.5",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/logic/safe/hooks/useLoadSafe.tsx
+++ b/src/logic/safe/hooks/useLoadSafe.tsx
@@ -17,7 +17,7 @@ export const useLoadSafe = (safeAddress?: string): void => {
     if (!safeAddress) return
 
     dispatch(fetchLatestMasterContractVersion())
-    dispatch(fetchSafe(safeAddress))
+    dispatch(fetchSafe(safeAddress, true))
     dispatch(fetchSafeTokens(safeAddress))
     dispatch(updateAvailableCurrencies())
     dispatch(addViewedSafe(safeAddress))

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -56,7 +56,7 @@ export const buildSafe = async (safeAddress: string): Promise<SafeRecordProps> =
  * @param {string} safeAddress
  */
 export const fetchSafe =
-  (safeAddress: string) =>
+  (safeAddress: string, isInitialLoad = false) =>
   async (dispatch: Dispatch<any>): Promise<Action<Partial<SafeRecordProps>> | void> => {
     let address = ''
     try {
@@ -94,11 +94,11 @@ export const fetchSafe =
       const shouldUpdateTxHistory = txHistoryTag !== safeInfo.txHistoryTag
       const shouldUpdateTxQueued = txQueuedTag !== safeInfo.txQueuedTag
 
-      if (shouldUpdateCollectibles) {
+      if (shouldUpdateCollectibles || isInitialLoad) {
         dispatch(fetchCollectibles(safeAddress))
       }
 
-      if (shouldUpdateTxHistory || shouldUpdateTxQueued) {
+      if (shouldUpdateTxHistory || shouldUpdateTxQueued || isInitialLoad) {
         dispatch(fetchTransactions(getNetworkId(), safeAddress))
       }
     }

--- a/src/logic/safe/store/actions/fetchSafe.ts
+++ b/src/logic/safe/store/actions/fetchSafe.ts
@@ -98,6 +98,8 @@ export const fetchSafe =
         dispatch(fetchCollectibles(safeAddress))
       }
 
+      console.log({ txHistoryTag }, safeInfo.txHistoryTag)
+
       if (shouldUpdateTxHistory || shouldUpdateTxQueued || isInitialLoad) {
         dispatch(fetchTransactions(getNetworkId(), safeAddress))
       }


### PR DESCRIPTION
## What it solves
Resolves a regression from #3086 – the tx history/queue sometimes weren't loaded on page load.

## How this PR fixes it
On initial Safe load, ignore the history/queue e-tags.

## How to test it
Reload the txns page.