### PR TITLE
Add token address in asset list

### DIFF
--- a/src/routes/safe/components/Balances/AssetTableCell/index.tsx
+++ b/src/routes/safe/components/Balances/AssetTableCell/index.tsx
@@ -1,21 +1,27 @@
 import { ReactElement } from 'react'
+import { ExplorerButton } from '@gnosis.pm/safe-react-components'
+import styled from 'styled-components'
 
 import Block from 'src/components/layout/Block'
 import Img from 'src/components/layout/Img'
 import Paragraph from 'src/components/layout/Paragraph'
 import { setImageToPlaceholder } from 'src/routes/safe/components/Balances/utils'
+import { getExplorerInfo } from 'src/config'
+import { BalanceData } from '../dataFetcher'
 
-const AssetTableCell = (props): ReactElement => {
-  const { asset } = props
+const StyledParagraph = styled(Paragraph)`
+  margin-left: 10px;
+  margin-right: 10px;
+`
 
-  return (
-    <Block justify="left">
-      <Img alt={asset.name} height={26} onError={setImageToPlaceholder} src={asset.logoUri} />
-      <Paragraph noMargin size="lg" style={{ marginLeft: 10 }}>
-        {asset.name}
-      </Paragraph>
-    </Block>
-  )
-}
+const AssetTableCell = ({ asset }: { asset: BalanceData['asset'] }): ReactElement => (
+  <Block justify="left">
+    <Img alt={asset.name} height={26} onError={setImageToPlaceholder} src={asset.logoUri} />
+    <StyledParagraph noMargin size="lg">
+      {asset.name}
+    </StyledParagraph>
+    <ExplorerButton explorerUrl={getExplorerInfo(asset.address)} />
+  </Block>
+)
 
 export default AssetTableCell


### PR DESCRIPTION
## What it solves
Resolves #2966

## How this PR fixes it
A button which opens Etherscan (or the relevant block explorer) to the token address was added next to the token name.

## How to test it
1. Open a safe with varying assets.
2. Click the button that opens the block explorer.
3. Verify that it is correct.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/144457145-99e1ecbe-d380-4987-9eb9-7e7fc38504d1.png)