### PR TITLE
Centralise transaction service selectors

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -100,8 +100,12 @@ export const getTokensServiceUrl = (): string => {
   return `${getTxServiceUrl()}/tokens`
 }
 
-export const getSafeServiceBaseUrl = (safeAddress: string): string => {
-  return `${getTxServiceUrl()}/safes/${safeAddress}`
+export const getMasterCopiesUrl = (): string => {
+  return `${getTxServiceUrl()}/about/master-copies/`
+}
+
+export const getDataDecoderUrl = (): string => {
+  return `${getTxServiceUrl()}/data-decoder/`
 }
 
 export const getDisabledWallets = (): ChainInfo['disabledWallets'] => {

--- a/src/logic/contracts/api/masterCopies.ts
+++ b/src/logic/contracts/api/masterCopies.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { getTxServiceUrl } from 'src/config'
+import { getMasterCopiesUrl } from 'src/config'
 import memoize from 'lodash/memoize'
 
 export enum MasterCopyDeployer {
@@ -35,9 +35,8 @@ const extractMasterCopyInfo = (mc: MasterCopyFetch): MasterCopy => {
 }
 
 export const fetchMasterCopies = memoize(async (): Promise<MasterCopy[] | undefined> => {
-  const url = `${getTxServiceUrl()}/about/master-copies/`
   try {
-    const res = await axios.get<{ address: string; version: string }[]>(url)
+    const res = await axios.get<{ address: string; version: string }[]>(getMasterCopiesUrl())
     return res.data.map(extractMasterCopyInfo)
   } catch (error) {
     console.error('Fetching data from master-copies errored', error)

--- a/src/logic/contracts/api/masterCopies.ts
+++ b/src/logic/contracts/api/masterCopies.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import { getMasterCopiesUrl } from 'src/config'
-import memoize from 'lodash/memoize'
 
 export enum MasterCopyDeployer {
   GNOSIS = 'Gnosis',
@@ -34,11 +33,11 @@ const extractMasterCopyInfo = (mc: MasterCopyFetch): MasterCopy => {
   return masterCopy
 }
 
-export const fetchMasterCopies = memoize(async (): Promise<MasterCopy[] | undefined> => {
+export const fetchMasterCopies = async (): Promise<MasterCopy[] | undefined> => {
   try {
     const res = await axios.get<{ address: string; version: string }[]>(getMasterCopiesUrl())
     return res.data.map(extractMasterCopyInfo)
   } catch (error) {
     console.error('Fetching data from master-copies errored', error)
   }
-})
+}

--- a/src/logic/tokens/store/actions/fetchTokens.ts
+++ b/src/logic/tokens/store/actions/fetchTokens.ts
@@ -1,7 +1,6 @@
 import ERC20Contract from '@openzeppelin/contracts/build/contracts/ERC20.json'
 import ERC721Contract from '@openzeppelin/contracts/build/contracts/ERC721.json'
 import { List } from 'immutable'
-import memoize from 'lodash/memoize'
 import { AnyAction } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 import { AbiItem } from 'web3-utils'
@@ -27,9 +26,9 @@ const createERC721TokenContract = (tokenAddress: string): ERC721 => {
   return new web3.eth.Contract(ERC721Contract.abi as AbiItem[], tokenAddress) as unknown as ERC721
 }
 
-export const getERC20TokenContract = memoize(createERC20TokenContract)
+export const getERC20TokenContract = createERC20TokenContract
 
-export const getERC721TokenContract = memoize(createERC721TokenContract)
+export const getERC721TokenContract = createERC721TokenContract
 
 export const containsMethodByHash = async (contractAddress: string, methodHash: string): Promise<boolean> => {
   const web3 = getWeb3()

--- a/src/utils/decodeTx.ts
+++ b/src/utils/decodeTx.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { getTxServiceUrl } from 'src/config'
+import { getDataDecoderUrl } from 'src/config'
 import { DecodedData } from 'src/types/transactions/decode.d'
 
 export const fetchTxDecoder = async (txData: string): Promise<DecodedData | null> => {
@@ -8,9 +8,8 @@ export const fetchTxDecoder = async (txData: string): Promise<DecodedData | null
     return null
   }
 
-  const url = `${getTxServiceUrl()}/data-decoder/`
   try {
-    const res = await axios.post<DecodedData>(url, { data: txData })
+    const res = await axios.post<DecodedData>(getDataDecoderUrl(), { data: txData })
     return res.data
   } catch (error) {
     return null


### PR DESCRIPTION
## How this PR fixes it
There was a redundant selector for interacting with the transaction service, as well as dynamic URL creation dotted around the project.

The redudant safe info request URL has been removed. The other URL creation 'selectors' have been moved to the config file.

## How to test it
1. The master copies selector is used in the 'Safe Details' settings section to show the contract version. If it is visible, it works.
2. The decode data selector is used in the 'Review Confirm' fund sending modal. If the decoded transactions are visible, it works.