### PR TITLE
Add nested delegate call warnings

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/DelegateCallWarning.tsx
+++ b/src/routes/safe/components/Transactions/TxList/DelegateCallWarning.tsx
@@ -1,0 +1,19 @@
+import { Text } from '@gnosis.pm/safe-react-components'
+import { ReactElement } from 'react'
+
+const DelegateCallWarning = ({ isKnown }: { isKnown: boolean }): ReactElement => {
+  if (!isKnown) {
+    return (
+      <Text size="xl" strong as="span" color="error">
+        ⚠️ Unexpected Delegate Call
+      </Text>
+    )
+  }
+  return (
+    <Text size="xl" strong as="span">
+      Delegate Call
+    </Text>
+  )
+}
+
+export default DelegateCallWarning

--- a/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
@@ -1,9 +1,10 @@
-import { AccordionSummary, IconText, Text } from '@gnosis.pm/safe-react-components'
+import { AccordionSummary, IconText } from '@gnosis.pm/safe-react-components'
 import { DataDecoded, Operation, TransactionData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement, ReactNode } from 'react'
 
 import { getNativeCurrency } from 'src/config'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
+import DelegateCallWarning from './DelegateCallWarning'
 import { HexEncodedData } from './HexEncodedData'
 import { MethodDetails } from './MethodDetails'
 import { isSpendingLimitMethod } from './SpendingLimitDetails'
@@ -25,25 +26,13 @@ type MultiSendTxGroupProps = {
 
 const MultiSendTxGroup = ({ actionTitle, children, txDetails }: MultiSendTxGroupProps): ReactElement => {
   const isDelegateCall = txDetails.operation === Operation.DELEGATE
-  const isKnownAddress = !!txDetails.name
-
-  const delegateCallDetails = isKnownAddress ? (
-    <Text size="xl" strong as="span">
-      Delegate Call
-    </Text>
-  ) : (
-    <Text size="xl" strong as="span" color="error">
-      ⚠️ Unexpected Delegate Call
-    </Text>
-  )
-
   return (
     <ActionAccordion>
       <AccordionSummary>
         <IconText iconSize="sm" iconType="code" text={actionTitle} textSize="xl" />
       </AccordionSummary>
       <ColumnDisplayAccordionDetails>
-        {isDelegateCall && delegateCallDetails}
+        {isDelegateCall && <DelegateCallWarning isKnown={!!txDetails.name} />}
         {!isSpendingLimitMethod(txDetails.dataDecoded?.method) && (
           <TxInfoDetails
             title={txDetails.title}

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -15,6 +15,7 @@ import { NOT_AVAILABLE } from './utils'
 import TxShareButton from './TxShareButton'
 import { IS_PRODUCTION } from 'src/utils/constants'
 import TxInfoMultiSend from './TxInfoMultiSend'
+import DelegateCallWarning from './DelegateCallWarning'
 
 type Props = { txDetails: ExpandedTxDetails }
 
@@ -82,15 +83,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
       </div>
       {txData?.operation === Operation.DELEGATE && (
         <div className="tx-operation">
-          {isCustomTxInfo(txInfo) && !!txInfo?.to?.name ? (
-            <Text size="xl" strong as="span">
-              Delegate Call
-            </Text>
-          ) : (
-            <Text size="xl" strong as="span" color="error">
-              ⚠️ Unexpected Delegate Call
-            </Text>
-          )}
+          <DelegateCallWarning isKnown={isCustomTxInfo(txInfo) && !!txInfo?.to?.name} />
         </div>
       )}
       {isMultiSendTxInfo(txInfo) && (

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -86,11 +86,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
           <DelegateCallWarning isKnown={isCustomTxInfo(txInfo) && !!txInfo?.to?.name} />
         </div>
       )}
-      {isMultiSendTxInfo(txInfo) && (
-        <div className="tx-ms-contract">
-          <TxInfoMultiSend txInfo={txInfo} />
-        </div>
-      )}
+      {isMultiSendTxInfo(txInfo) && <TxInfoMultiSend txInfo={txInfo} />}
     </>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -387,10 +387,6 @@ export const TxDetailsContainer = styled.div`
     }
   }
 
-  .tx-ms-contract {
-    padding-top: 40px;
-  }
-
   .tx-details-actions {
     align-items: center;
     display: flex;


### PR DESCRIPTION
## What it solves
Resolves #3115

## How this PR fixes it
Nested delegate calls now display that they are a) a delegate call and b) (un-)expected. They also, like #3091, base their legitimacy on whether the address is known or not.

An unexpected, nested delegate call can be found [here](https://pr3122--safereact.review-safe.gnosisdev.com/app/rin:0x73a7AA145338587f7aB7f63c06d187C85dF4727e/transactions/multisig_0x73a7AA145338587f7aB7f63c06d187C85dF4727e_0xba28109747222d6cfb7f0fb75f03d49957e343674bc116162b038e244dbcc6d6).

## How to test it

The linked example transaction can be used as a PoC for this new warning.

In order to create another, it needs to be done via a script. You would have to use node.js or propose a transaction.

## Screenshots
(The following "parent" delegate calls are "unexpected" because our MultiSend contract is not a known address on Rinkeby.)

![image](https://user-images.githubusercontent.com/20442784/144873659-f173fb3a-0007-4d32-93db-e6f0145bb9f5.png)

The known address name was set manually here in order to trigger the warning:
![image](https://user-images.githubusercontent.com/20442784/144873512-3a5c605f-003c-431e-855c-a8c259d5eccc.png)