### PR TITLE
Upgrade safe-deployments 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@gnosis.pm/safe-apps-sdk": "6.1.0",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^0.3.1",
-    "@gnosis.pm/safe-deployments": "^1.2.0",
+    "@gnosis.pm/safe-deployments": "^1.5.0",
     "@gnosis.pm/safe-react-components": "^0.9.0",
     "@gnosis.pm/safe-react-gateway-sdk": "^2.5.7",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2149,10 +2149,10 @@
     "@gnosis.pm/safe-core-sdk-types" "^0.1.1"
     ethereumjs-util "^7.0.10"
 
-"@gnosis.pm/safe-deployments@^1.2.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.4.0.tgz#d49d3d36cc014ef62306d09c0f4761895a17d7a6"
-  integrity sha512-q4salJNQ/Gx0DnZJytAFO/U4OwGI6xTGtTJSOZK+C9Fh2NW8sep+YfSunHQvCLcu4b7WgWEBhxnCV6rpyveLHg==
+"@gnosis.pm/safe-deployments@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.5.0.tgz#5e01ccc2e2d78bf91ecb4453a64d1cac3a5ba2d6"
+  integrity sha512-IDU7I+IQr1zUU94/uD8shDVI+/nUA1unQUg8jtbTG0YGcmm49Lu8G01rqtWt2mhLxZWzFsgbLWGnU+/BzUqk7g==
 
 "@gnosis.pm/safe-react-components@^0.9.0":
   version "0.9.0"


### PR DESCRIPTION
## What it solves
The interface was using an older version (0xa25b3579a295be016de5eb5F082b54B12d45F72C) of `safe-deployments`, it doesn't have any drawbacks but this version was meant to be used. The reason for that is that we forgot to release safe-deployments with the updated address (0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2). 

## How this PR fixes it
By updating `safe-deployments` to version `1.5.0` that uses the new address

## How to test it
connect the safe to https://example.walletconnect.org/ and click use `eth_sign` button, the transaction pop up should call `0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2`

<img width="526" alt="Screenshot 2021-12-06 at 17 38 55" src="https://user-images.githubusercontent.com/16622558/144885702-d0fb8c45-e486-4e83-9769-cf35678815d7.png">