### PR TITLE
Expand nested, unexpected delegate calls by default

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
@@ -26,13 +26,14 @@ type MultiSendTxGroupProps = {
 
 const MultiSendTxGroup = ({ actionTitle, children, txDetails }: MultiSendTxGroupProps): ReactElement => {
   const isDelegateCall = txDetails.operation === Operation.DELEGATE
+  const isKnown = !!txDetails.name
   return (
-    <ActionAccordion>
+    <ActionAccordion defaultExpanded={(isDelegateCall && !isKnown) || undefined}>
       <AccordionSummary>
         <IconText iconSize="sm" iconType="code" text={actionTitle} textSize="xl" />
       </AccordionSummary>
       <ColumnDisplayAccordionDetails>
-        {isDelegateCall && <DelegateCallWarning isKnown={!!txDetails.name} />}
+        {isDelegateCall && <DelegateCallWarning isKnown={isKnown} />}
         {!isSpendingLimitMethod(txDetails.dataDecoded?.method) && (
           <TxInfoDetails
             title={txDetails.title}


### PR DESCRIPTION
## What it solves
Resolves #3115

## How this PR fixes it
Unexpected delegate calls from nested transactions automatically expand their relevant multisend transaction by default.

## How to test it
- When viewing transaction 1 in the list [here](https://pr3143--safereact.review-safe.gnosisdev.com/app/rin:0x73a7AA145338587f7aB7f63c06d187C85dF4727e/transactions/multisig_0x73a7AA145338587f7aB7f63c06d187C85dF4727e_0xba28109747222d6cfb7f0fb75f03d49957e343674bc116162b038e244dbcc6d6), Action 3 (an unexpected delegate call) should be automatically expanded.
- Viewing it via deeplink [here](https://pr3143--safereact.review-safe.gnosisdev.com/app/rin:0x73a7AA145338587f7aB7f63c06d187C85dF4727e/transactions) should also automatically expand it.

## Screenshots
Transaction list:
![image](https://user-images.githubusercontent.com/20442784/145221670-d8b38094-cbd1-4107-9727-b49ac294fbc4.png)

Deeplink:
![image](https://user-images.githubusercontent.com/20442784/145221719-9362bc1a-4654-46ba-a22e-4d01a1c93690.png)