### PR TITLE
Fix: show AddressInput ENS resolution for existing AB entries

### DIFF
--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -53,10 +53,13 @@ const AddressInput = ({
     [validators],
   )
 
+  // Default validators
+  const internalValidators = useMemo(() => composeValidators(required, mustBeEthereumAddress), [])
+
   // Internal validators + externally passed validators
   const allValidators = useMemo(
-    () => composeValidators(required, mustBeEthereumAddress, sanitizedValidators),
-    [sanitizedValidators],
+    () => composeValidators(internalValidators, sanitizedValidators),
+    [internalValidators, sanitizedValidators],
   )
 
   const onValueChange = useCallback(
@@ -80,7 +83,7 @@ const AddressInput = ({
           })
       } else {
         // A regular address hash
-        if (!allValidators(address)) {
+        if (!internalValidators(address)) {
           const parsed = parsePrefixedAddress(address)
           const checkedAddress = checksumAddress(parsed.address) || parsed.address
 
@@ -89,7 +92,7 @@ const AddressInput = ({
         }
       }
     },
-    [setCurrentInput, setResolutions, allValidators, fieldMutator],
+    [setCurrentInput, setResolutions, internalValidators, fieldMutator],
   )
 
   useEffect(() => {

--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -53,13 +53,10 @@ const AddressInput = ({
     [validators],
   )
 
-  // Default validators
-  const internalValidators = useMemo(() => composeValidators(required, mustBeEthereumAddress), [])
-
   // Internal validators + externally passed validators
   const allValidators = useMemo(
-    () => composeValidators(internalValidators, sanitizedValidators),
-    [internalValidators, sanitizedValidators],
+    () => composeValidators(required, mustBeEthereumAddress, sanitizedValidators),
+    [sanitizedValidators],
   )
 
   const onValueChange = useCallback(
@@ -83,7 +80,7 @@ const AddressInput = ({
           })
       } else {
         // A regular address hash
-        if (!internalValidators(address)) {
+        if (!mustBeEthereumAddress(address)) {
           const parsed = parsePrefixedAddress(address)
           const checkedAddress = checksumAddress(parsed.address) || parsed.address
 
@@ -92,7 +89,7 @@ const AddressInput = ({
         }
       }
     },
-    [setCurrentInput, setResolutions, internalValidators, fieldMutator],
+    [setCurrentInput, setResolutions, fieldMutator],
   )
 
   useEffect(() => {


### PR DESCRIPTION
## What it solves
Resolves #3131

## How this PR fixes it
The resolved ENS address that was already in the AB wasn't displayed because we're not mutating the input value unless the new value is validated.

I've changed this condition to only check the value against the pre-mutation validators.

## How to test it
* Create an AB entry with alice.eth as the address
* Try to create another entry with the same alice.eth domain
* It should show the resolved address but not let you add the duplicate entry

## Screenshot
<img width="555" alt="Screenshot 2021-12-08 at 17 34 43" src="https://user-images.githubusercontent.com/381895/145246740-8546fbc1-5e1a-4558-97b8-a678ae4061ed.png">