### PR TITLE
Fix: deep-linked tx – use current timestamp as fallback

### DIFF
--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -31,13 +31,11 @@ import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionPara
 import { isTxPendingError } from 'src/logic/wallets/getWeb3'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { currentChainId } from 'src/logic/config/store/selectors'
-import { extractShortChainName, generateSafeRoute, history, SAFE_ROUTES } from 'src/routes/routes'
+import { extractShortChainName, history, SAFE_ROUTES } from 'src/routes/routes'
 import { getPrefixedSafeAddressSlug, SAFE_ADDRESS_SLUG, TRANSACTION_ID_SLUG } from 'src/routes/routes'
 import { generatePath } from 'react-router-dom'
 import { getContractErrorMessage } from 'src/logic/contracts/safeContractErrors'
 import { getLastTransaction, getLastTxNonce } from '../selectors/gatewayTransactions'
-import { getShortName } from 'src/config'
-import { IS_PRODUCTION } from 'src/utils/constants'
 
 export interface CreateTransactionArgs {
   navigateToTransactionsTab?: boolean
@@ -71,19 +69,7 @@ const navigateToTx = (safeAddress: string, txId: string) => {
     [TRANSACTION_ID_SLUG]: txId,
   })
 
-  // TODO: uncomment once we fix deep linking bugs
-  // history.push(txRoute)
-
-  if (!IS_PRODUCTION) {
-    console.info('Created transaction', txRoute)
-  }
-
-  history.push(
-    generateSafeRoute(SAFE_ROUTES.TRANSACTIONS_QUEUE, {
-      shortName: getShortName(),
-      safeAddress,
-    }),
-  )
+  history.push(txRoute)
 }
 
 export const createTransaction =

--- a/src/routes/safe/components/Transactions/TxList/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/utils.ts
@@ -163,7 +163,7 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
     : getMultisigExecutionInfo(txDetails)
 
   // Will only be used as a fallback whilst waiting on backend tx creation cache
-  const now = new Date().getTime()
+  const now = Date.now()
   const timestamp = isTxQueued(txDetails.txStatus)
     ? isMultiSigExecutionDetails(txDetails.detailedExecutionInfo)
       ? txDetails.detailedExecutionInfo.submittedAt

--- a/src/routes/safe/components/Transactions/TxList/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/utils.ts
@@ -162,11 +162,13 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
     ? txDetails.detailedExecutionInfo
     : getMultisigExecutionInfo(txDetails)
 
+  // Will only be used as a fallback whilst waiting on backend tx creation cache
+  const now = new Date().getTime()
   const timestamp = isTxQueued(txDetails.txStatus)
     ? isMultiSigExecutionDetails(txDetails.detailedExecutionInfo)
       ? txDetails.detailedExecutionInfo.submittedAt
-      : 0
-    : txDetails.executedAt || 0
+      : now
+    : txDetails.executedAt || now
 
   const tx: Transaction = {
     id: txDetails.txId,


### PR DESCRIPTION
## What it solves
Resolves #3069

## How this PR fixes it
Navigation to deeplinked transaction after transaction creation was enabled because the error was occurring with this feature. When a deeplinked transaction is opened, and hence loaded from backend via it's `txId`, the custom frontend-only `Transaction` typed object is created.

After the immediate creation of a transaction, the fetched transaction may lack a `timestamp`. As such, the fallback value was changed from `0` to the current timestamp because the transaction was effectively created 'now'. Later polls for transactions will overwrite this with the exact timestamp that is eventually fetched.

## How to test it
1. Create a transaction, adding it to the queue.
2. Reject said transaction and await for rejection execution.
3. The transaction details date label and/or list position should now be correct: today.