### PR TITLE
Allow non-owners to execute confirmed (rejection) transactions

### DIFF
--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -220,7 +220,7 @@ export const processTransaction =
         }),
       )
 
-      const executeData = safeInstance.methods.approveHash(txHash).encodeABI()
+      const executeData = safeInstance.methods.approveHash(txHash || '').encodeABI()
       const contractErrorMessage = await getContractErrorMessage({
         safeInstance,
         from,

--- a/src/logic/safe/utils/aboutToExecuteTx.ts
+++ b/src/logic/safe/utils/aboutToExecuteTx.ts
@@ -4,7 +4,6 @@ import { getNotificationsFromTxType } from 'src/logic/notifications'
 import { isStatusFailed, isTransactionSummary } from 'src/logic/safe/store/models/types/gateway.d'
 import { HistoryPayload } from 'src/logic/safe/store/reducer/gatewayTransactions'
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
-import { isUserAnOwner } from 'src/logic/wallets/ethAddresses'
 import { SafesMap } from 'src/logic/safe/store/reducer/types/safe'
 import { Notification } from 'src/logic/notifications/notificationTypes'
 
@@ -22,7 +21,7 @@ export const getNotification = (
   const currentSafe = safes.get(safeAddress)
 
   // no notification if not in the current safe or if its not an owner
-  if (!currentSafe || !isUserAnOwner(currentSafe, userAddress)) {
+  if (!currentSafe) {
     return
   }
 

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
@@ -15,7 +15,6 @@ import { formatDateTime, formatTime, formatTimeInWords } from 'src/utils/date'
 import { KNOWN_MODULES } from 'src/utils/constants'
 import { sameString } from 'src/utils/strings'
 import { AssetInfo, isTokenTransferAsset } from './hooks/useAssetInfo'
-import { TransactionActions } from './hooks/useTransactionActions'
 import { TransactionStatusProps } from './hooks/useTransactionStatus'
 import { TxTypeProps } from './hooks/useTransactionType'
 import { StyledGroupedTransactions, StyledTransaction } from './styled'
@@ -99,7 +98,6 @@ type TxCollapsedProps = {
   info?: AssetInfo
   time: number
   votes?: CalculatedVotes
-  actions?: TransactionActions
   status: TransactionStatusProps
 }
 
@@ -111,7 +109,6 @@ export const TxCollapsed = ({
   info,
   time,
   votes,
-  actions,
   status,
 }: TxCollapsedProps): ReactElement => {
   const { txLocation } = useContext(TxLocationContext)
@@ -169,7 +166,7 @@ export const TxCollapsed = ({
 
   const txCollapsedActions = (
     <div className={'tx-actions' + willBeReplaced}>
-      {actions?.isUserAnOwner && transaction && <TxCollapsedActions transaction={transaction} />}
+      {transaction && <TxCollapsedActions transaction={transaction} />}
     </div>
   )
 

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -11,7 +11,6 @@ import {
   isTransferTxInfo,
   Transaction,
 } from 'src/logic/safe/store/models/types/gateway.d'
-import { TransactionActions } from './hooks/useTransactionActions'
 import { useTransactionDetails } from './hooks/useTransactionDetails'
 import { TxDetailsContainer, Centered, AlignItemsWithMargin } from './styled'
 import { TxData } from './TxData'
@@ -79,10 +78,9 @@ const TxDataGroup = ({ txDetails }: { txDetails: ExpandedTxDetails }): ReactElem
 
 type TxDetailsProps = {
   transaction: Transaction
-  actions?: TransactionActions
 }
 
-export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElement => {
+export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
   const { txLocation } = useContext(TxLocationContext)
   const { data, loading } = useTransactionDetails(transaction.id)
 
@@ -120,13 +118,12 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
       </div>
       <div
         className={cn('tx-owners', {
-          'no-owner': txLocation !== 'history' && !actions?.isUserAnOwner,
           'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED',
         })}
       >
         <TxOwners txDetails={data} />
       </div>
-      {!data.executedAt && txLocation !== 'history' && actions?.isUserAnOwner && (
+      {!data.executedAt && txLocation !== 'history' && (
         <div className={cn('tx-details-actions', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}>
           <TxExpandedActions transaction={transaction} />
         </div>

--- a/src/routes/safe/components/Transactions/TxList/TxQueueCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxQueueCollapsed.tsx
@@ -3,7 +3,6 @@ import { ReactElement } from 'react'
 
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { useAssetInfo } from './hooks/useAssetInfo'
-import { TransactionActions } from './hooks/useTransactionActions'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useTransactionType } from './hooks/useTransactionType'
 import { TxCollapsed } from './TxCollapsed'
@@ -28,10 +27,9 @@ const calculateVotes = (executionInfo: MultisigExecutionInfo): CalculatedVotes |
 type TxQueuedCollapsedProps = {
   isGrouped?: boolean
   transaction: Transaction
-  actions?: TransactionActions
 }
 
-export const TxQueueCollapsed = ({ isGrouped = false, transaction, actions }: TxQueuedCollapsedProps): ReactElement => {
+export const TxQueueCollapsed = ({ isGrouped = false, transaction }: TxQueuedCollapsedProps): ReactElement => {
   const executionInfo = transaction.executionInfo as MultisigExecutionInfo
   const nonce = executionInfo?.nonce
   const type = useTransactionType(transaction)
@@ -48,7 +46,6 @@ export const TxQueueCollapsed = ({ isGrouped = false, transaction, actions }: Tx
       info={info}
       time={transaction.timestamp}
       votes={votes}
-      actions={actions}
       status={status}
     />
   )

--- a/src/routes/safe/components/Transactions/TxList/TxQueueRow.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxQueueRow.tsx
@@ -3,7 +3,6 @@ import { TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement, useContext, useEffect, useState } from 'react'
 
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
-import { useTransactionActions } from 'src/routes/safe/components/Transactions/TxList/hooks/useTransactionActions'
 import { NoPaddingAccordion, StyledAccordionSummary } from './styled'
 import { TxDetails } from './TxDetails'
 import { TxHoverContext } from './TxHoverProvider'
@@ -16,7 +15,6 @@ type TxQueueRowProps = {
 
 export const TxQueueRow = ({ isGrouped = false, transaction }: TxQueueRowProps): ReactElement => {
   const { activeHover } = useContext(TxHoverContext)
-  const actions = useTransactionActions(transaction)
   const [tx, setTx] = useState<Transaction>(transaction)
 
   useEffect(() => {
@@ -37,10 +35,10 @@ export const TxQueueRow = ({ isGrouped = false, transaction }: TxQueueRowProps):
       }}
     >
       <StyledAccordionSummary>
-        <TxQueueCollapsed isGrouped={isGrouped} transaction={tx} actions={actions} />
+        <TxQueueCollapsed isGrouped={isGrouped} transaction={tx} />
       </StyledAccordionSummary>
       <AccordionDetails>
-        <TxDetails transaction={tx} actions={actions} />
+        <TxDetails transaction={tx} />
       </AccordionDetails>
     </NoPaddingAccordion>
   )

--- a/src/routes/safe/components/Transactions/TxList/hooks/useTransactionActions.ts
+++ b/src/routes/safe/components/Transactions/TxList/hooks/useTransactionActions.ts
@@ -33,7 +33,8 @@ export const useTransactionActions = (transaction: Transaction): TransactionActi
   const transactionsByNonce = useSelector((state: AppReduxState) =>
     getTransactionsByNonce(state, (transaction.executionInfo as MultisigExecutionInfo)?.nonce ?? -1),
   )
-  const canCancel = !transactionsByNonce.some(({ txInfo }) => isCustomTxInfo(txInfo) && txInfo.isCancellation)
+  const canCancel =
+    !transactionsByNonce.some(({ txInfo }) => isCustomTxInfo(txInfo) && txInfo.isCancellation) && isUserAnOwner
 
   const [state, setState] = useState<TransactionActions>({
     canConfirm: false,
@@ -45,22 +46,17 @@ export const useTransactionActions = (transaction: Transaction): TransactionActi
   })
 
   useEffect(() => {
-    if (
-      isUserAnOwner &&
-      txLocation !== 'history' &&
-      isMultisigExecutionInfo(transaction.executionInfo) &&
-      transaction.executionInfo
-    ) {
+    if (txLocation !== 'history' && isMultisigExecutionInfo(transaction.executionInfo) && transaction.executionInfo) {
       const { missingSigners, confirmationsSubmitted = 0, confirmationsRequired = 0 } = transaction.executionInfo || {}
 
       const currentUserSigned = !missingSigners?.some((missingSigner) => sameAddress(missingSigner.value, currentUser))
-      const oneToGo = confirmationsSubmitted === confirmationsRequired - 1
-      const canConfirm = ['queued.next', 'queued.queued'].includes(txLocation) && !currentUserSigned
+      const oneToGo = confirmationsSubmitted === confirmationsRequired - 1 && isUserAnOwner
+      const canConfirm = ['queued.next', 'queued.queued'].includes(txLocation) && !currentUserSigned && isUserAnOwner
       const thresholdReached = confirmationsSubmitted >= confirmationsRequired
 
       setState({
         canConfirm,
-        canConfirmThenExecute: txLocation === 'queued.next' && canConfirm && oneToGo,
+        canConfirmThenExecute: txLocation === 'queued.next' && canConfirm && oneToGo && isUserAnOwner,
         canExecute: txLocation === 'queued.next' && thresholdReached,
         canCancel,
         isUserAnOwner,

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -381,10 +381,6 @@ export const TxDetailsContainer = styled.div`
     grid-column-start: 2;
     grid-row-end: span 2;
     grid-row-start: 1;
-
-    &.no-owner {
-      grid-row-end: span 3;
-    }
   }
 
   .tx-details-actions {


### PR DESCRIPTION
## What it solves
Resolves #1811

## How this PR fixes it
Transactions with sufficient confirmations are now executable by non-owners.

The `canExecute` action flag was modified to not require `isUserAnOwner`. All instances of the `isUserAnOwner` were remove, where logical. Associated styling was updated and unnecessary props removed.

Note: a bug within `processTransaction()` was fixed by including a fallback for `txHash` when an error occurs.

## How to test it
1. Create a transaction on a safe that has a threshold higher than 1.
2. Confirm said transaction in order to reach the treshold, but do not execute the transaction.
3. Open the transaction under an account that is not an owner of the Safe. It should be possible to execute the transaction without error.

The above is also possible with rejection transactions (see below).

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/145372599-f3f526cc-bd93-4994-a637-9700497171a0.png)