### PR TITLE
Add Spending Limit reset periods

### DIFF
--- a/src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/FormFields/ResetTime.tsx
@@ -82,10 +82,17 @@ const ResetTimeOptions = styled.div`
   grid-area: resetTimeOption;
 `
 
+const resetDays = (days: number): string => {
+  const minutes = days * 24 * 60
+  return minutes.toString()
+}
+
 const RESET_TIME_OPTIONS = [
-  { label: '1 day', value: '1440' }, // 1 day x 24h x 60min
-  { label: '1 week', value: '10080' }, // 7 days x 24h x 60min
-  { label: '1 month', value: '43200' }, // 30 days x 24h x 60min
+  { label: '1 day', value: resetDays(1) },
+  { label: '1 week', value: resetDays(7) },
+  { label: '1 month', value: resetDays(30) },
+  { label: '1 quarter', value: resetDays(90) },
+  { label: '1 year', value: resetDays(365) },
 ]
 
 const RINKEBY_RESET_TIME_OPTIONS = [


### PR DESCRIPTION
## What it solves
Resolves #3119

## How this PR fixes it
Two extra Spending Limit reset periods have been added: one quarter (90 days) and one year (365 days) in accordance with the suggestion from @A2be.

Note: if we want to allow for fine-grained control in the future, I would suggest keeping this issue in the backlog. We would likely have to install a datepicker (in my experience Safari doesn't play well with the native picker) and calculate the remaining minutes until reset expiration.

## How to test it
1. Open a Safe with >1 owner and assign a Spending Limit for one of them.
2. There should be two new periods available (when not on Rinkeby).

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/145541216-48f4ad44-4f95-4197-885e-c615b4584f9a.png)