### PR TITLE
Remove duplicate scrollIntoView

### DIFF
--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -91,12 +91,6 @@ const SafeListItem = ({
     setChainId(networkId)
   }
 
-  useEffect(() => {
-    if (isCurrentSafe && shouldScrollToSafe) {
-      safeRef?.current?.scrollIntoView({ behavior: 'smooth' })
-    }
-  }, [isCurrentSafe, shouldScrollToSafe])
-
   return (
     <ListItem button onClick={handleOpenSafe} ref={safeRef}>
       <StyledIcon type="check" size="md" color="primary" checked={isCurrentSafe} />


### PR DESCRIPTION
## What it solves
The removal of duplicate code. This may also fix the scrolling in long Safe lists.