### PR TITLE
Feature: use public RPCs for suggested wallet configs

### DIFF
--- a/src/config/__tests__/index.test.ts
+++ b/src/config/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+import { setChainId } from 'src/logic/config/utils'
+import { CHAIN_ID } from '../chain.d'
+import { getPublicRpcUrl } from '..'
+
+describe('Config getters', () => {
+  describe('getPublicRpcUrl', () => {
+    afterEach(() => {
+      setChainId(CHAIN_ID.RINKEBY)
+    })
+
+    it('gets a public RPC from the config', () => {
+      setChainId(CHAIN_ID.POLYGON)
+      expect(getPublicRpcUrl()).toBe('https://polygon-rpc.com/')
+    })
+  })
+})

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -65,8 +65,8 @@ export const getNativeCurrency = (): ChainInfo['nativeCurrency'] => {
 }
 
 const formatRpcServiceUrl = ({ authentication, value }: RpcUri, TOKEN: string): string => {
-  const usesInfuraRPC = authentication === RPC_AUTHENTICATION.API_KEY_PATH
-  return usesInfuraRPC && TOKEN ? `${value}${TOKEN}` : value
+  const needsToken = authentication === RPC_AUTHENTICATION.API_KEY_PATH
+  return needsToken ? `${value}${TOKEN}` : value
 }
 
 export const getRpcServiceUrl = (): string => {
@@ -76,7 +76,8 @@ export const getRpcServiceUrl = (): string => {
 
 export const getPublicRpcUrl = (): string => {
   const { publicRpcUri } = getChainInfo()
-  return publicRpcUri.value
+  // Don't pass any auth token because this RPC is for user's wallet
+  return formatRpcServiceUrl(publicRpcUri, '')
 }
 
 export const getSafeAppsRpcServiceUrl = (): string => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -74,6 +74,11 @@ export const getRpcServiceUrl = (): string => {
   return formatRpcServiceUrl(rpcUri, INFURA_TOKEN)
 }
 
+export const getPublicRpcUrl = (): string => {
+  const { publicRpcUri } = getChainInfo()
+  return formatRpcServiceUrl(publicRpcUri, INFURA_TOKEN)
+}
+
 export const getSafeAppsRpcServiceUrl = (): string => {
   const { safeAppsRpcUri } = getChainInfo()
   return formatRpcServiceUrl(safeAppsRpcUri, SAFE_APPS_RPC_TOKEN)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -76,7 +76,7 @@ export const getRpcServiceUrl = (): string => {
 
 export const getPublicRpcUrl = (): string => {
   const { publicRpcUri } = getChainInfo()
-  return formatRpcServiceUrl(publicRpcUri, INFURA_TOKEN)
+  return publicRpcUri.value
 }
 
 export const getSafeAppsRpcServiceUrl = (): string => {

--- a/src/logic/safe/utils/mocks/remoteConfig.json
+++ b/src/logic/safe/utils/mocks/remoteConfig.json
@@ -135,8 +135,8 @@
         "value": "https://polygon-mainnet.infura.io/v3/"
       },
       "publicRpcUri": {
-        "authentication": "API_KEY_PATH",
-        "value": "https://polygon-mainnet.infura.io/v3/"
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://polygon-rpc.com/"
       },
       "blockExplorerUriTemplate": {
         "address": "https://polygonscan.com/address/{{address}}",

--- a/src/logic/safe/utils/mocks/remoteConfig.json
+++ b/src/logic/safe/utils/mocks/remoteConfig.json
@@ -65,6 +65,61 @@
       ]
     },
     {
+      "transactionService": "https://safe-transaction.avalanche.gnosis.io",
+      "chainId": "43114",
+      "chainName": "Avalanche",
+      "shortName": "Avalanche",
+      "l2": true,
+      "description": "",
+      "rpcUri": {
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://api.avax.network/ext/bc/C/rpc"
+      },
+      "safeAppsRpcUri": {
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://api.avax.network/ext/bc/C/rpc"
+      },
+      "publicRpcUri": {
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://api.avax.network/ext/bc/C/rpc"
+      },
+      "blockExplorerUriTemplate": {
+        "address": "https://snowtrace.io/address/{{address}}",
+        "txHash": "https://snowtrace.io/tx/{{txHash}}",
+        "api": "https://api.snowtrace.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+      },
+      "nativeCurrency": {
+        "name": "Avalanche",
+        "symbol": "AVAX",
+        "decimals": 18,
+        "logoUri": "https://safe-transaction-assets.staging.gnosisdev.com/chains/43114/currency_logo.png"
+      },
+      "theme": {
+        "textColor": "#ffffff",
+        "backgroundColor": "#e84142"
+      },
+      "gasPrice": [],
+      "disabledWallets": [
+        "authereum",
+        "fortmatic",
+        "keystone",
+        "lattice",
+        "opera",
+        "operaTouch",
+        "portis",
+        "torus",
+        "trezor",
+        "trust"
+      ],
+      "features": [
+        "CONTRACT_INTERACTION",
+        "DOMAIN_LOOKUP",
+        "ERC721",
+        "SAFE_APPS",
+        "SAFE_TX_GAS_OPTIONAL"
+      ]
+    },
+    {
       "transactionService": "https://safe-transaction-polygon.staging.gnosisdev.com",
       "chainId": "137",
       "chainName": "Polygon",
@@ -129,61 +184,6 @@
       ]
     },
     {
-      "transactionService": "https://safe-transaction.avalanche.gnosis.io",
-      "chainId": "43114",
-      "chainName": "Avalanche",
-      "shortName": "Avalanche",
-      "l2": true,
-      "description": "",
-      "rpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "safeAppsRpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "publicRpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "blockExplorerUriTemplate": {
-        "address": "https://snowtrace.io/address/{{address}}",
-        "txHash": "https://snowtrace.io/tx/{{txHash}}",
-        "api": "https://api.snowtrace.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
-      },
-      "nativeCurrency": {
-        "name": "Avalanche",
-        "symbol": "AVAX",
-        "decimals": 18,
-        "logoUri": "https://safe-transaction-assets.staging.gnosisdev.com/chains/43114/currency_logo.png"
-      },
-      "theme": {
-        "textColor": "#ffffff",
-        "backgroundColor": "#333333"
-      },
-      "gasPrice": [],
-      "disabledWallets": [
-        "authereum",
-        "fortmatic",
-        "keystone",
-        "lattice",
-        "opera",
-        "operaTouch",
-        "portis",
-        "torus",
-        "trezor",
-        "trust"
-      ],
-      "features": [
-        "CONTRACT_INTERACTION",
-        "EIP1559",
-        "ERC721",
-        "SAFE_APPS",
-        "SAFE_TX_GAS_OPTIONAL"
-      ]
-    },
-    {
       "transactionService": "https://safe-transaction.optimism.gnosis.io",
       "chainId": "10",
       "chainName": "Optimism",
@@ -205,7 +205,7 @@
       "blockExplorerUriTemplate": {
         "address": "https://optimistic.etherscan.io/address/{{address}}",
         "txHash": "https://optimistic.etherscan.io/tx/{{txHash}}",
-        "api": "https://api.optimistic.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        "api": "https://api-optimistic.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
       },
       "nativeCurrency": {
         "name": "Ether",
@@ -234,6 +234,9 @@
         "walletLink"
       ],
       "features": [
+        "CONTRACT_INTERACTION",
+        "ERC721",
+        "SAFE_APPS",
         "SAFE_TX_GAS_OPTIONAL"
       ]
     },

--- a/src/logic/wallets/utils/network.ts
+++ b/src/logic/wallets/utils/network.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'bnc-onboard/dist/src/interfaces'
 import onboard from 'src/logic/wallets/onboard'
 import { numberToHex } from 'web3-utils'
 
-import { getChainInfo, getExplorerUrl, getRpcServiceUrl, _getChainId } from 'src/config'
+import { getChainInfo, getExplorerUrl, getPublicRpcUrl, _getChainId } from 'src/config'
 import { ChainId } from 'src/config/chain.d'
 import { Errors, CodedException } from 'src/logic/exceptions/CodedException'
 
@@ -42,7 +42,7 @@ const requestAdd = async (wallet: Wallet, chainId: ChainId): Promise<void> => {
         chainId: numberToHex(chainId),
         chainName,
         nativeCurrency,
-        rpcUrls: [getRpcServiceUrl()],
+        rpcUrls: [getPublicRpcUrl()],
         blockExplorerUrls: [getExplorerUrl()],
       },
     ],


### PR DESCRIPTION
## What it solves
Resolves #2869

## How this PR fixes it
Uses the new config field.

## How to test it

- Delete previous wallet configs.
- Switch to an L2 network, accept suggested config
- Make sure it's a public RPC

<img width="472" alt="Screenshot 2021-12-13 at 10 47 58" src="https://user-images.githubusercontent.com/381895/145789403-c9568d83-e3df-4377-a764-e6860971df94.png">

