### PR TITLE
Fix: parsing undefined in localStorage

### DIFF
--- a/src/utils/storage/Storage.ts
+++ b/src/utils/storage/Storage.ts
@@ -26,7 +26,7 @@ class Storage {
       logError(Errors._700, `key ${key} – ${err.message}`)
     }
 
-    if (!saved) return
+    if (!saved || saved === 'undefined') return
 
     try {
       return JSON.parse(saved) as T

--- a/src/utils/storage/__tests__/local.test.ts
+++ b/src/utils/storage/__tests__/local.test.ts
@@ -30,4 +30,12 @@ describe('local storage', () => {
       expect(window.localStorage.getItem('SAFE__test')).toBe('true')
     })
   })
+
+  describe('handling undefined', () => {
+    it('saves ands reads undefined', () => {
+      setItem('test_undefined', undefined)
+      expect(getItem('test_undefined')).toBe(undefined)
+      expect(window.localStorage.getItem('SAFE__test_undefined')).toBe('undefined')
+    })
+  })
 })


### PR DESCRIPTION
## What it solves
When `undefined` is saved into the localStorage, it cannot be parsed when read afterwards.

![image (2)](https://user-images.githubusercontent.com/381895/145800154-7efa6f20-fcd5-455c-b21d-0e6c9cbcf60e.png)

## How this PR fixes it
I've added a special handling for this case.