### PR TITLE
Fix: legacy storage keys

### DIFF
--- a/src/logic/safe/utils/mocks/remoteConfig.json
+++ b/src/logic/safe/utils/mocks/remoteConfig.json
@@ -65,6 +65,61 @@
       ]
     },
     {
+      "transactionService": "https://safe-transaction.avalanche.gnosis.io",
+      "chainId": "43114",
+      "chainName": "Avalanche",
+      "shortName": "Avalanche",
+      "l2": true,
+      "description": "",
+      "rpcUri": {
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://api.avax.network/ext/bc/C/rpc"
+      },
+      "safeAppsRpcUri": {
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://api.avax.network/ext/bc/C/rpc"
+      },
+      "publicRpcUri": {
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://api.avax.network/ext/bc/C/rpc"
+      },
+      "blockExplorerUriTemplate": {
+        "address": "https://snowtrace.io/address/{{address}}",
+        "txHash": "https://snowtrace.io/tx/{{txHash}}",
+        "api": "https://api.snowtrace.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+      },
+      "nativeCurrency": {
+        "name": "Avalanche",
+        "symbol": "AVAX",
+        "decimals": 18,
+        "logoUri": "https://safe-transaction-assets.staging.gnosisdev.com/chains/43114/currency_logo.png"
+      },
+      "theme": {
+        "textColor": "#ffffff",
+        "backgroundColor": "#e84142"
+      },
+      "gasPrice": [],
+      "disabledWallets": [
+        "authereum",
+        "fortmatic",
+        "keystone",
+        "lattice",
+        "opera",
+        "operaTouch",
+        "portis",
+        "torus",
+        "trezor",
+        "trust"
+      ],
+      "features": [
+        "CONTRACT_INTERACTION",
+        "DOMAIN_LOOKUP",
+        "ERC721",
+        "SAFE_APPS",
+        "SAFE_TX_GAS_OPTIONAL"
+      ]
+    },
+    {
       "transactionService": "https://safe-transaction-polygon.staging.gnosisdev.com",
       "chainId": "137",
       "chainName": "Polygon",
@@ -80,8 +135,8 @@
         "value": "https://polygon-mainnet.infura.io/v3/"
       },
       "publicRpcUri": {
-        "authentication": "API_KEY_PATH",
-        "value": "https://polygon-mainnet.infura.io/v3/"
+        "authentication": "NO_AUTHENTICATION",
+        "value": "https://polygon-rpc.com/"
       },
       "blockExplorerUriTemplate": {
         "address": "https://polygonscan.com/address/{{address}}",
@@ -129,61 +184,6 @@
       ]
     },
     {
-      "transactionService": "https://safe-transaction.avalanche.gnosis.io",
-      "chainId": "43114",
-      "chainName": "Avalanche",
-      "shortName": "Avalanche",
-      "l2": true,
-      "description": "",
-      "rpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "safeAppsRpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "publicRpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "blockExplorerUriTemplate": {
-        "address": "https://snowtrace.io/address/{{address}}",
-        "txHash": "https://snowtrace.io/tx/{{txHash}}",
-        "api": "https://api.snowtrace.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
-      },
-      "nativeCurrency": {
-        "name": "Avalanche",
-        "symbol": "AVAX",
-        "decimals": 18,
-        "logoUri": "https://safe-transaction-assets.staging.gnosisdev.com/chains/43114/currency_logo.png"
-      },
-      "theme": {
-        "textColor": "#ffffff",
-        "backgroundColor": "#333333"
-      },
-      "gasPrice": [],
-      "disabledWallets": [
-        "authereum",
-        "fortmatic",
-        "keystone",
-        "lattice",
-        "opera",
-        "operaTouch",
-        "portis",
-        "torus",
-        "trezor",
-        "trust"
-      ],
-      "features": [
-        "CONTRACT_INTERACTION",
-        "EIP1559",
-        "ERC721",
-        "SAFE_APPS",
-        "SAFE_TX_GAS_OPTIONAL"
-      ]
-    },
-    {
       "transactionService": "https://safe-transaction.optimism.gnosis.io",
       "chainId": "10",
       "chainName": "Optimism",
@@ -205,7 +205,7 @@
       "blockExplorerUriTemplate": {
         "address": "https://optimistic.etherscan.io/address/{{address}}",
         "txHash": "https://optimistic.etherscan.io/tx/{{txHash}}",
-        "api": "https://api.optimistic.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        "api": "https://api-optimistic.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
       },
       "nativeCurrency": {
         "name": "Ether",
@@ -234,6 +234,9 @@
         "walletLink"
       ],
       "features": [
+        "CONTRACT_INTERACTION",
+        "ERC721",
+        "SAFE_APPS",
         "SAFE_TX_GAS_OPTIONAL"
       ]
     },

--- a/src/logic/safe/utils/safeStorage.ts
+++ b/src/logic/safe/utils/safeStorage.ts
@@ -1,6 +1,5 @@
 import { getStoragePrefix, loadFromStorage, saveToStorage } from 'src/utils/storage'
 import { SafeRecordProps } from 'src/logic/safe/store/models/safe'
-import { getChainById } from 'src/config'
 import { ChainId } from 'src/config/chain.d'
 
 export const SAFES_KEY = 'SAFES'
@@ -12,8 +11,7 @@ export const loadStoredSafes = (): Promise<StoredSafes | undefined> => {
 }
 
 export const loadStoredNetworkSafeById = (id: ChainId): Promise<StoredSafes | undefined> => {
-  const chain = getChainById(id)
-  return loadFromStorage<StoredSafes>(SAFES_KEY, getStoragePrefix(chain.chainName))
+  return loadFromStorage<StoredSafes>(SAFES_KEY, getStoragePrefix(id))
 }
 
 export const saveSafes = async (safes: StoredSafes): Promise<void> => {

--- a/src/utils/storage/__tests__/index.test.ts
+++ b/src/utils/storage/__tests__/index.test.ts
@@ -3,6 +3,10 @@ import { getStoragePrefix } from '..'
 describe('getStoragePrefix', () => {
   it('saves a stringified value', () => {
     expect(getStoragePrefix('137')).toBe('_immortal|v2_POLYGON__')
+    expect(getStoragePrefix('4')).toBe('_immortal|v2_RINKEBY__')
+    expect(getStoragePrefix('1')).toBe('_immortal|v2_MAINNET__')
+    expect(getStoragePrefix('100')).toBe('_immortal|v2_XDAI__')
+    expect(getStoragePrefix('246')).toBe('_immortal|v2_ENERGY_WEB_CHAIN__')
     expect(getStoragePrefix('9358392457')).toBe('_immortal|v2_9358392457__')
     expect(getStoragePrefix()).toBe('_immortal|v2_RINKEBY__')
   })

--- a/src/utils/storage/__tests__/index.test.ts
+++ b/src/utils/storage/__tests__/index.test.ts
@@ -1,0 +1,9 @@
+import { getStoragePrefix } from '..'
+
+describe('getStoragePrefix', () => {
+  it('saves a stringified value', () => {
+    expect(getStoragePrefix('137')).toBe('_immortal|v2_POLYGON__')
+    expect(getStoragePrefix('9358392457')).toBe('_immortal|v2_9358392457__')
+    expect(getStoragePrefix()).toBe('_immortal|v2_RINKEBY__')
+  })
+})

--- a/src/utils/storage/index.ts
+++ b/src/utils/storage/index.ts
@@ -1,10 +1,28 @@
-import { getChainName } from 'src/config'
+import { _getChainId } from 'src/config'
+import { ChainId } from 'src/config/chain'
 import Storage from './Storage'
+
+// Legacy storage keys. New chains will use the chain id as prefix.
+// @TODO: migrate them to chain ids.
+const STORAGE_KEYS: Record<ChainId, string> = {
+  '1': 'MAINNET',
+  '4': 'RINKEBY',
+  '56': 'BSC',
+  '100': 'XDAI',
+  '137': 'POLYGON',
+  '246': 'ENERGY_WEB_CHAIN',
+  '42161': 'ARBITRUM',
+  '73799': 'VOLTA',
+}
 
 export const storage = new Storage(window.localStorage, '')
 
-// We need this to update on run time depending on selected network name
-export const getStoragePrefix = (chainName = getChainName()): string => `_immortal|v2_${chainName}__`
+export const getStoragePrefix = (id = _getChainId()): string => {
+  const name = STORAGE_KEYS[id] || id
+  // Legacy ImmortalDB prefix
+  // @TODO: migrate it
+  return `_immortal|v2_${name}__`
+}
 
 export const loadFromStorage = async <T = unknown>(
   key: string,

--- a/src/utils/storage/index.ts
+++ b/src/utils/storage/index.ts
@@ -1,18 +1,18 @@
 import { _getChainId } from 'src/config'
-import { ChainId } from 'src/config/chain'
+import { ChainId, CHAIN_ID } from 'src/config/chain.d'
 import Storage from './Storage'
 
 // Legacy storage keys. New chains will use the chain id as prefix.
 // @TODO: migrate them to chain ids.
 const STORAGE_KEYS: Record<ChainId, string> = {
-  '1': 'MAINNET',
-  '4': 'RINKEBY',
-  '56': 'BSC',
-  '100': 'XDAI',
-  '137': 'POLYGON',
-  '246': 'ENERGY_WEB_CHAIN',
-  '42161': 'ARBITRUM',
-  '73799': 'VOLTA',
+  [CHAIN_ID.ETHEREUM]: 'MAINNET',
+  [CHAIN_ID.RINKEBY]: 'RINKEBY',
+  [CHAIN_ID.BSC]: 'BSC',
+  [CHAIN_ID.XDAI]: 'XDAI',
+  [CHAIN_ID.POLYGON]: 'POLYGON',
+  [CHAIN_ID.ENERGY_WEB_CHAIN]: 'ENERGY_WEB_CHAIN',
+  [CHAIN_ID.ARBITRUM]: 'ARBITRUM',
+  [CHAIN_ID.VOLTA]: 'VOLTA',
 }
 
 export const storage = new Storage(window.localStorage, '')


### PR DESCRIPTION
## What it solves
We used to use hard-coded chain names for local storage keys.
It was changed to use `chainName` from config-service. Those `chainNames` aren't the same as the old ones.

## How this PR fixes it
Restores a hard-coded config for old chains and uses `chainId` for new chains.

## How to test it
* Use old local storage
* See that your data is read correctly