### PR TITLE
Fix: catch spending limits error

### DIFF
--- a/src/logic/safe/utils/spendingLimits.ts
+++ b/src/logic/safe/utils/spendingLimits.ts
@@ -124,17 +124,16 @@ const requestAllowancesByDelegatesAndTokens = async (
 export const getSpendingLimits = async (modules: string[], safeAddress: string): Promise<SpendingLimit[] | null> => {
   const isSpendingLimitEnabled = isModuleEnabled(modules, SPENDING_LIMIT_MODULE_ADDRESS)
 
+  if (!isSpendingLimitEnabled) return null
+
   try {
-    if (isSpendingLimitEnabled) {
-      const delegates = await getSpendingLimitContract().methods.getDelegates(safeAddress, 0, 100).call()
-      const tokensByDelegate = await requestTokensByDelegate(safeAddress, delegates.results)
-      return requestAllowancesByDelegatesAndTokens(safeAddress, tokensByDelegate)
-    }
+    const delegates = await getSpendingLimitContract().methods.getDelegates(safeAddress, 0, 100).call()
+    const tokensByDelegate = await requestTokensByDelegate(safeAddress, delegates.results)
+    const limits = await requestAllowancesByDelegatesAndTokens(safeAddress, tokensByDelegate)
+    return limits
   } catch (error) {
     throw new CodedException(Errors._609, error.message)
   }
-
-  return null
 }
 
 type DeleteAllowanceParams = {


### PR DESCRIPTION
## What it solves
Resolves #3173

The Spending Limits feature is throwing on Avalanche, but the error wasn't caught properly.

## How this PR fixes it
The error is now caught and is logged.

## How to test it
* Open `Avalanche:0xbD99AB5EbD2a68e4Ad4b21dF73f5f393fe223411`
* Check the console

## Screenshots
<img width="1300" alt="Screenshot 2021-12-13 at 18 40 50" src="https://user-images.githubusercontent.com/381895/145861560-6af42fff-a6e2-4613-a284-a73aafee097a.png">
