### PR TITLE
Fix: incorrect mainnet networkName used in onboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/logic/safe/utils/mocks/remoteConfig.json
+++ b/src/logic/safe/utils/mocks/remoteConfig.json
@@ -114,6 +114,7 @@
       "features": [
         "CONTRACT_INTERACTION",
         "DOMAIN_LOOKUP",
+        "EIP1559",
         "ERC721",
         "SAFE_APPS",
         "SAFE_TX_GAS_OPTIONAL"

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -6,6 +6,11 @@ import { setWeb3 } from './getWeb3'
 import { fetchProvider, removeProvider } from './store/actions'
 import transactionDataCheck from './transactionDataCheck'
 import { getSupportedWallets } from './utils/walletList'
+import { ChainId, CHAIN_ID } from 'src/config/chain.d'
+
+const NETWORK_NAMES: Record<ChainId, string> = {
+  [CHAIN_ID.ETHEREUM]: 'mainnet',
+}
 
 const getOnboardConfiguration = () => {
   let lastUsedAddress = ''
@@ -15,7 +20,8 @@ const getOnboardConfiguration = () => {
   return {
     networkId: parseInt(_getChainId(), 10),
     // Is it mandatory for Ledger to work to send network name in lowercase
-    networkName: getChainName().toLowerCase(),
+    // @FIXME: Move to CGW
+    networkName: NETWORK_NAMES[_getChainId()] || getChainName().toLowerCase(),
     subscriptions: {
       wallet: (wallet: Wallet) => {
         if (wallet.provider) {


### PR DESCRIPTION
## What it solves
Issues with Trezor (and Ledger?) transactions on mainnet.

## How this PR fixes it
With the migration to the chains endpoint, 'Mainnet' was renamed to 'Ethereum'.

This PR includes a hardcoded quick fix to send `'mainnet'` when it would send `'ethereum'` to onboard's `networkName` configuration.

## How to test it
1. Perform a transaction on mainnet and expect it to succeed.