### PR TITLE
Add GA appearance/EIP-3770 tracking

### DIFF
--- a/src/routes/safe/components/Settings/Appearance/index.tsx
+++ b/src/routes/safe/components/Settings/Appearance/index.tsx
@@ -1,7 +1,7 @@
 import FormGroup from '@material-ui/core/FormGroup/FormGroup'
 import Checkbox from '@material-ui/core/Checkbox/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel/FormControlLabel'
-import { ChangeEvent, ReactElement } from 'react'
+import { ChangeEvent, ReactElement, useEffect } from 'react'
 
 import Block from 'src/components/layout/Block'
 import styled from 'styled-components'
@@ -14,6 +14,7 @@ import { setShowShortName } from 'src/logic/appearance/actions/setShowShortName'
 import { setCopyShortName } from 'src/logic/appearance/actions/setCopyShortName'
 import { extractSafeAddress } from 'src/routes/routes'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
+import { useAnalytics, SETTINGS_EVENTS } from 'src/utils/googleAnalytics'
 
 // Other settings sections use MUI createStyles .container
 // will adjust that during dark mode implementation
@@ -31,8 +32,18 @@ const Appearance = (): ReactElement => {
   const showShortName = useSelector(showShortNameSelector)
   const safeAddress = extractSafeAddress()
 
-  const handleShowChange = (_: ChangeEvent<HTMLInputElement>, checked: boolean) =>
+  const { trackEvent } = useAnalytics()
+
+  useEffect(() => {
+    trackEvent(SETTINGS_EVENTS.APPEARANCE)
+  }, [trackEvent])
+
+  const handleShowChange = (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
     dispatch(setShowShortName({ showShortName: checked }))
+
+    const label = `${SETTINGS_EVENTS.APPEARANCE.label} (${checked ? 'Enable' : 'Disable'} EIP-3770 prefixes)`
+    trackEvent({ ...SETTINGS_EVENTS.APPEARANCE, label })
+  }
   const handleCopyChange = (_: ChangeEvent<HTMLInputElement>, checked: boolean) =>
     dispatch(setCopyShortName({ copyShortName: checked }))
 

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -68,6 +68,7 @@ export const SAFE_APP_EVENTS: Record<string, EventArgs> = {
 
 export const SETTINGS_EVENTS: Record<string, EventArgs> = {
   ADVANCED: { ...SAFE_EVENTS.SETTINGS, label: 'Advanced' },
+  APPEARANCE: { ...SAFE_EVENTS.SETTINGS, label: 'Appearance' },
   DETAILS: { ...SAFE_EVENTS.SETTINGS, label: 'Details' },
   OWNERS: { ...SAFE_EVENTS.SETTINGS, label: 'Owners' },
 }


### PR DESCRIPTION
## What it solves
Appearance setting tracking.

## How this PR fixes it
When a user opens the appearance setting tab a GA tracking event is dispatched. A dynamic (enable/disable) event is dispatched when a user changes their EIP-3770 prefix preferences.

## How to test it
1. Open the appearance settings pane and note the GA event.
2. Change the prefix preference and note the matching GA event.