### PR TITLE
Tx list tx details

### DIFF
--- a/src/components/DecodeTxs/__tests__/index.ts
+++ b/src/components/DecodeTxs/__tests__/index.ts
@@ -1,4 +1,4 @@
-import { getByteLength } from '..'
+import { getByteLength } from '../../../utils/getByteLength'
 
 describe('DecodeTxs tests', () => {
   it('should calculate the byte length of a single hex string', () => {

--- a/src/components/DecodeTxs/index.tsx
+++ b/src/components/DecodeTxs/index.tsx
@@ -3,12 +3,12 @@ import styled from 'styled-components'
 import { Transaction } from '@gnosis.pm/safe-apps-sdk-v1'
 import get from 'lodash/get'
 import { Text, CopyToClipboardBtn, IconText, FixedIcon } from '@gnosis.pm/safe-react-components'
-import { hexToBytes } from 'web3-utils'
 
 import { getExplorerInfo, getNativeCurrency } from 'src/config'
 import { DecodedData, DecodedDataBasicParameter, DecodedDataParameterValue } from 'src/types/transactions/decode.d'
 import { DecodedTxDetail } from 'src/routes/safe/components/Apps/components/ConfirmTxModal'
 import PrefixedEthHashInfo from '../PrefixedEthHashInfo'
+import { getByteLength } from 'src/utils/getByteLength'
 
 const FlexWrapper = styled.div<{ margin: number }>`
   display: flex;
@@ -49,21 +49,6 @@ const TxListItem = styled.div`
 const ElementWrapper = styled.div`
   margin-bottom: 15px;
 `
-
-export const getByteLength = (data: string | string[]): number => {
-  try {
-    if (!Array.isArray(data)) {
-      data = data.split(',')
-    }
-    // Return the sum of the byte sizes of each hex string
-    return data.reduce((result, hex) => {
-      const bytes = hexToBytes(hex)
-      return result + bytes.length
-    }, 0)
-  } catch (err) {
-    return 0
-  }
-}
 
 export const BasicTxInfo = ({
   txRecipient,

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -126,7 +126,7 @@ export const createTransaction =
     const beforeExecutionKey = dispatch(enqueueSnackbar(notificationsQueue.beforeExecution))
 
     let txHash
-    const txArgs: TxArgs & { sender: string } = {
+    const txArgs: TxArgs = {
       safeInstance,
       to,
       valueInWei,

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -27,6 +27,7 @@ import { Dispatch, DispatchReturn } from './types'
 import { PayableTx } from 'src/types/contracts/types'
 import { updateTransactionStatus } from 'src/logic/safe/store/actions/updateTransactionStatus'
 import { Confirmation } from 'src/logic/safe/store/models/types/confirmation'
+import { TxArgs } from 'src/logic/safe/store/models/types/transaction'
 import { Operation, TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
 import { isTxPendingError } from 'src/logic/wallets/getWeb3'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
@@ -101,7 +102,7 @@ export const processTransaction =
 
     let txHash
     let transaction
-    const txArgs = {
+    const txArgs: TxArgs = {
       ...tx, // merge the previous tx with new data
       safeInstance,
       to: tx.to,

--- a/src/logic/safe/store/models/types/transaction.ts
+++ b/src/logic/safe/store/models/types/transaction.ts
@@ -17,7 +17,7 @@ export type TxArgs = {
   refundReceiver: string
   safeInstance: GnosisSafe
   safeTxGas: string
-  sender?: string
+  sender: string
   sigs: string
   to: string
   valueInWei: string

--- a/src/logic/safe/transactions/txHistory.ts
+++ b/src/logic/safe/transactions/txHistory.ts
@@ -1,12 +1,13 @@
+import { MultisigTransactionRequest, proposeTransaction, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
+
 import { GnosisSafe } from 'src/types/contracts/gnosis_safe.d'
 import { _getChainId } from 'src/config'
 
 import { checksumAddress } from 'src/utils/checksumAddress'
-import { MultisigTransactionRequest, proposeTransaction, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
 import { GATEWAY_URL } from 'src/utils/constants'
 import { TxArgs } from '../store/models/types/transaction'
 
-type ProposeTxBodyProps = Omit<MultisigTransactionRequest, 'safeTxHash'> & {
+type ProposeTxBody = Omit<MultisigTransactionRequest, 'safeTxHash'> & {
   safeInstance: GnosisSafe
   data: string | number[]
 }
@@ -26,7 +27,7 @@ const calculateBodyFrom = async ({
   sender,
   origin,
   signature,
-}: ProposeTxBodyProps): Promise<MultisigTransactionRequest> => {
+}: ProposeTxBody): Promise<MultisigTransactionRequest> => {
   const safeTxHash = await safeInstance.methods
     .getTransactionHash(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver || '', nonce)
     .call()
@@ -49,7 +50,7 @@ const calculateBodyFrom = async ({
   }
 }
 
-type SaveTxToHistoryProps = TxArgs & { origin?: string | null; signature?: string }
+type SaveTxToHistoryTypes = TxArgs & { origin?: string | null; signature?: string }
 
 export const saveTxToHistory = async ({
   baseGas,
@@ -66,7 +67,7 @@ export const saveTxToHistory = async ({
   signature,
   to,
   valueInWei,
-}: SaveTxToHistoryProps): Promise<TransactionDetails> => {
+}: SaveTxToHistoryTypes): Promise<TransactionDetails> => {
   const address = checksumAddress(safeInstance.options.address)
   const body = await calculateBodyFrom({
     safeInstance,

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -44,6 +44,15 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
 
   return (
     <>
+      {canCancel && (
+        <Tooltip title="Reject" placement="top">
+          <span>
+            <IconButton size="small" type="button" onClick={handleCancelButtonClick} disabled={isPending}>
+              <Icon type="circleCross" color="error" size="sm" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
       <Tooltip title={getTitle()} placement="top">
         <span>
           <IconButton
@@ -58,15 +67,6 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
           </IconButton>
         </span>
       </Tooltip>
-      {canCancel && (
-        <Tooltip title="Reject" placement="top">
-          <span>
-            <IconButton size="small" type="button" onClick={handleCancelButtonClick} disabled={isPending}>
-              <Icon type="circleCross" color="error" size="sm" />
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
     </>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxDataRow.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDataRow.tsx
@@ -1,0 +1,41 @@
+import { ReactElement, ReactNode } from 'react'
+import styled from 'styled-components'
+import { CopyToClipboardBtn, Text } from '@gnosis.pm/safe-react-components'
+
+import { InlineEthHashInfo, StyledGridRow } from './styled'
+import { getExplorerInfo } from 'src/config'
+import { getByteLength } from 'src/utils/getByteLength'
+
+const FlexWrapper = styled.div<{ margin: number }>`
+  display: flex;
+  align-items: center;
+
+  > :nth-child(2) {
+    margin-left: ${({ margin }) => margin}px;
+  }
+`
+
+type TxDataRowType = { children?: ReactNode; inlineType?: 'hash' | 'rawData'; title: string; value: string | null }
+
+export const TxDataRow = ({ children, inlineType, title, value }: TxDataRowType): ReactElement => (
+  <StyledGridRow>
+    <Text size="xl" as="span">
+      {title}
+    </Text>
+    {inlineType === 'hash' && typeof value === 'string' && (
+      <InlineEthHashInfo textSize="xl" hash={value} shortenHash={8} showCopyBtn explorerUrl={getExplorerInfo(value)} />
+    )}
+    {inlineType === 'rawData' && typeof value === 'string' && (
+      <FlexWrapper margin={5}>
+        <Text size="xl">{value ? getByteLength(value) : 0} bytes</Text>
+        {value && <CopyToClipboardBtn textToCopy={value || ''} />}
+      </FlexWrapper>
+    )}
+    {!inlineType && typeof value === 'string' && (
+      <Text size="xl" as="span">
+        {value}
+      </Text>
+    )}
+    {children}
+  </StyledGridRow>
+)

--- a/src/routes/safe/components/Transactions/TxList/TxDataRow.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDataRow.tsx
@@ -15,23 +15,23 @@ const FlexWrapper = styled.div<{ margin: number }>`
   }
 `
 
-type TxDataRowType = { children?: ReactNode; inlineType?: 'hash' | 'rawData'; title: string; value: string | null }
+type TxDataRowType = { children?: ReactNode; inlineType?: 'hash' | 'rawData'; title: string; value?: string }
 
 export const TxDataRow = ({ children, inlineType, title, value }: TxDataRowType): ReactElement => (
   <StyledGridRow>
     <Text size="xl" as="span">
       {title}
     </Text>
-    {inlineType === 'hash' && typeof value === 'string' && (
+    {value && inlineType === 'hash' && (
       <InlineEthHashInfo textSize="xl" hash={value} shortenHash={8} showCopyBtn explorerUrl={getExplorerInfo(value)} />
     )}
-    {inlineType === 'rawData' && typeof value === 'string' && (
+    {value && inlineType === 'rawData' && (
       <FlexWrapper margin={5}>
         <Text size="xl">{value ? getByteLength(value) : 0} bytes</Text>
-        {value && <CopyToClipboardBtn textToCopy={value || ''} />}
+        <CopyToClipboardBtn textToCopy={value} />
       </FlexWrapper>
     )}
-    {!inlineType && typeof value === 'string' && (
+    {!inlineType && value && (
       <Text size="xl" as="span">
         {value}
       </Text>

--- a/src/routes/safe/components/Transactions/TxList/TxDataRow.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDataRow.tsx
@@ -15,15 +15,27 @@ const FlexWrapper = styled.div<{ margin: number }>`
   }
 `
 
-type TxDataRowType = { children?: ReactNode; inlineType?: 'hash' | 'rawData'; title: string; value?: string }
+type TxDataRowType = {
+  children?: ReactNode
+  inlineType?: 'hash' | 'rawData'
+  hasExplorer?: boolean
+  title: string
+  value?: string
+}
 
-export const TxDataRow = ({ children, inlineType, title, value }: TxDataRowType): ReactElement => (
+export const TxDataRow = ({ children, inlineType, hasExplorer = true, title, value }: TxDataRowType): ReactElement => (
   <StyledGridRow>
     <Text size="xl" as="span">
       {title}
     </Text>
     {value && inlineType === 'hash' && (
-      <InlineEthHashInfo textSize="xl" hash={value} shortenHash={8} showCopyBtn explorerUrl={getExplorerInfo(value)} />
+      <InlineEthHashInfo
+        textSize="xl"
+        hash={value}
+        shortenHash={8}
+        showCopyBtn
+        explorerUrl={hasExplorer ? getExplorerInfo(value) : undefined}
+      />
     )}
     {value && inlineType === 'rawData' && (
       <FlexWrapper margin={5}>

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -29,7 +29,6 @@ const NormalBreakingText = styled(Text)`
 
 const TxDataGroup = ({ txDetails }: { txDetails: ExpandedTxDetails }): ReactElement | null => {
   if (isTransferTxInfo(txDetails.txInfo) || isSettingsChangeTxInfo(txDetails.txInfo)) {
-    // txInfo.type === TRANSFER || SETTINGS_CHANGE
     return <TxInfo txInfo={txDetails.txInfo} />
   }
 
@@ -130,7 +129,6 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
         >
           <TxOwners txDetails={data} />
         </div>
-        {/* FIX: HOW CAN txLocation !== 'history' ???? */}
         {!data.executedAt && txLocation !== 'history' && actions?.isUserAnOwner && (
           <div
             className={cn('tx-details-actions', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -106,9 +106,6 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
 
   return (
     <TxDetailsContainer>
-      <div className={cn('tx-summary', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}>
-        <TxSummary txDetails={data} />
-      </div>
       <div
         className={cn('tx-details', {
           'no-padding': isMultiSendTxInfo(data.txInfo),
@@ -117,6 +114,9 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
         })}
       >
         <TxDataGroup txDetails={data} />
+      </div>
+      <div className={cn('tx-summary', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}>
+        <TxSummary txDetails={data} />
       </div>
       <div
         className={cn('tx-owners', {

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -29,6 +29,7 @@ const NormalBreakingText = styled(Text)`
 
 const TxDataGroup = ({ txDetails }: { txDetails: ExpandedTxDetails }): ReactElement | null => {
   if (isTransferTxInfo(txDetails.txInfo) || isSettingsChangeTxInfo(txDetails.txInfo)) {
+    // txInfo.type === TRANSFER || SETTINGS_CHANGE
     return <TxInfo txInfo={txDetails.txInfo} />
   }
 
@@ -106,31 +107,38 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
 
   return (
     <TxDetailsContainer>
-      <div
-        className={cn('tx-details', {
-          'no-padding': isMultiSendTxInfo(data.txInfo),
-          'not-executed': !data.executedAt,
-          'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED',
-        })}
-      >
-        <TxDataGroup txDetails={data} />
-      </div>
-      <div className={cn('tx-summary', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}>
-        <TxSummary txDetails={data} />
-      </div>
-      <div
-        className={cn('tx-owners', {
-          'no-owner': txLocation !== 'history' && !actions?.isUserAnOwner,
-          'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED',
-        })}
-      >
-        <TxOwners txDetails={data} />
-      </div>
-      {!data.executedAt && txLocation !== 'history' && actions?.isUserAnOwner && (
-        <div className={cn('tx-details-actions', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}>
-          <TxExpandedActions transaction={transaction} />
+      <div>
+        <div
+          className={cn('tx-details', {
+            'no-padding': isMultiSendTxInfo(data.txInfo),
+            'not-executed': !data.executedAt,
+            'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED',
+          })}
+        >
+          <TxDataGroup txDetails={data} />
         </div>
-      )}
+        <div className={cn('tx-summary', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}>
+          <TxSummary txDetails={data} />
+        </div>
+      </div>
+      <div>
+        <div
+          className={cn('tx-owners', {
+            'no-owner': txLocation !== 'history' && !actions?.isUserAnOwner,
+            'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED',
+          })}
+        >
+          <TxOwners txDetails={data} />
+        </div>
+        {/* FIX: HOW CAN txLocation !== 'history' ???? */}
+        {!data.executedAt && txLocation !== 'history' && actions?.isUserAnOwner && (
+          <div
+            className={cn('tx-details-actions', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}
+          >
+            <TxExpandedActions transaction={transaction} />
+          </div>
+        )}
+      </div>
     </TxDetailsContainer>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -126,7 +126,6 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
       <div>
         <div
           className={cn('tx-owners', {
-            'no-owner': !isHistoryTxList && !actions?.isUserAnOwner,
             'will-be-replaced': willBeReplaced,
           })}
         >

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -86,6 +86,9 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
   const { txLocation } = useContext(TxLocationContext)
   const { data, loading } = useTransactionDetails(transaction.id)
 
+  const willBeReplaced = transaction.txStatus === 'WILL_BE_REPLACED'
+  const isHistoryTxList = txLocation === 'history'
+
   if (loading) {
     return (
       <Centered padding={10}>
@@ -111,28 +114,26 @@ export const TxDetails = ({ transaction, actions }: TxDetailsProps): ReactElemen
           className={cn('tx-details', {
             'no-padding': isMultiSendTxInfo(data.txInfo),
             'not-executed': !data.executedAt,
-            'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED',
+            'will-be-replaced': willBeReplaced,
           })}
         >
           <TxDataGroup txDetails={data} />
         </div>
-        <div className={cn('tx-summary', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}>
+        <div className={cn('tx-summary', { 'will-be-replaced': willBeReplaced })}>
           <TxSummary txDetails={data} />
         </div>
       </div>
       <div>
         <div
           className={cn('tx-owners', {
-            'no-owner': txLocation !== 'history' && !actions?.isUserAnOwner,
-            'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED',
+            'no-owner': !isHistoryTxList && !actions?.isUserAnOwner,
+            'will-be-replaced': willBeReplaced,
           })}
         >
           <TxOwners txDetails={data} />
         </div>
-        {!data.executedAt && txLocation !== 'history' && actions?.isUserAnOwner && (
-          <div
-            className={cn('tx-details-actions', { 'will-be-replaced': transaction.txStatus === 'WILL_BE_REPLACED' })}
-          >
+        {!data.executedAt && !isHistoryTxList && actions?.isUserAnOwner && (
+          <div className={cn('tx-details-actions', { 'will-be-replaced': willBeReplaced })}>
             <TxExpandedActions transaction={transaction} />
           </div>
         )}

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -41,6 +41,11 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   // https://github.com/facebook/react/issues/4492
   return (
     <>
+      {canCancel && (
+        <Button size="md" color="error" onClick={handleCancelButtonClick} className="error" disabled={isPending}>
+          Reject
+        </Button>
+      )}
       <Tooltip title={getConfirmTooltipTitle()} placement="top">
         <span>
           <Button
@@ -56,11 +61,6 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
           </Button>
         </span>
       </Tooltip>
-      {canCancel && (
-        <Button size="md" color="error" onClick={handleCancelButtonClick} className="error" disabled={isPending}>
-          Reject
-        </Button>
-      )}
     </>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
@@ -1,15 +1,16 @@
 import { Text } from '@gnosis.pm/safe-react-components'
 import { ReactElement } from 'react'
+import styled from 'styled-components'
 
 import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { NOT_AVAILABLE } from './utils'
-import { InlineEthHashInfo, TxDetailsContainer, StyledGridRow } from './styled'
+import { TxDetailsContainer } from './styled'
 import { Creation } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useKnownAddress } from './hooks/useKnownAddress'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
-import styled from 'styled-components'
+import { TxDataRow } from './TxDataRow'
 
 const StyledPadding = styled.div`
   background-color: ${({ theme }) => theme.colors.white};
@@ -26,30 +27,9 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
   return (
     <TxDetailsContainer>
       <div className="tx-summary">
-        <StyledGridRow>
-          <Text size="xl" strong as="span">
-            Transaction hash:{' '}
-          </Text>
-          <InlineEthHashInfo
-            textSize="xl"
-            hash={txInfo.transactionHash}
-            shortenHash={8}
-            showCopyBtn
-            explorerUrl={getExplorerInfo(txInfo.transactionHash)}
-          />
-        </StyledGridRow>
-        <StyledGridRow>
-          <Text size="xl" strong as="span">
-            Created:{' '}
-          </Text>
-          <Text size="xl" as="span">
-            {formatDateTime(timestamp)}
-          </Text>
-        </StyledGridRow>
-        <StyledGridRow>
-          <Text size="xl" strong>
-            Creator:{' '}
-          </Text>
+        <TxDataRow title="Transaction hash:" value={txInfo.transactionHash} inlineType="hash" />
+        <TxDataRow title="Created:" value={formatDateTime(timestamp)} />
+        <TxDataRow title="Creator:" value={null}>
           <PrefixedEthHashInfo
             textSize="xl"
             hash={txInfo.creator.value}
@@ -59,11 +39,8 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
             customAvatar={creator.logoUri || undefined}
             showAvatar
           />
-        </StyledGridRow>
-        <StyledGridRow>
-          <Text size="xl" strong>
-            Factory:{' '}
-          </Text>
+        </TxDataRow>
+        <TxDataRow title="Factory:" value={null}>
           {txInfo.factory ? (
             <PrefixedEthHashInfo
               textSize="xl"
@@ -79,11 +56,8 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
               {NOT_AVAILABLE}
             </Text>
           )}
-        </StyledGridRow>
-        <StyledGridRow>
-          <Text size="xl" strong>
-            Mastercopy:{' '}
-          </Text>
+        </TxDataRow>
+        <TxDataRow title="Mastercopy:" value={null}>
           {txInfo.implementation ? (
             <PrefixedEthHashInfo
               textSize="xl"
@@ -99,10 +73,10 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
               {NOT_AVAILABLE}
             </Text>
           )}
-        </StyledGridRow>
+        </TxDataRow>
       </div>
-      <StyledPadding></StyledPadding>
-      {/* <div className="tx-owners" /> */}
+      {/* filler */}
+      <StyledPadding />
     </TxDetailsContainer>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
@@ -5,10 +5,15 @@ import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'
 import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { NOT_AVAILABLE } from './utils'
-import { InlineEthHashInfo, TxDetailsContainer } from './styled'
+import { InlineEthHashInfo, TxDetailsContainer, StyledGridRow } from './styled'
 import { Creation } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useKnownAddress } from './hooks/useKnownAddress'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
+import styled from 'styled-components'
+
+const StyledPadding = styled.div`
+  background-color: ${({ theme }) => theme.colors.white};
+`
 
 export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): ReactElement => {
   const txInfo = transaction.txInfo as Creation
@@ -21,7 +26,7 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
   return (
     <TxDetailsContainer>
       <div className="tx-summary">
-        <div className="tx-hash">
+        <StyledGridRow>
           <Text size="xl" strong as="span">
             Transaction hash:{' '}
           </Text>
@@ -32,18 +37,16 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
             showCopyBtn
             explorerUrl={getExplorerInfo(txInfo.transactionHash)}
           />
-        </div>
-        <div className="tx-created">
+        </StyledGridRow>
+        <StyledGridRow>
           <Text size="xl" strong as="span">
             Created:{' '}
           </Text>
           <Text size="xl" as="span">
             {formatDateTime(timestamp)}
           </Text>
-        </div>
-      </div>
-      <div className="tx-details">
-        <div className="tx-creator">
+        </StyledGridRow>
+        <StyledGridRow>
           <Text size="xl" strong>
             Creator:{' '}
           </Text>
@@ -56,8 +59,8 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
             customAvatar={creator.logoUri || undefined}
             showAvatar
           />
-        </div>
-        <div className="tx-factory">
+        </StyledGridRow>
+        <StyledGridRow>
           <Text size="xl" strong>
             Factory:{' '}
           </Text>
@@ -76,8 +79,8 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
               {NOT_AVAILABLE}
             </Text>
           )}
-        </div>
-        <div className="tx-mastercopy">
+        </StyledGridRow>
+        <StyledGridRow>
           <Text size="xl" strong>
             Mastercopy:{' '}
           </Text>
@@ -96,9 +99,10 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
               {NOT_AVAILABLE}
             </Text>
           )}
-        </div>
+        </StyledGridRow>
       </div>
-      <div className="tx-owners" />
+      <StyledPadding></StyledPadding>
+      {/* <div className="tx-owners" /> */}
     </TxDetailsContainer>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoCreation.tsx
@@ -29,7 +29,7 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
       <div className="tx-summary">
         <TxDataRow title="Transaction hash:" value={txInfo.transactionHash} inlineType="hash" />
         <TxDataRow title="Created:" value={formatDateTime(timestamp)} />
-        <TxDataRow title="Creator:" value={null}>
+        <TxDataRow title="Creator:">
           <PrefixedEthHashInfo
             textSize="xl"
             hash={txInfo.creator.value}
@@ -40,7 +40,7 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
             showAvatar
           />
         </TxDataRow>
-        <TxDataRow title="Factory:" value={null}>
+        <TxDataRow title="Factory:">
           {txInfo.factory ? (
             <PrefixedEthHashInfo
               textSize="xl"
@@ -57,7 +57,7 @@ export const TxInfoCreation = ({ transaction }: { transaction: Transaction }): R
             </Text>
           )}
         </TxDataRow>
-        <TxDataRow title="Mastercopy:" value={null}>
+        <TxDataRow title="Mastercopy:">
           {txInfo.implementation ? (
             <PrefixedEthHashInfo
               textSize="xl"

--- a/src/routes/safe/components/Transactions/TxList/TxInfoMultiSend.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoMultiSend.tsx
@@ -1,9 +1,9 @@
 import { ReactElement } from 'react'
 import { MultiSend } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Text } from '@gnosis.pm/safe-react-components'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { getExplorerInfo } from 'src/config'
 import { InfoDetails } from './InfoDetails'
+import { TxDataRow } from './TxDataRow'
 
 // Does not use AddressInfo as to not allow address book data display
 // as we use backend data to verify the deligate call
@@ -22,12 +22,7 @@ const TxInfoMultiSend = ({ txInfo }: { txInfo: MultiSend }): ReactElement => {
         showCopyBtn
         explorerUrl={getExplorerInfo(hash)}
       />
-      <Text size="xl" strong as="span">
-        Value:{' '}
-      </Text>
-      <Text size="xl" as="span">
-        {value}
-      </Text>
+      <TxDataRow title="Value:" value={value} />
     </InfoDetails>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxInfoMultiSend.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoMultiSend.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react'
 import { MultiSend } from '@gnosis.pm/safe-react-gateway-sdk'
+import { Text } from '@gnosis.pm/safe-react-components'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { getExplorerInfo } from 'src/config'
 import { InfoDetails } from './InfoDetails'
@@ -10,6 +11,7 @@ const TxInfoMultiSend = ({ txInfo }: { txInfo: MultiSend }): ReactElement => {
   const hash = txInfo?.to.value
   const name = txInfo.to?.name || undefined
   const customAvatar = txInfo.to?.logoUri || undefined
+  const value = txInfo?.value
   return (
     <InfoDetails title="MultiSend contract:">
       <PrefixedEthHashInfo
@@ -20,6 +22,12 @@ const TxInfoMultiSend = ({ txInfo }: { txInfo: MultiSend }): ReactElement => {
         showCopyBtn
         explorerUrl={getExplorerInfo(hash)}
       />
+      <Text size="xl" strong as="span">
+        Value:{' '}
+      </Text>
+      <Text size="xl" as="span">
+        {value}
+      </Text>
     </InfoDetails>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -40,6 +40,7 @@ const FlexWrapper = styled.div<{ margin: number }>`
 `
 
 export const TxSummary = ({ txDetails }: Props): ReactElement => {
+  console.log('TxSummary', txDetails)
   const { txHash, detailedExecutionInfo, executedAt, txData, txInfo } = txDetails
   const explorerUrl = txHash ? getExplorerInfo(txHash) : undefined
 
@@ -121,13 +122,13 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
       </div>
       <br></br>
       {/* TODO: Refactor repeated code to a component*/}
-      {txData?.operation && (
+      {txData?.operation !== undefined && (
         <StyledGridRow>
           <Text size="xl" as="span">
             Operation:
           </Text>
           <Text size="xl" as="span">
-            {txData?.operation}
+            {`${txData?.operation} (${Operation[txData?.operation].toLowerCase()})`}
           </Text>
         </StyledGridRow>
       )}

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@gnosis.pm/safe-react-components'
+import { CopyToClipboardBtn, Text } from '@gnosis.pm/safe-react-components'
 import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement } from 'react'
 
@@ -16,15 +16,55 @@ import TxShareButton from './TxShareButton'
 import { IS_PRODUCTION } from 'src/utils/constants'
 import TxInfoMultiSend from './TxInfoMultiSend'
 import DelegateCallWarning from './DelegateCallWarning'
+import styled from 'styled-components'
+import { getByteLength } from 'src/components/DecodeTxs' // must pass to utils
+import { generateSignaturesFromTxConfirmations } from 'src/logic/safe/safeTxSigner'
+import { makeConfirmation } from 'src/logic/safe/store/models/confirmation'
 
 type Props = { txDetails: ExpandedTxDetails }
+
+const StyledGridRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  justify-content: flex-start;
+  max-width: 480px;
+`
+
+const FlexWrapper = styled.div<{ margin: number }>`
+  display: flex;
+  align-items: center;
+
+  > :nth-child(2) {
+    margin-left: ${({ margin }) => margin}px;
+  }
+`
 
 export const TxSummary = ({ txDetails }: Props): ReactElement => {
   const { txHash, detailedExecutionInfo, executedAt, txData, txInfo } = txDetails
   const explorerUrl = txHash ? getExplorerInfo(txHash) : undefined
-  const nonce = isMultiSigExecutionDetails(detailedExecutionInfo) ? detailedExecutionInfo.nonce : undefined
-  const created = isMultiSigExecutionDetails(detailedExecutionInfo) ? detailedExecutionInfo.submittedAt : undefined
-  const safeTxHash = isMultiSigExecutionDetails(detailedExecutionInfo) ? detailedExecutionInfo.safeTxHash : undefined
+
+  let created, confirmations, safeTxHash, baseGas, gasPrice, gasToken, refundReceiver, safeTxGas
+  if (isMultiSigExecutionDetails(detailedExecutionInfo)) {
+    // prettier-ignore
+    ({
+      submittedAt: created,
+      confirmations,
+      safeTxHash,
+      baseGas,
+      gasPrice,
+      gasToken,
+      safeTxGas,
+    } = detailedExecutionInfo)
+    refundReceiver = detailedExecutionInfo.refundReceiver?.value
+  }
+
+  let signaturesFromConfirmations
+  if (confirmations && confirmations?.length > 0) {
+    const signatures = confirmations?.map(({ signer, signature }) =>
+      makeConfirmation({ owner: signer.value, signature }),
+    )
+    signaturesFromConfirmations = generateSignaturesFromTxConfirmations(signatures)
+  }
 
   return (
     <>
@@ -34,53 +74,145 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
         </div>
       )}
       <div className="tx-hash">
-        <Text size="xl" strong as="span">
-          Transaction hash:{' '}
-        </Text>
-        {txHash ? (
-          <InlineEthHashInfo textSize="xl" hash={txHash} shortenHash={8} showCopyBtn explorerUrl={explorerUrl} />
-        ) : (
+        <StyledGridRow>
           <Text size="xl" as="span">
-            {NOT_AVAILABLE}
+            Transaction hash:
           </Text>
-        )}
+          {txHash ? (
+            <InlineEthHashInfo textSize="xl" hash={txHash} shortenHash={8} showCopyBtn explorerUrl={explorerUrl} />
+          ) : (
+            <Text size="xl" as="span">
+              {NOT_AVAILABLE}
+            </Text>
+          )}
+        </StyledGridRow>
       </div>
-      {safeTxHash !== undefined && (
+      {safeTxHash && (
         <div className="tx-hash">
-          <Text size="xl" strong as="span">
-            SafeTxHash:{' '}
-          </Text>
-          <InlineEthHashInfo textSize="xl" hash={safeTxHash} shortenHash={8} showCopyBtn />
-        </div>
-      )}
-      {nonce !== undefined && (
-        <div className="tx-nonce">
-          <Text size="xl" strong as="span">
-            Nonce:{' '}
-          </Text>
-          <Text size="xl" as="span">
-            {nonce}
-          </Text>
+          <StyledGridRow>
+            <Text size="xl" as="span">
+              SafeTxHash:
+            </Text>
+            <InlineEthHashInfo textSize="xl" hash={safeTxHash} shortenHash={8} showCopyBtn />
+          </StyledGridRow>
         </div>
       )}
       {created && (
         <div className="tx-created">
-          <Text size="xl" strong as="span">
-            Created:{' '}
-          </Text>
-          <Text size="xl" as="span">
-            {formatDateTime(created)}
-          </Text>
+          <StyledGridRow>
+            <Text size="xl" as="span">
+              Created:
+            </Text>
+            <Text size="xl" as="span">
+              {formatDateTime(created)}
+            </Text>
+          </StyledGridRow>
         </div>
       )}
       <div className="tx-executed">
-        <Text size="xl" strong as="span">
-          Executed:{' '}
-        </Text>
-        <Text size="xl" as="span">
-          {executedAt ? formatDateTime(executedAt) : NOT_AVAILABLE}
-        </Text>
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            Executed:
+          </Text>
+          <Text size="xl" as="span">
+            {executedAt ? formatDateTime(executedAt) : NOT_AVAILABLE}
+          </Text>
+        </StyledGridRow>
       </div>
+      <br></br>
+      {/* TODO: Refactor repeated code to a component*/}
+      {txData?.operation && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            Operation:
+          </Text>
+          <Text size="xl" as="span">
+            {txData?.operation}
+          </Text>
+        </StyledGridRow>
+      )}
+      {safeTxGas && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            safeTxGas:
+          </Text>
+          <Text size="xl" as="span">
+            {safeTxGas}
+          </Text>
+        </StyledGridRow>
+      )}
+      {baseGas && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            baseGas:
+          </Text>
+          <Text size="xl" as="span">
+            {baseGas}
+          </Text>
+        </StyledGridRow>
+      )}
+      {gasPrice && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            gasPrice:
+          </Text>
+          <Text size="xl" as="span">
+            {gasPrice}
+          </Text>
+        </StyledGridRow>
+      )}
+      {gasToken && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            gasToken:
+          </Text>
+          <Text size="xl" as="span">
+            <InlineEthHashInfo textSize="xl" hash={gasToken} shortenHash={8} showCopyBtn />
+          </Text>
+        </StyledGridRow>
+      )}
+      {refundReceiver && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            refundReceiver:
+          </Text>
+          <Text size="xl" as="span">
+            <InlineEthHashInfo textSize="xl" hash={refundReceiver} shortenHash={8} showCopyBtn />
+          </Text>
+        </StyledGridRow>
+      )}
+      {confirmations?.map(({ signature }, index) => (
+        <StyledGridRow key={index}>
+          <Text size="xl" as="span">
+            {`Signature ${index} :`}
+          </Text>
+          <Text size="xl" as="span">
+            <InlineEthHashInfo textSize="xl" hash={signature} shortenHash={8} showCopyBtn />
+          </Text>
+        </StyledGridRow>
+      ))}
+      {confirmations?.length > 1 && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            {`Signatures :`}
+          </Text>
+          <FlexWrapper margin={5}>
+            <Text size="xl">{signaturesFromConfirmations ? getByteLength(signaturesFromConfirmations) : 0} bytes</Text>
+            <CopyToClipboardBtn textToCopy={signaturesFromConfirmations || ''} />
+          </FlexWrapper>
+        </StyledGridRow>
+      )}
+      {txData?.hexData && (
+        <StyledGridRow>
+          <Text size="xl" as="span">
+            Raw data:
+          </Text>
+          <FlexWrapper margin={5}>
+            <Text size="xl">{txData?.hexData ? getByteLength(txData?.hexData) : 0} bytes</Text>
+            <CopyToClipboardBtn textToCopy={txData?.hexData || ''} />
+          </FlexWrapper>
+        </StyledGridRow>
+      )}
       {txData?.operation === Operation.DELEGATE && (
         <div className="tx-operation">
           <DelegateCallWarning isKnown={isCustomTxInfo(txInfo) && !!txInfo?.to?.name} />

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -1,8 +1,6 @@
-import { CopyToClipboardBtn, Text } from '@gnosis.pm/safe-react-components'
 import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement } from 'react'
 
-import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'
 import {
   ExpandedTxDetails,
@@ -10,51 +8,16 @@ import {
   isMultiSendTxInfo,
   isMultiSigExecutionDetails,
 } from 'src/logic/safe/store/models/types/gateway.d'
-import { InlineEthHashInfo, StyledGridRow } from './styled'
 import { NOT_AVAILABLE } from './utils'
 import TxShareButton from './TxShareButton'
 import { IS_PRODUCTION } from 'src/utils/constants'
 import TxInfoMultiSend from './TxInfoMultiSend'
 import DelegateCallWarning from './DelegateCallWarning'
-import styled from 'styled-components'
-import { getByteLength } from 'src/components/DecodeTxs' // must pass to utils
 import { generateSignaturesFromTxConfirmations } from 'src/logic/safe/safeTxSigner'
 import { makeConfirmation } from 'src/logic/safe/store/models/confirmation'
+import { TxDataRow } from './TxDataRow'
 
 type Props = { txDetails: ExpandedTxDetails }
-
-const FlexWrapper = styled.div<{ margin: number }>`
-  display: flex;
-  align-items: center;
-
-  > :nth-child(2) {
-    margin-left: ${({ margin }) => margin}px;
-  }
-`
-
-type TxDataRowType = { inlineType?: 'hash' | 'rawData'; title: string; value: string }
-
-const TxDataRow = ({ inlineType, title, value }: TxDataRowType) => (
-  <StyledGridRow>
-    <Text size="xl" as="span">
-      {title}
-    </Text>
-    {inlineType === 'hash' && (
-      <InlineEthHashInfo textSize="xl" hash={value} shortenHash={8} showCopyBtn explorerUrl={getExplorerInfo(value)} />
-    )}
-    {inlineType === 'rawData' && (
-      <FlexWrapper margin={5}>
-        <Text size="xl">{value ? getByteLength(value) : 0} bytes</Text>
-        <CopyToClipboardBtn textToCopy={value || ''} />
-      </FlexWrapper>
-    )}
-    {!inlineType && (
-      <Text size="xl" as="span">
-        {value}
-      </Text>
-    )}
-  </StyledGridRow>
-)
 
 export const TxSummary = ({ txDetails }: Props): ReactElement => {
   const { txHash, detailedExecutionInfo, executedAt, txData, txInfo } = txDetails
@@ -75,7 +38,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
   }
 
   let signaturesFromConfirmations
-  if (confirmations && confirmations?.length > 0) {
+  if (confirmations?.length > 0) {
     const signatures = confirmations?.map(({ signer, signature }) =>
       makeConfirmation({ owner: signer.value, signature }),
     )
@@ -97,18 +60,15 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
 
       {/* Advanced TxData */}
       {txData?.operation !== undefined && (
-        <TxDataRow title="Operation:" value={`${txData?.operation} (${Operation[txData?.operation].toLowerCase()})`} />
+        <TxDataRow title="Operation:" value={`${txData?.operation} (${Operation[txData.operation].toLowerCase()})`} />
       )}
       {safeTxGas && <TxDataRow title="safeTxGas:" value={safeTxGas} />}
       {baseGas && <TxDataRow title="baseGas:" value={baseGas} />}
       {gasPrice && <TxDataRow title="gasPrice:" value={gasPrice} />}
       {gasToken && <TxDataRow title="gasToken:" value={gasToken} inlineType="hash" />}
       {refundReceiver && <TxDataRow title="refundReceiver:" value={refundReceiver} inlineType="hash" />}
-      {confirmations?.map(({ signature }, index) => (
-        <TxDataRow title={`Signature ${index + 1} :`} value={signature} inlineType="rawData" key={index} />
-      ))}
       {confirmations?.length > 1 && (
-        <TxDataRow title="Signatures :" value={signaturesFromConfirmations} inlineType="rawData" />
+        <TxDataRow title="Signatures:" value={signaturesFromConfirmations} inlineType="rawData" />
       )}
       {txData?.hexData && <TxDataRow title="Raw data:" value={txData?.hexData} inlineType="rawData" />}
       {txData?.operation === Operation.DELEGATE && (

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -39,7 +39,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
 
   let signaturesFromConfirmations
   if (confirmations?.length > 0) {
-    const signatures = confirmations?.map(({ signer, signature }) =>
+    const signatures = confirmations.map(({ signer, signature }) =>
       makeConfirmation({ owner: signer.value, signature }),
     )
     signaturesFromConfirmations = generateSignaturesFromTxConfirmations(signatures)

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -40,7 +40,6 @@ const FlexWrapper = styled.div<{ margin: number }>`
 `
 
 export const TxSummary = ({ txDetails }: Props): ReactElement => {
-  console.log('TxSummary', txDetails)
   const { txHash, detailedExecutionInfo, executedAt, txData, txInfo } = txDetails
   const explorerUrl = txHash ? getExplorerInfo(txHash) : undefined
 
@@ -185,7 +184,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
       {confirmations?.map(({ signature }, index) => (
         <StyledGridRow key={index}>
           <Text size="xl" as="span">
-            {`Signature ${index} :`}
+            {`Signature ${index + 1} :`}
           </Text>
           <Text size="xl" as="span">
             <InlineEthHashInfo textSize="xl" hash={signature} shortenHash={8} showCopyBtn />

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -53,7 +53,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
         </div>
       )}
       {txHash && <TxDataRow title="Transaction hash:" value={txHash} inlineType="hash" />}
-      {safeTxHash && <TxDataRow title="SafeTxHash:" value={safeTxHash} inlineType="hash" />}
+      {safeTxHash && <TxDataRow title="SafeTxHash:" value={safeTxHash} inlineType="hash" hasExplorer={false} />}
       {created && <TxDataRow title="Created:" value={formatDateTime(created)} />}
       <TxDataRow title="Executed:" value={executedAt ? formatDateTime(executedAt) : NOT_AVAILABLE} />
       <br></br>

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -10,7 +10,7 @@ import {
   isMultiSendTxInfo,
   isMultiSigExecutionDetails,
 } from 'src/logic/safe/store/models/types/gateway.d'
-import { InlineEthHashInfo } from './styled'
+import { InlineEthHashInfo, StyledGridRow } from './styled'
 import { NOT_AVAILABLE } from './utils'
 import TxShareButton from './TxShareButton'
 import { IS_PRODUCTION } from 'src/utils/constants'
@@ -22,13 +22,6 @@ import { generateSignaturesFromTxConfirmations } from 'src/logic/safe/safeTxSign
 import { makeConfirmation } from 'src/logic/safe/store/models/confirmation'
 
 type Props = { txDetails: ExpandedTxDetails }
-
-const StyledGridRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  justify-content: flex-start;
-  max-width: 500px;
-`
 
 const FlexWrapper = styled.div<{ margin: number }>`
   display: flex;
@@ -112,7 +105,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
       {gasToken && <TxDataRow title="gasToken:" value={gasToken} inlineType="hash" />}
       {refundReceiver && <TxDataRow title="refundReceiver:" value={refundReceiver} inlineType="hash" />}
       {confirmations?.map(({ signature }, index) => (
-        <TxDataRow title={`Signature ${index + 1} :`} value={signature} inlineType="hash" key={index} />
+        <TxDataRow title={`Signature ${index + 1} :`} value={signature} inlineType="rawData" key={index} />
       ))}
       {confirmations?.length > 1 && (
         <TxDataRow title="Signatures :" value={signaturesFromConfirmations} inlineType="rawData" />

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -60,17 +60,17 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
 
       {/* Advanced TxData */}
       {txData?.operation !== undefined && (
-        <TxDataRow title="Operation:" value={`${txData?.operation} (${Operation[txData.operation].toLowerCase()})`} />
+        <TxDataRow title="Operation:" value={`${txData.operation} (${Operation[txData.operation].toLowerCase()})`} />
       )}
       {safeTxGas && <TxDataRow title="safeTxGas:" value={safeTxGas} />}
       {baseGas && <TxDataRow title="baseGas:" value={baseGas} />}
       {gasPrice && <TxDataRow title="gasPrice:" value={gasPrice} />}
       {gasToken && <TxDataRow title="gasToken:" value={gasToken} inlineType="hash" />}
       {refundReceiver && <TxDataRow title="refundReceiver:" value={refundReceiver} inlineType="hash" />}
-      {confirmations?.length > 1 && (
+      {confirmations?.length > 0 && (
         <TxDataRow title="Signatures:" value={signaturesFromConfirmations} inlineType="rawData" />
       )}
-      {txData?.hexData && <TxDataRow title="Raw data:" value={txData?.hexData} inlineType="rawData" />}
+      {txData?.hexData && <TxDataRow title="Raw data:" value={txData.hexData} inlineType="rawData" />}
       {txData?.operation === Operation.DELEGATE && (
         <div className="tx-operation">
           <DelegateCallWarning isKnown={isCustomTxInfo(txInfo) && !!txInfo?.to?.name} />

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -384,13 +384,7 @@ export const TxDetailsContainer = styled.div`
 
   .tx-owners {
     padding: 24px;
-    /* grid-column-start: 2;
-    grid-row-start: 1; */
     grid-row-end: span 2;
-
-    &.no-owner {
-      /* grid-row-end: span 3; */
-    }
   }
 
   .tx-details-actions {

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -345,18 +345,24 @@ export const TxDetailsContainer = styled.div`
   background-color: ${({ theme }) => theme.colors.separator} !important;
   column-gap: 2px;
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-auto-rows: minmax(min-content, max-content);
-  grid-template-rows: [tx-summary] minmax(min-content, max-content) [tx-details] minmax(min-content, 1fr);
+  grid-template-columns: 2fr 1fr;
   row-gap: 2px;
   width: 100%;
 
   & > div {
-    background-color: ${({ theme }) => theme.colors.white};
+    display: grid;
+    grid-auto-rows: minmax(min-content, max-content);
+    grid-template-rows: [tx-summary] minmax(min-content, max-content) [tx-details] minmax(min-content, 1fr);
+    background-color: ${({ theme }) => theme.colors.separator};
     line-break: anywhere;
     overflow: hidden;
-    padding: 20px 24px;
     word-break: break-all;
+    gap: 2px;
+
+    & > div {
+      padding: 20px 24px;
+      background-color: ${({ theme }) => theme.colors.white};
+    }
   }
 
   .tx-summary {
@@ -378,24 +384,23 @@ export const TxDetailsContainer = styled.div`
 
   .tx-owners {
     padding: 24px;
-    grid-column-start: 2;
+    /* grid-column-start: 2;
+    grid-row-start: 1; */
     grid-row-end: span 2;
-    grid-row-start: 1;
 
     &.no-owner {
-      grid-row-end: span 3;
+      /* grid-row-end: span 3; */
     }
   }
 
   .tx-details-actions {
-    align-items: center;
+    align-items: flex-end;
     display: flex;
-    height: 60px;
+    gap: 8px;
     justify-content: center;
 
     button {
       color: ${({ theme }) => theme.colors.white};
-      margin: 0 8px;
 
       &:hover {
         color: ${({ theme }) => theme.colors.white};

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -353,7 +353,6 @@ export const TxDetailsContainer = styled.div`
     display: grid;
     grid-auto-rows: minmax(min-content, max-content);
     grid-template-rows: [tx-summary] minmax(min-content, max-content) [tx-details] minmax(min-content, 1fr);
-    background-color: ${({ theme }) => theme.colors.separator};
     line-break: anywhere;
     overflow: hidden;
     word-break: break-all;
@@ -366,6 +365,7 @@ export const TxDetailsContainer = styled.div`
   }
 
   .tx-summary {
+    background-color: ${({ theme }) => theme.colors.white};
   }
 
   .tx-share {
@@ -548,4 +548,10 @@ export const NoTransactions = styled.div`
   display: flex;
   flex-direction: column;
   margin-top: 60px;
+`
+export const StyledGridRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  justify-content: flex-start;
+  max-width: 500px;
 `

--- a/src/utils/getByteLength.ts
+++ b/src/utils/getByteLength.ts
@@ -1,0 +1,16 @@
+import { hexToBytes } from 'web3-utils'
+
+export const getByteLength = (data: string | string[]): number => {
+  try {
+    if (!Array.isArray(data)) {
+      data = data.split(',')
+    }
+    // Return the sum of the byte sizes of each hex string
+    return data.reduce((result, hex) => {
+      const bytes = hexToBytes(hex)
+      return result + bytes.length
+    }, 0)
+  } catch (err) {
+    return 0
+  }
+}


### PR DESCRIPTION
## What it solves
Resolves #2989

## How this PR fixes it
Now it should be possible to verify advanced Tx data in all types of transactions:

- safeTxHash
- nonce
- to
- value
- raw data - no need to display in full, being able to copy is sufficient
- operation
- safeTxGas
- baseGas
- gasPrice
- gasToken
- refundReceiver
- signatures

## How to test it
Go to the Transactions list.
Click on one of the entries.
The transactions details (queued/history) shall display the Tx advanced info

## Screenshots
![Screen Shot 2021-12-16 at 11 09 28](https://user-images.githubusercontent.com/32431609/146352276-f68ba392-8f96-43ad-927c-afa497708d4d.png)
![Screen Shot 2021-12-16 at 11 10 06](https://user-images.githubusercontent.com/32431609/146352279-0c99b5ca-e4ba-4bba-a1c1-68bc95de7431.png)
![Screen Shot 2021-12-16 at 11 10 20](https://user-images.githubusercontent.com/32431609/146352281-fe8a7279-f2d9-4bc8-8188-9c07c9fa86d0.png)
![Screen Shot 2021-12-16 at 11 11 10](https://user-images.githubusercontent.com/32431609/146352282-1f5d110f-bed4-4352-a049-9834ceb0065d.png)

