### PR TITLE
Chore: configurable GATEWAY_URL

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -42,4 +42,7 @@ const isProdGateway = () => {
 }
 
 export const GATEWAY_URL =
-  IS_PRODUCTION || isProdGateway() ? 'https://safe-client.gnosis.io/v1' : 'https://safe-client.staging.gnosisdev.com/v1'
+  process.env.GATEWAY_URL ||
+  (IS_PRODUCTION || isProdGateway()
+    ? 'https://safe-client.gnosis.io/v1'
+    : 'https://safe-client.staging.gnosisdev.com/v1')


### PR DESCRIPTION
## What it solves
Resolves #

## How this PR fixes it
If one wants to run his own stack of gnosis infra I think it needs to override GATEWAY_URL in safe-react.
## How to test it

## Screenshots
