### PR TITLE
fix: prefix envs with REACT_APP_

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,7 +20,7 @@ export const SAFE_POLLING_INTERVAL = process.env.NODE_ENV === 'test' ? 4500 : 15
 export const ETHERSCAN_API_KEY = process.env.REACT_APP_ETHERSCAN_API_KEY || ''
 export const ETHGASSTATION_API_KEY = process.env.REACT_APP_ETHGASSTATION_API_KEY
 export const CONFIG_SERVICE_URL =
-  process.env.CONFIG_SERVICE_URL || IS_PRODUCTION
+  process.env.REACT_APP_CONFIG_SERVICE_URL || IS_PRODUCTION
     ? 'https://safe-config.gnosis.io/api/v1'
     : 'https://safe-config.staging.gnosisdev.com/api/v1'
 export const IPFS_GATEWAY = process.env.REACT_APP_IPFS_GATEWAY
@@ -42,7 +42,7 @@ const isProdGateway = () => {
 }
 
 export const GATEWAY_URL =
-  process.env.GATEWAY_URL ||
+  process.env.REACT_APP_GATEWAY_URL ||
   (IS_PRODUCTION || isProdGateway()
     ? 'https://safe-client.gnosis.io/v1'
     : 'https://safe-client.staging.gnosisdev.com/v1')


### PR DESCRIPTION
## What it solves
Resolves #
React doesn't pick up env vars if not prefixed with `REACT_APP_`
## How this PR fixes it
adds prefixes REACT_APP_ to `GATEWAY_URL` and `CONFIG_SERVICE_URL`
## How to test it

## Screenshots
