### PR TITLE
Fix: wrong keys after migration 🔥

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/components/StoreMigrator/index.tsx
+++ b/src/components/StoreMigrator/index.tsx
@@ -28,6 +28,23 @@ const StoreMigrator = (): ReactElement | null => {
     setNetworksToMigrate(remainingNetworks)
   }, [])
 
+  // Fix broken keys that start with v2_
+  useEffect(() => {
+    try {
+      Object.keys(localStorage).forEach((key) => {
+        if (key.startsWith('v2_')) {
+          const val = localStorage.getItem(key)
+          localStorage.removeItem(key)
+          if (val) {
+            localStorage.setItem(`_immortal|${key}`, val)
+          }
+        }
+      })
+    } catch (err) {
+      // ignore
+    }
+  }, [])
+
   // Add an event listener to receive the data to be migrated and save it into the storage
   useEffect(() => {
     if (!currentNetwork) return

--- a/src/logic/safe/utils/mocks/remoteConfig.json
+++ b/src/logic/safe/utils/mocks/remoteConfig.json
@@ -65,62 +65,6 @@
       ]
     },
     {
-      "transactionService": "https://safe-transaction.avalanche.gnosis.io",
-      "chainId": "43114",
-      "chainName": "Avalanche",
-      "shortName": "Avalanche",
-      "l2": true,
-      "description": "",
-      "rpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "safeAppsRpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "publicRpcUri": {
-        "authentication": "NO_AUTHENTICATION",
-        "value": "https://api.avax.network/ext/bc/C/rpc"
-      },
-      "blockExplorerUriTemplate": {
-        "address": "https://snowtrace.io/address/{{address}}",
-        "txHash": "https://snowtrace.io/tx/{{txHash}}",
-        "api": "https://api.snowtrace.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
-      },
-      "nativeCurrency": {
-        "name": "Avalanche",
-        "symbol": "AVAX",
-        "decimals": 18,
-        "logoUri": "https://safe-transaction-assets.staging.gnosisdev.com/chains/43114/currency_logo.png"
-      },
-      "theme": {
-        "textColor": "#ffffff",
-        "backgroundColor": "#e84142"
-      },
-      "gasPrice": [],
-      "disabledWallets": [
-        "authereum",
-        "fortmatic",
-        "keystone",
-        "lattice",
-        "opera",
-        "operaTouch",
-        "portis",
-        "torus",
-        "trezor",
-        "trust"
-      ],
-      "features": [
-        "CONTRACT_INTERACTION",
-        "DOMAIN_LOOKUP",
-        "EIP1559",
-        "ERC721",
-        "SAFE_APPS",
-        "SAFE_TX_GAS_OPTIONAL"
-      ]
-    },
-    {
       "transactionService": "https://safe-transaction-polygon.staging.gnosisdev.com",
       "chainId": "137",
       "chainName": "Polygon",
@@ -168,7 +112,6 @@
         "fortmatic",
         "keystone",
         "lattice",
-        "ledger",
         "opera",
         "operaTouch",
         "portis",

--- a/src/utils/storage/index.ts
+++ b/src/utils/storage/index.ts
@@ -41,5 +41,5 @@ export const removeFromStorage = async (key: string): Promise<void> => {
 
 // This function is only meant to be used in L2-UX migration to gather information from other networks
 export const saveMigratedKeyToStorage = async <T = unknown>(key: string, value: T): Promise<void> => {
-  storage.setItem(key, value)
+  storage.setItem(`_immortal|${key}`, value)
 }


### PR DESCRIPTION
## What it solves
After the [localStorage refactoring](https://github.com/gnosis/safe-react/commit/134c787c76b7ef073264fe84c19aeadb953f71d9#diff-74d715bc7b3f7d56dd1259d277cfef3dbebdc48b65bd8a019adc6477e122060c) and removal of ImmortalDB, the L2-UX migration became broken.

<img width="614" alt="Screenshot 2021-12-21 at 11 25 25" src="https://user-images.githubusercontent.com/381895/146918119-c89ec279-81eb-4649-be94-471e49569bdd.png">

## How this PR fixes it
* Renames the `v2_` keys to `_immortal|v2_` to fix existing broken data
* Adds the correct prefix so that new migrations are correct

## How to test it
**Case 1 (no prior migration):**
* Run app on localhost:3001 and open some L2 chain on there 
* Run another version of the app on localhost:3000, open mainnet
* Clear localStorage and refresh
* It should migrate data from localhost:3001

**Case 2 (with prior broken migration):**
* Run app on localhost:3001
* Run another version of the app on localhost:3000 on commit before this fix, open mainnet
* Clear localStorage and refresh
* Migration should happen but keys will be broken (v2_)
* After this commit, these keys should be renamed to `_immortal|v2_`
