### PR TITLE
Make the Electron server listen only on localhost instead of on all interfaces

### DIFF
--- a/public/electron.ts
+++ b/public/electron.ts
@@ -28,7 +28,7 @@ function createServer(port: number): void {
   const staticRoute = path.join(__dirname, '../build')
 
   app.use(express.static(staticRoute))
-  https.createServer(options, app).listen(port)
+  https.createServer(options, app).listen(port, '127.0.0.1')
 }
 
 let mainWindow


### PR DESCRIPTION

## What it solves
Only the Electron application needs to access the server it creates in: https://github.com/gnosis/safe-react/blob/8815f8bee61acf5db5a8c0c6aa4277cb1e13a82c/public/electron.ts#L31

So, the server should only be exposed localhost.

## How this PR fixes it
This PR uses '127.0.0.1' as the second argument of the `listen` method to accomplish this.

## How to test it
Run `netstat -tulnp` to verify that worked.

Before:
```
tcp6       0      0 :::5000                 :::*                    LISTEN      81840/safe-react
```

After:
```
tcp        0      0 127.0.0.1:5000          0.0.0.0:*               LISTEN      84561/safe-react    
```