### PR TITLE
Pin the action-electron-builder action to a full commit hash instead of a tag

### DIFF
--- a/.github/workflows/release-mainnet-desktop.yml
+++ b/.github/workflows/release-mainnet-desktop.yml
@@ -47,7 +47,7 @@ jobs:
           # macOS notarization API key
           APPLEID: ${{ secrets.APPLE_ID }}
           APPLEIDPASS: ${{ secrets.APPLE_ID_PASS }}
-        uses: samuelmeuli/action-electron-builder@v1
+        uses: samuelmeuli/action-electron-builder@92327c67bc45ff7c38bf55d8aa8c4d75b7ea38e7
         with:
           #Build scipt
           build_script_name: build-desktop


### PR DESCRIPTION
## What it solves
This PR pins the action-electron-builder action to the full commit hash instead of the v1 tag. As [github states](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) pinning to tag has a risk, "because a tag can be moved or deleted if a bad actor gains access to the repository storing the action", i.e., the contents of the action can change. By using the full hash this cannot happen.

## How this PR fixes it
Changes the v1 tag to the corresponding commit hash. You can confirm the hash is correct here https://github.com/samuelmeuli/action-electron-builder/releases/tag/v1
