### PR TITLE
Allow certificates errors only for the Electron-created back end

### DIFF
--- a/public/electron.ts
+++ b/public/electron.ts
@@ -138,13 +138,24 @@ process.on('uncaughtException', function (error) {
 app.userAgentFallback =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) old-airport-include/1.0.0 Chrome Electron/11.3.0 Safari/537.36'
 
-app.commandLine.appendSwitch('ignore-certificate-errors')
 app.whenReady().then(async () => {
   // Hide the menu
   Menu.setApplicationMenu(null)
 
   const port = await getFreePort()
+
   if (!isDev) {
+    // Allow self-signed certificates only for the Electron-created localhost server
+    app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+      const parsedUrl = new URL(url)
+      if (parsedUrl.origin === `https://localhost:${port}`) {
+        event.preventDefault()
+        callback(true)
+      } else {
+        callback(false)
+      }
+    })
+
     createServer(port)
   }
 


### PR DESCRIPTION
## What it solves
This commit ensures that the Electron app allows only the Electron-created backend at https://localhost:5000 to have an invalid (self-signed) certificate.

## How this PR fixes it
Instead of appending `'ignore-certificate-errors'` to the command line, catch certificate errors and check the associated origin. 

Reference: https://www.electronjs.org/docs/latest/api/app#event-certificate-error