### PR TITLE
Fix: deeplinked, out of nonce order transactions allow confirmation 

### DIFF
--- a/src/logic/safe/store/reducer/gatewayTransactions.ts
+++ b/src/logic/safe/store/reducer/gatewayTransactions.ts
@@ -119,6 +119,10 @@ export const gatewayTransactionsReducer = handleActions<GatewayTransactionsState
           return
         }
 
+        if (!label) {
+          label = newNext[txNonce] ? 'next' : 'queued'
+        }
+
         const newTx = value.transaction
         if (label === 'queued') {
           if (newQueued?.[txNonce]) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -53,8 +53,7 @@ export const SAFE_ROUTES = {
   TRANSACTIONS: `${ADDRESSED_ROUTE}/transactions`,
   TRANSACTIONS_HISTORY: `${ADDRESSED_ROUTE}/transactions/history`,
   TRANSACTIONS_QUEUE: `${ADDRESSED_ROUTE}/transactions/queue`,
-  // RegExp route rejection, i.e. !history|queue does not work so it is important to have singular after the above two in Switches
-  TRANSACTIONS_SINGULAR: `${ADDRESSED_ROUTE}/transactions/:${TRANSACTION_ID_SLUG}(${hashRegExp}+)`, // [TRANSACTION_HASH_SLUG] === 'txId'
+  TRANSACTIONS_SINGULAR: `${ADDRESSED_ROUTE}/transactions/:${TRANSACTION_ID_SLUG}(${hashRegExp}+)`, // [TRANSACTION_HASH_SLUG] === 'safeTxHash'
   ADDRESS_BOOK: `${ADDRESSED_ROUTE}/address-book`,
   APPS: `${ADDRESSED_ROUTE}/apps`,
   SETTINGS: `${ADDRESSED_ROUTE}/settings`,

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -28,7 +28,7 @@ export const SAFE_SECTION_ROUTE = `${ADDRESSED_ROUTE}/:${SAFE_SECTION_SLUG}`
 export const SAFE_SUBSECTION_SLUG = 'safeSubsection'
 export const SAFE_SUBSECTION_ROUTE = `${SAFE_SECTION_ROUTE}/:${SAFE_SUBSECTION_SLUG}`
 
-export const TRANSACTION_ID_SLUG = `txId`
+export const TRANSACTION_ID_SLUG = `safeTxHash`
 
 // URL: gnosis-safe.io/app/:[SAFE_ADDRESS_SLUG]/:[SAFE_SECTION_SLUG]/:[SAFE_SUBSECTION_SLUG]
 export type SafeRouteSlugs = {
@@ -54,7 +54,7 @@ export const SAFE_ROUTES = {
   TRANSACTIONS_HISTORY: `${ADDRESSED_ROUTE}/transactions/history`,
   TRANSACTIONS_QUEUE: `${ADDRESSED_ROUTE}/transactions/queue`,
   // RegExp route rejection, i.e. !history|queue does not work so it is important to have singular after the above two in Switches
-  TRANSACTIONS_SINGULAR: `${ADDRESSED_ROUTE}/transactions/:${TRANSACTION_ID_SLUG}`, // [TRANSACTION_HASH_SLUG] === 'txId'
+  TRANSACTIONS_SINGULAR: `${ADDRESSED_ROUTE}/transactions/:${TRANSACTION_ID_SLUG}(${hashRegExp}+)`, // [TRANSACTION_HASH_SLUG] === 'txId'
   ADDRESS_BOOK: `${ADDRESSED_ROUTE}/address-book`,
   APPS: `${ADDRESSED_ROUTE}/apps`,
   SETTINGS: `${ADDRESSED_ROUTE}/settings`,

--- a/src/routes/safe/components/Transactions/TxList/TxShareButton.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxShareButton.tsx
@@ -6,13 +6,13 @@ import { getPrefixedSafeAddressSlug, SAFE_ADDRESS_SLUG, SAFE_ROUTES, TRANSACTION
 import { PUBLIC_URL } from 'src/utils/constants'
 
 type Props = {
-  id: string
+  safeTxHash: string
 }
 
-const TxShareButton = ({ id }: Props): ReactElement => {
+const TxShareButton = ({ safeTxHash }: Props): ReactElement => {
   const txDetailsPathname = generatePath(SAFE_ROUTES.TRANSACTIONS_SINGULAR, {
     [SAFE_ADDRESS_SLUG]: getPrefixedSafeAddressSlug(),
-    [TRANSACTION_ID_SLUG]: id,
+    [TRANSACTION_ID_SLUG]: safeTxHash,
   })
   const txDetailsLink = `${window.location.origin}${PUBLIC_URL}${txDetailsPathname}`
 

--- a/src/routes/safe/components/Transactions/TxList/TxSingularDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSingularDetails.tsx
@@ -5,7 +5,15 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { isTxQueued, TxLocation } from 'src/logic/safe/store/models/types/gateway.d'
-import { extractSafeAddress, SafeRouteSlugs, TRANSACTION_ID_SLUG } from 'src/routes/routes'
+import {
+  extractPrefixedSafeAddress,
+  extractSafeAddress,
+  generateSafeRoute,
+  SafeRouteSlugs,
+  SAFE_ROUTES,
+  TRANSACTION_ID_SLUG,
+  history,
+} from 'src/routes/routes'
 import { Centered } from './styled'
 import { getTransactionWithLocationByAttribute } from 'src/logic/safe/store/selectors/gatewayTransactions'
 import { TxLocationContext } from './TxLocationProvider'
@@ -54,6 +62,8 @@ const TxSingularDetails = (): ReactElement => {
     setFetchedTx(undefined)
 
     if (!safeTxHash) {
+      const txsRoute = generateSafeRoute(SAFE_ROUTES.TRANSACTIONS, extractPrefixedSafeAddress())
+      history.replace(txsRoute)
       return
     }
 

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -30,7 +30,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
     <>
       {!IS_PRODUCTION && isMultiSigExecutionDetails(txDetails.detailedExecutionInfo) && (
         <div className="tx-share">
-          <TxShareButton id={txDetails.detailedExecutionInfo.safeTxHash} />
+          <TxShareButton safeTxHash={txDetails.detailedExecutionInfo.safeTxHash} />
         </div>
       )}
       <div className="tx-hash">

--- a/src/routes/safe/components/Transactions/TxList/hooks/useQueueTransactions.ts
+++ b/src/routes/safe/components/Transactions/TxList/hooks/useQueueTransactions.ts
@@ -1,8 +1,12 @@
 import { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
+import { _getChainId } from 'src/config'
+import { loadQueuedTransactions } from 'src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions'
+import { addQueuedTransactions } from 'src/logic/safe/store/actions/transactions/gatewayTransactions'
 
 import { TransactionDetails } from 'src/logic/safe/store/models/types/gateway.d'
 import { nextTransactions, queuedTransactions } from 'src/logic/safe/store/selectors/gatewayTransactions'
+import { extractSafeAddress } from 'src/routes/routes'
 
 export type QueueTransactionsInfo = {
   next: TransactionDetails
@@ -15,6 +19,7 @@ export type QueueTransactionsInfo = {
 export const useQueueTransactions = (): QueueTransactionsInfo | undefined => {
   const nextTxs = useSelector(nextTransactions)
   const queuedTxs = useSelector(queuedTransactions)
+  const dispatch = useDispatch()
   const [txsCount, setTxsCount] = useState<{ next: number; queued: number } | undefined>()
 
   useEffect(() => {
@@ -24,6 +29,18 @@ export const useQueueTransactions = (): QueueTransactionsInfo | undefined => {
     const queued = queuedTxs
       ? Object.entries(queuedTxs).reduce((acc, [, transactions]) => (acc += transactions.length), 0)
       : 0
+
+    // If 'queued.queued' deeplinked tx was open then queue visited before next poll
+    const hasDeeplinkLoaded = next === 0 && queued === 1
+    if (hasDeeplinkLoaded) {
+      const getQueuedTxs = async () => {
+        const safeAddress = extractSafeAddress()
+        const values = await loadQueuedTransactions(safeAddress)
+        dispatch(addQueuedTransactions({ chainId: _getChainId(), safeAddress, values }))
+      }
+      getQueuedTxs()
+    }
+
     setTxsCount({ next, queued })
   }, [nextTxs, queuedTxs])
 

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -72,7 +72,6 @@ const Container = (): React.ReactElement => {
             SAFE_ROUTES.TRANSACTIONS,
             SAFE_ROUTES.TRANSACTIONS_HISTORY,
             SAFE_ROUTES.TRANSACTIONS_QUEUE,
-            // Must be below the above due to :txId slug recognising history/queue
             SAFE_ROUTES.TRANSACTIONS_SINGULAR,
           ]}
           render={() => wrapInSuspense(<TxList />, null)}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -43,6 +43,4 @@ const isProdGateway = () => {
 
 export const GATEWAY_URL =
   process.env.REACT_APP_GATEWAY_URL ||
-  (IS_PRODUCTION || isProdGateway()
-    ? 'https://safe-client.gnosis.io/v1'
-    : 'https://safe-client.staging.gnosisdev.com/v1')
+  (IS_PRODUCTION || isProdGateway() ? 'https://safe-client.gnosis.io' : 'https://safe-client.staging.gnosisdev.com')


### PR DESCRIPTION
## What it solves
Resolves #3204

## How this PR fixes it
Queued transactions were sometimes lacking a `label` and ythere was no distinguishment between `queued.next` and `queued.queued`. All unlabelled transactions were being deemed as `queued.next`, therefore showing the confirmation buttons.

Successfully labeled transactions then prevented due to the `txQueuedTag` conditional polling. Queued transactions are now manually requested if the deeplink inconsistency is present: a `queued.next` transaction does **not** exist, but a `queued.queued` does.

Note: deeplink slug names were also clarified as `safeTxHash` within the project and regex matching was included.

## How to test it
1. Create a queued transaction.
2. Create a second queued transaction.
3. The second should have a disabled confirm button.
4. Navigating back to the queued list, both queued transactions should load.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/147068329-37e02805-f9a8-4f4c-9fa3-e32d47c74d37.png)
