### PR TITLE
Reset to default chain if CGW doesn't return current chainId

### DIFF
--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -7,7 +7,7 @@ import App from 'src/components/App'
 import GlobalErrorBoundary from 'src/components/GlobalErrorBoundary'
 import AppRoutes from 'src/routes'
 import { store } from 'src/store'
-import { history } from 'src/routes/routes'
+import { history, WELCOME_ROUTE } from 'src/routes/routes'
 import theme from 'src/theme/mui'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import Providers from '../Providers'
@@ -36,14 +36,14 @@ const RootConsumer = (): React.ReactElement | null => {
     const initChains = async () => {
       try {
         await loadChains()
+        if (!isValidChainId(_getChainId())) {
+          setChainId(DEFAULT_CHAIN_ID)
+          history.push(WELCOME_ROUTE)
+        }
         setHasChains(true)
       } catch (err) {
         logError(Errors._904, err.message)
         setIsError(true)
-      } finally {
-        if (!isValidChainId(_getChainId())) {
-          setChainId(DEFAULT_CHAIN_ID)
-        }
       }
     }
     initChains()

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -18,6 +18,11 @@ import StoreMigrator from 'src/components/StoreMigrator'
 import LegacyRouteRedirection from './LegacyRouteRedirection'
 import { logError, Errors, CodedException } from 'src/logic/exceptions/CodedException'
 import { loadChains } from 'src/config/cache/chains'
+import { DEFAULT_CHAIN_ID } from 'src/utils/constants'
+import { useSelector } from 'react-redux'
+import { currentChainId } from 'src/logic/config/store/selectors'
+import { isValidChainId } from 'src/config'
+import { setChainId } from 'src/logic/config/utils'
 
 // Preloader is rendered outside of '#root' and acts as a loading spinner
 // for the app and then chains loading
@@ -26,6 +31,7 @@ const removePreloader = () => {
 }
 
 const RootConsumer = (): React.ReactElement | null => {
+  const chainId = useSelector(currentChainId)
   const [hasChains, setHasChains] = useState<boolean>(false)
   const [isError, setIsError] = useState<boolean>(false)
 
@@ -37,6 +43,11 @@ const RootConsumer = (): React.ReactElement | null => {
       } catch (err) {
         logError(Errors._904, err.message)
         setIsError(true)
+      } finally {
+        // If chain is not returned from CGW, revert to default
+        if (!isValidChainId(chainId)) {
+          setChainId(DEFAULT_CHAIN_ID)
+        }
       }
     }
     initChains()

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -7,20 +7,20 @@ import App from 'src/components/App'
 import GlobalErrorBoundary from 'src/components/GlobalErrorBoundary'
 import AppRoutes from 'src/routes'
 import { store } from 'src/store'
-import { getNetworkRootRoutes, history, ROOT_ROUTE } from 'src/routes/routes'
+import { history } from 'src/routes/routes'
 import theme from 'src/theme/mui'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import Providers from '../Providers'
+import './index.module.scss'
+import './OnboardCustom.module.scss'
+import './KeystoneCustom.module.scss'
 import StoreMigrator from 'src/components/StoreMigrator'
 import LegacyRouteRedirection from './LegacyRouteRedirection'
 import { logError, Errors, CodedException } from 'src/logic/exceptions/CodedException'
 import { loadChains } from 'src/config/cache/chains'
 import { isValidChainId, _getChainId } from 'src/config'
 import { DEFAULT_CHAIN_ID } from 'src/utils/constants'
-
-import './index.module.scss'
-import './OnboardCustom.module.scss'
-import './KeystoneCustom.module.scss'
+import { setChainId } from 'src/logic/config/utils'
 
 // Preloader is rendered outside of '#root' and acts as a loading spinner
 // for the app and then chains loading
@@ -41,14 +41,9 @@ const RootConsumer = (): React.ReactElement | null => {
         logError(Errors._904, err.message)
         setIsError(true)
       } finally {
-        if (isValidChainId(_getChainId())) {
-          return
+        if (!isValidChainId(_getChainId())) {
+          setChainId(DEFAULT_CHAIN_ID)
         }
-
-        // If chain is not returned from CGW, revert to default
-        const chainRoute =
-          getNetworkRootRoutes().find(({ chainId }) => chainId === DEFAULT_CHAIN_ID)?.chainId || ROOT_ROUTE
-        history.replace(chainRoute)
       }
     }
     initChains()

--- a/src/config/cache/chains.ts
+++ b/src/config/cache/chains.ts
@@ -8,7 +8,7 @@ let chains: ChainInfo[] = []
 export const getChains = (): ChainInfo[] => chains
 
 export const loadChains = async () => {
-  const { results = [] } = await getChainsConfig(GATEWAY_URL)
+  const { results = [] } = await getChainsConfig(GATEWAY_URL, { limit: 100 })
   chains = results
   // Set the initail web3 provider after loading chains
   setWeb3ReadOnly()


### PR DESCRIPTION
## What it solves
Connection issues when switching from production chain to staging CGW.

## How this PR fixes it
Checks the validity of the current `chainId` against the returned values from the CGW, setting it to default if it does not get returned.

## How to test it
1. Open the Safe on the prod. CGW and select a prod. only chain.
2. Switch to staging CGW and observe it defaulting to Rinkeby.