### PR TITLE
Increase backoff cap loading safe

### DIFF
--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -18,6 +18,11 @@ import StoreMigrator from 'src/components/StoreMigrator'
 import LegacyRouteRedirection from './LegacyRouteRedirection'
 import { logError, Errors, CodedException } from 'src/logic/exceptions/CodedException'
 import { loadChains } from 'src/config/cache/chains'
+import { DEFAULT_CHAIN_ID } from 'src/utils/constants'
+import { useSelector } from 'react-redux'
+import { currentChainId } from 'src/logic/config/store/selectors'
+import { isValidChainId } from 'src/config'
+import { setChainId } from 'src/logic/config/utils'
 
 // Preloader is rendered outside of '#root' and acts as a loading spinner
 // for the app and then chains loading
@@ -26,6 +31,7 @@ const removePreloader = () => {
 }
 
 const RootConsumer = (): React.ReactElement | null => {
+  const chainId = useSelector(currentChainId)
   const [hasChains, setHasChains] = useState<boolean>(false)
   const [isError, setIsError] = useState<boolean>(false)
 
@@ -37,6 +43,11 @@ const RootConsumer = (): React.ReactElement | null => {
       } catch (err) {
         logError(Errors._904, err.message)
         setIsError(true)
+      } finally {
+        // If chain is not returned from CGW, revert to default
+        if (!isValidChainId(chainId)) {
+          setChainId(DEFAULT_CHAIN_ID)
+        }
       }
     }
     initChains()

--- a/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
+++ b/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
@@ -158,8 +158,11 @@ function SafeCreationProcess(): ReactElement {
     // a default 5s wait before starting to request safe information
     await sleep(5000)
 
+    // exponential delay between attempts for around 4 min
     await backOff(() => getSafeInfo(newSafeAddress), {
       startingDelay: 750,
+      maxDelay: 20000,
+      numOfAttempts: 19,
       retry: (e) => {
         console.info('waiting for client-gateway to provide safe information', e)
         return true


### PR DESCRIPTION
## What it solves
Resolves #3078

## How this PR fixes it
Increases the backoff cap to 4 minutes.
Displays a message informing the user that the Safe failed to be retrieved from our services.

## How to test it
In the creating a safe flow, when clicking "Get Started", if the Safe loading fails a message should be displayed informing the user

## Screenshots
![Screen Shot 2021-12-29 at 19 18 06](https://user-images.githubusercontent.com/32431609/147691882-b15d97c3-b716-4e13-80e5-7eeda5a065a5.png)
![Screen Shot 2021-12-29 at 19 17 06](https://user-images.githubusercontent.com/32431609/147691822-ad54fd0c-15e1-4c5a-bdb2-d09bcaadab04.png)

