### PR TITLE
Fix: Use recommended nonce for already executed nonce message

### DIFF
--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -39,15 +39,6 @@ export const ReviewInfoText = ({
   const safeAddress = extractSafeAddress()
   const [recommendedNonce, setRecommendedNonce] = useState<string>(storeNextNonce)
 
-  const isTxNonceOutOfOrder = () => {
-    if (safeNonceNumber === nonce) return false
-    if (lastTxNonce !== undefined && safeNonceNumber === lastTxNonce + 1) return false
-    return true
-  }
-  const shouldShowWarning = isTxNonceOutOfOrder()
-
-  const transactionsToGo = safeNonceNumber - nonce
-
   useEffect(() => {
     const fetchRecommendedNonce = async () => {
       try {
@@ -61,28 +52,38 @@ export const ReviewInfoText = ({
   }, [safeAddress])
 
   const warningMessage = () => {
-    if (transactionsToGo < 0) {
-      return `Nonce ${safeNonce} has already been used. Your transaction will fail. Please use nonce ${recommendedNonce}.`
+    const isTxNonceOutOfOrder = () => {
+      if (safeNonceNumber === nonce) return false
+      if (lastTxNonce !== undefined && safeNonceNumber === lastTxNonce + 1) return false
+      return true
     }
+    const shouldShowWarning = isTxNonceOutOfOrder()
 
+    const transactionsToGo = safeNonceNumber - nonce
+
+    if (!shouldShowWarning) return null
     return (
-      <>
-        <Text size="lg" as="span" color="text" strong>
-          {transactionsToGo}
-        </Text>
-        {` transaction${transactionsToGo > 1 ? 's' : ''} will need to be created and executed before this transaction,
+      <Paragraph size="lg" align="center">
+        {transactionsToGo < 0 ? (
+          `Nonce ${safeNonce} has already been used. Your transaction will fail. Please use nonce ${recommendedNonce}.`
+        ) : (
+          <>
+            <Text size="lg" as="span" color="text" strong>
+              {transactionsToGo}
+            </Text>
+            {` transaction${
+              transactionsToGo > 1 ? 's' : ''
+            } will need to be created and executed before this transaction,
         are you sure you want to do this?`}
-      </>
+          </>
+        )}
+      </Paragraph>
     )
   }
 
   return (
     <ReviewInfoTextWrapper data-testid={testId}>
-      {shouldShowWarning ? (
-        <Paragraph size="lg" align="center">
-          {warningMessage()}
-        </Paragraph>
-      ) : (
+      {warningMessage() || (
         <TransactionFees
           gasCostFormatted={gasCostFormatted}
           isCreation={isCreation}


### PR DESCRIPTION
## What it solves
Resolves #3219

## How this PR fixes it
Suggests the **BE-services** recommended tx nonce when trying to create a tx with an already executed nonce

## How to test it
1. Start creating a transaction
2. Change the "Safe nonce" to an already executed nonce
3. You shall see the implemented warning message

## Screenshots
![Screen Shot 2021-12-30 at 14 14 35](https://user-images.githubusercontent.com/32431609/147755412-30235da6-2496-40e5-a23c-d6e3df52fe09.png)

