### PR TITLE
Fix: redirect when invalid chain prefix in URL

### DIFF
--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -7,7 +7,7 @@ import App from 'src/components/App'
 import GlobalErrorBoundary from 'src/components/GlobalErrorBoundary'
 import AppRoutes from 'src/routes'
 import { store } from 'src/store'
-import { history } from 'src/routes/routes'
+import { history, WELCOME_ROUTE } from 'src/routes/routes'
 import theme from 'src/theme/mui'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import Providers from '../Providers'
@@ -36,14 +36,14 @@ const RootConsumer = (): React.ReactElement | null => {
     const initChains = async () => {
       try {
         await loadChains()
+        if (!isValidChainId(_getChainId())) {
+          setChainId(DEFAULT_CHAIN_ID)
+          history.push(WELCOME_ROUTE)
+        }
         setHasChains(true)
       } catch (err) {
         logError(Errors._904, err.message)
         setIsError(true)
-      } finally {
-        if (!isValidChainId(_getChainId())) {
-          setChainId(DEFAULT_CHAIN_ID)
-        }
       }
     }
     initChains()

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -18,6 +18,11 @@ import StoreMigrator from 'src/components/StoreMigrator'
 import LegacyRouteRedirection from './LegacyRouteRedirection'
 import { logError, Errors, CodedException } from 'src/logic/exceptions/CodedException'
 import { loadChains } from 'src/config/cache/chains'
+import { DEFAULT_CHAIN_ID } from 'src/utils/constants'
+import { useSelector } from 'react-redux'
+import { currentChainId } from 'src/logic/config/store/selectors'
+import { isValidChainId } from 'src/config'
+import { setChainId } from 'src/logic/config/utils'
 
 // Preloader is rendered outside of '#root' and acts as a loading spinner
 // for the app and then chains loading
@@ -26,6 +31,7 @@ const removePreloader = () => {
 }
 
 const RootConsumer = (): React.ReactElement | null => {
+  const chainId = useSelector(currentChainId)
   const [hasChains, setHasChains] = useState<boolean>(false)
   const [isError, setIsError] = useState<boolean>(false)
 
@@ -37,6 +43,11 @@ const RootConsumer = (): React.ReactElement | null => {
       } catch (err) {
         logError(Errors._904, err.message)
         setIsError(true)
+      } finally {
+        // If chain is not returned from CGW, revert to default
+        if (!isValidChainId(chainId)) {
+          setChainId(DEFAULT_CHAIN_ID)
+        }
       }
     }
     initChains()

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -7,20 +7,20 @@ import App from 'src/components/App'
 import GlobalErrorBoundary from 'src/components/GlobalErrorBoundary'
 import AppRoutes from 'src/routes'
 import { store } from 'src/store'
-import { getNetworkRootRoutes, history, ROOT_ROUTE } from 'src/routes/routes'
+import { history } from 'src/routes/routes'
 import theme from 'src/theme/mui'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import Providers from '../Providers'
+import './index.module.scss'
+import './OnboardCustom.module.scss'
+import './KeystoneCustom.module.scss'
 import StoreMigrator from 'src/components/StoreMigrator'
 import LegacyRouteRedirection from './LegacyRouteRedirection'
 import { logError, Errors, CodedException } from 'src/logic/exceptions/CodedException'
 import { loadChains } from 'src/config/cache/chains'
 import { isValidChainId, _getChainId } from 'src/config'
 import { DEFAULT_CHAIN_ID } from 'src/utils/constants'
-
-import './index.module.scss'
-import './OnboardCustom.module.scss'
-import './KeystoneCustom.module.scss'
+import { setChainId } from 'src/logic/config/utils'
 
 // Preloader is rendered outside of '#root' and acts as a loading spinner
 // for the app and then chains loading
@@ -41,14 +41,9 @@ const RootConsumer = (): React.ReactElement | null => {
         logError(Errors._904, err.message)
         setIsError(true)
       } finally {
-        if (isValidChainId(_getChainId())) {
-          return
+        if (!isValidChainId(_getChainId())) {
+          setChainId(DEFAULT_CHAIN_ID)
         }
-
-        // If chain is not returned from CGW, revert to default
-        const chainRoute =
-          getNetworkRootRoutes().find(({ chainId }) => chainId === DEFAULT_CHAIN_ID)?.chainId || ROOT_ROUTE
-        history.replace(chainRoute)
       }
     }
     initChains()

--- a/src/config/cache/chains.ts
+++ b/src/config/cache/chains.ts
@@ -8,7 +8,7 @@ let chains: ChainInfo[] = []
 export const getChains = (): ChainInfo[] => chains
 
 export const loadChains = async () => {
-  const { results = [] } = await getChainsConfig(GATEWAY_URL)
+  const { results = [] } = await getChainsConfig(GATEWAY_URL, { limit: 100 })
   chains = results
   // Set the initail web3 provider after loading chains
   setWeb3ReadOnly()

--- a/src/routes/routes.test.tsx
+++ b/src/routes/routes.test.tsx
@@ -13,6 +13,7 @@ import {
 import { Route, Switch } from 'react-router'
 import { render } from 'src/utils/test-utils'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
+import Root from 'src/components/Root'
 
 const validSafeAddress = '0xF5A2915982BC8b0dEDda9cEF79297A83081Fe88f'
 
@@ -47,7 +48,7 @@ describe('chainSpecificSafeAddressPathRegExp', () => {
 })
 
 describe('extractPrefixedSafeAddress', () => {
-  it('returns the chain-specific addresses from the url if both supplied', async () => {
+  it('returns the chain and address from the url if both supplied', async () => {
     const shortName = 'matic'
 
     const route = generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, { shortName, safeAddress: validSafeAddress })
@@ -56,11 +57,11 @@ describe('extractPrefixedSafeAddress', () => {
     expect(extractPrefixedSafeAddress()).toStrictEqual({ shortName, safeAddress: validSafeAddress })
   })
 
-  it('returns the malformed chain prefix with safe address when a malformed chain is supplied', () => {
-    const route = `/fakechain:${validSafeAddress}/balances`
+  it('returns the incorrect chain prefix with safe address when an incorrect chain is supplied', () => {
+    const fakeChainShortName = 'fakechain'
+    const route = `/${fakeChainShortName}:${validSafeAddress}/balances`
     history.push(route)
 
-    // 'rin' is default dev env shortName
     expect(extractPrefixedSafeAddress()).toStrictEqual({ shortName: 'fakechain', safeAddress: validSafeAddress })
   })
 
@@ -74,7 +75,7 @@ describe('extractPrefixedSafeAddress', () => {
     expect(extractPrefixedSafeAddress()).toStrictEqual({ shortName: 'rin', safeAddress: '' })
   })
 
-  it('returns the chain prefix with numbers in in', () => {
+  it('returns the chain prefix with zero address', () => {
     const shortName = 'eth'
 
     const route = `/${shortName}:${ZERO_ADDRESS}/balances`

--- a/src/routes/routes.test.tsx
+++ b/src/routes/routes.test.tsx
@@ -56,12 +56,12 @@ describe('extractPrefixedSafeAddress', () => {
     expect(extractPrefixedSafeAddress()).toStrictEqual({ shortName, safeAddress: validSafeAddress })
   })
 
-  it('returns the current chain prefix with safe address when a malformed chain is supplied', () => {
+  it('returns the malformed chain prefix with safe address when a malformed chain is supplied', () => {
     const route = `/fakechain:${validSafeAddress}/balances`
     history.push(route)
 
     // 'rin' is default dev env shortName
-    expect(extractPrefixedSafeAddress()).toStrictEqual({ shortName: 'rin', safeAddress: validSafeAddress })
+    expect(extractPrefixedSafeAddress()).toStrictEqual({ shortName: 'fakechain', safeAddress: validSafeAddress })
   })
 
   // matchPath will fail because of chainSpecificSafeAddressPathRegExp path

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,12 +1,11 @@
 import { createBrowserHistory } from 'history'
 import { generatePath, matchPath } from 'react-router-dom'
 
-import { getShortName } from 'src/config'
 import { getChains } from 'src/config/cache/chains'
 import { ChainId, ShortName } from 'src/config/chain.d'
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { PUBLIC_URL } from 'src/utils/constants'
-import { isValidPrefix, parsePrefixedAddress } from 'src/utils/prefixedAddress'
+import { parsePrefixedAddress } from 'src/utils/prefixedAddress'
 
 export const history = createBrowserHistory({
   basename: PUBLIC_URL,
@@ -91,7 +90,7 @@ export const extractPrefixedSafeAddress = (
   const { prefix, address } = parsePrefixedAddress(prefixedSafeAddress || '')
 
   return {
-    shortName: isValidPrefix(prefix) ? prefix : getShortName(),
+    shortName: prefix,
     safeAddress: checksumAddress(address),
   }
 }

--- a/src/utils/__tests__/history.test.ts
+++ b/src/utils/__tests__/history.test.ts
@@ -1,6 +1,7 @@
+import { getShortName } from 'src/config'
 import * as configUtils from 'src/logic/config/utils'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
-import { history } from 'src/routes/routes'
+import { history, WELCOME_ROUTE } from 'src/routes/routes'
 import { switchNetworkWithUrl } from '../history'
 
 describe('switchNetworkWithUrl', () => {
@@ -14,23 +15,30 @@ describe('switchNetworkWithUrl', () => {
     expect(setChainIdMock).not.toHaveBeenCalled()
   })
   it('does not switch the network when the shortName has not changed', () => {
+    // chainId defaults to RINKEBY in non-production environments if it can't be read from LS
     const setChainIdMock = jest.spyOn(configUtils, 'setChainId')
 
-    const pathname = `/rin:${ZERO_ADDRESS}`
+    history.push(`/rin:${ZERO_ADDRESS}`)
 
-    history.push(pathname)
-
-    switchNetworkWithUrl({ pathname })
+    switchNetworkWithUrl(history.location)
 
     expect(setChainIdMock).not.toHaveBeenCalled()
   })
   it('switches the network when the shortName changes', () => {
+    // chainId defaults to RINKEBY in non-production environments if it can't be read from LS
     const setChainIdMock = jest.spyOn(configUtils, 'setChainId')
 
     history.push(`/eth:${ZERO_ADDRESS}`)
 
-    switchNetworkWithUrl({ pathname: `/eth:${ZERO_ADDRESS}` })
+    switchNetworkWithUrl(history.location)
 
     expect(setChainIdMock).toHaveBeenCalled()
+  })
+  it('redirects to the Welcome page when incorrect shortName is in the URL', () => {
+    history.push(`/fakechain:${ZERO_ADDRESS}`)
+
+    switchNetworkWithUrl(history.location)
+
+    expect(history.location.pathname).toBe(WELCOME_ROUTE)
   })
 })

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -3,6 +3,7 @@ import { getShortName } from 'src/config'
 import { getChains } from 'src/config/cache/chains'
 import { setChainId } from 'src/logic/config/utils'
 import { hasPrefixedSafeAddressInUrl, extractPrefixedSafeAddress, history, WELCOME_ROUTE } from 'src/routes/routes'
+import { DEFAULT_CHAIN_ID } from './constants'
 
 export const switchNetworkWithUrl = ({ pathname }: LocationDescriptorObject): void => {
   if (!hasPrefixedSafeAddressInUrl()) {
@@ -19,6 +20,7 @@ export const switchNetworkWithUrl = ({ pathname }: LocationDescriptorObject): vo
   const chainId = getChains().find((chain) => chain.shortName === shortName)?.chainId
 
   if (!chainId) {
+    setChainId(DEFAULT_CHAIN_ID)
     history.push(WELCOME_ROUTE)
     return
   }

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -2,7 +2,7 @@ import { LocationDescriptorObject } from 'history'
 import { getShortName } from 'src/config'
 import { getChains } from 'src/config/cache/chains'
 import { setChainId } from 'src/logic/config/utils'
-import { hasPrefixedSafeAddressInUrl, extractPrefixedSafeAddress } from 'src/routes/routes'
+import { hasPrefixedSafeAddressInUrl, extractPrefixedSafeAddress, history, WELCOME_ROUTE } from 'src/routes/routes'
 
 export const switchNetworkWithUrl = ({ pathname }: LocationDescriptorObject): void => {
   if (!hasPrefixedSafeAddressInUrl()) {
@@ -19,6 +19,7 @@ export const switchNetworkWithUrl = ({ pathname }: LocationDescriptorObject): vo
   const chainId = getChains().find((chain) => chain.shortName === shortName)?.chainId
 
   if (!chainId) {
+    history.push(WELCOME_ROUTE)
     return
   }
 


### PR DESCRIPTION
## What it solves

- Connection issues when switching from production chain to staging CGW.

- Resolves #3218

## How this PR fixes it

- Checks the validity of the current `chainId` against the returned values from the CGW and redirects to "Welcome Page" when the URL chain prefix is not in the retrieved chains

## How to test it
Insert an URL with a invalid chain prefix like
https://pr3228--safereact.review-safe.gnosisdev.com/app/xdai:0x0209eB92EB883dBD9bD01fD207d588E24F947913/balances (`xdai` does not exist in _staging_)

OR

https://pr3228--safereact.review-safe.gnosisdev.com/app/dummy:0x0209eB92EB883dBD9bD01fD207d588E24F947913/balances (unexistant chain)
