### PR TITLE
Fix: remove email and update Discord link from error boundary

### DIFF
--- a/src/components/GlobalErrorBoundary/index.tsx
+++ b/src/components/GlobalErrorBoundary/index.tsx
@@ -92,16 +92,7 @@ const GlobalErrorBoundaryFallback: FallbackRender = ({ error, componentStack }) 
               In case the problem persists, please reach out to us via{' '}
             </Text>
             <LinkWrapper>
-              <a target="_blank" href="email: mailto:safe@gnosis.io" rel="noopener noreferrer">
-                <Text color="primary" size="lg" as="span">
-                  Email
-                </Text>
-              </a>
-              <Icon type="externalLink" color="primary" size="sm" />
-            </LinkWrapper>
-            or{' '}
-            <LinkWrapper>
-              <a target="_blank" href="https://discordapp.com/invite/FPMRAwK" rel="noopener noreferrer">
+              <a target="_blank" href="https://discord.gg/M82FMJST7x" rel="noopener noreferrer">
                 <Text color="primary" size="lg" as="span">
                   Discord
                 </Text>


### PR DESCRIPTION
## What it solves
Resolves #3220

## How this PR fixes it
The `<ErrorBoundary>` component was updated to remove the email address and update the Discord invitation link.

## How to test it
Trigger the app to crash and observe no email link and an updated Discord link.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/147919102-e15c9799-9347-4a4e-bd13-0d3fca2b08de.png)