### PR TITLE
Use generic Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For support requests, please open up a [bug issue](https://github.com/gnosis/saf
 - Production: https://gnosis-safe.io/app/
 - Staging: https://safe-team.staging.gnosisdev.com/app/
 - Dev: https://safe-team.dev.gnosisdev.com/app/
-- PRs: https://pr<PR_NUMBER>--safereact.review-safe.gnosisdev.com/app/
+- PRs: `https://pr<PR_NUMBER>--safereact.review-safe.gnosisdev.com/app/`
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The most trusted platform to store digital assets on Ethereum. More info at [gno
 
 For technical information please refer to the [Gnosis Developer Portal](https://docs.gnosis.io/safe/).
 
-For support requests, please open up a [bug issue](https://github.com/gnosis/safe-react/issues/new?template=bug-report.md) or reach out via [Discord](https://discordapp.com/invite/FPMRAwK).
+For support requests, please open up a [bug issue](https://github.com/gnosis/safe-react/issues/new?template=bug-report.md) or reach out via [Discord](https://chat.gnosis-safe.io).
 
 ## Related repos
 
@@ -20,10 +20,10 @@ For support requests, please open up a [bug issue](https://github.com/gnosis/saf
 
 ## Deployed environments
 
-* Production: https://gnosis-safe.io/app/
-* Staging: https://safe-team.staging.gnosisdev.com/app/
-* Dev: https://safe-team.dev.gnosisdev.com/app/
-* PRs: https://pr<PR_NUMBER>--safereact.review-safe.gnosisdev.com/app/
+- Production: https://gnosis-safe.io/app/
+- Staging: https://safe-team.staging.gnosisdev.com/app/
+- Dev: https://safe-team.dev.gnosisdev.com/app/
+- PRs: https://pr<PR_NUMBER>--safereact.review-safe.gnosisdev.com/app/
 
 ## Getting Started
 

--- a/src/components/GlobalErrorBoundary/index.tsx
+++ b/src/components/GlobalErrorBoundary/index.tsx
@@ -92,7 +92,7 @@ const GlobalErrorBoundaryFallback: FallbackRender = ({ error, componentStack }) 
               In case the problem persists, please reach out to us via{' '}
             </Text>
             <LinkWrapper>
-              <a target="_blank" href="https://discord.gg/M82FMJST7x" rel="noopener noreferrer">
+              <a target="_blank" href="https://chat.gnosis-safe.io" rel="noopener noreferrer">
                 <Text color="primary" size="lg" as="span">
                   Discord
                 </Text>


### PR DESCRIPTION
## What it solves
Use our generic Discord link in all places where we link to our Discord.

## How this PR fixes it
All instances of the Discord link were changed.

## How to test it
- Observe that the Discord link has changed in the `README.md`, as well as in the error boundary.