### PR TITLE
Fix: truncate long token names

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TokenTransferAmount.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TokenTransferAmount.tsx
@@ -11,6 +11,10 @@ import { TokenTransferAsset } from './hooks/useAssetInfo'
 const Amount = styled(Text)`
   margin-left: 10px;
   line-height: 16px;
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 const AmountWrapper = styled.div`


### PR DESCRIPTION
## What it solves
Resolves #2251

## How this PR fixes it
Long token names are truncated.

## How to test it
- Open eth:0x7fDc01fF064216493e7c695abA46Dcd4eCC376Ae and go to historical transactions: https://pr3237--safereact.review-safe.gnosisdev.com/app/eth:0x7fDc01fF064216493e7c695abA46Dcd4eCC376Ae/transactions/history
- Scroll down to the incoming txs with 1 MYDARKTWISTEDFANTASYOPENEDITIONBYDOTPIGEON and observe that it is now truncated

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/147934066-489bed1c-3219-4bba-8d7a-e70d8f2f5763.png)