### PR TITLE
Remove bottom margin on close button

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/ChooseTxType/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ChooseTxType/style.ts
@@ -25,7 +25,6 @@ export const useStyles = makeStyles(
     closeIcon: {
       height: '35px',
       width: '35px',
-      marginBottom: `-${xs}`,
     },
     buttonColumn: {
       margin: '52px 0 44px 0',


### PR DESCRIPTION
## What it solves
Resolves #2759

## How this PR fixes it
All bottom margins on close buttons were removed.

## How to test it
- Open modals
- Hover over close button and bserve the circular, centralised background

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/147954992-5fb825e5-ec60-4bb7-8f14-d782d8e49539.png)
