### PR TITLE
Enable execution button on deeplink transactions

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/hooks/useActionButtonsHandlers.ts
+++ b/src/routes/safe/components/Transactions/TxList/hooks/useActionButtonsHandlers.ts
@@ -31,7 +31,7 @@ export const useActionButtonsHandlers = (transaction: Transaction): ActionButton
   const currentUser = useSelector(userAccountSelector)
   const actionContext = useRef(useContext(TransactionActionStateContext))
   const hoverContext = useRef(useContext(TxHoverContext))
-  const locationContext = useRef(useContext(TxLocationContext))
+  const locationContext = useContext(TxLocationContext)
   const dispatch = useDispatch()
   const { canCancel, canConfirmThenExecute, canExecute } = useTransactionActions(transaction)
   const txStatus = useLocalTxStatus(transaction)
@@ -86,8 +86,7 @@ export const useActionButtonsHandlers = (transaction: Transaction): ActionButton
   const disabledActions =
     !currentUser ||
     isPending ||
-    (txStatus === LocalTransactionStatus.AWAITING_EXECUTION &&
-      locationContext.current.txLocation === 'queued.queued') ||
+    (txStatus === LocalTransactionStatus.AWAITING_EXECUTION && locationContext.txLocation === 'queued.queued') ||
     (txStatus === LocalTransactionStatus.AWAITING_CONFIRMATIONS && !signaturePending(currentUser))
 
   return {


### PR DESCRIPTION
## What it solves
Resolves #3244

## How this PR fixes it
The `txLocation` context was not updating as it was wrapped in a `useRef`. Removing it allowed for the contextualised value to update when it changed in accordance with the `TxLocationProvider`.

## How to test it

**Ensure that the Safe has a 1/? threshold and that the transaction queue is empty**

1. Create a transaction but do not execute it.
2. When navigated to the deeplink view, the execution button should be enabled.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/148190016-72586e44-93c2-49ec-8016-90f30d9d7a26.png)