### PR TITLE
Fix: show confirm button for rejection txns

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -21,8 +21,9 @@ import { TxLocationContext } from './TxLocationProvider'
 import { TxOwners } from './TxOwners'
 import { TxSummary } from './TxSummary'
 import { isCancelTxDetails, NOT_AVAILABLE } from './utils'
-import { useTransactionActions } from './hooks/useTransactionActions'
 import useLocalTxStatus from 'src/logic/hooks/useLocalTxStatus'
+import { useSelector } from 'react-redux'
+import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 
 const NormalBreakingText = styled(Text)`
   line-break: normal;
@@ -89,7 +90,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
   const txStatus = useLocalTxStatus(transaction)
   const willBeReplaced = txStatus === LocalTransactionStatus.WILL_BE_REPLACED
   const isPending = txStatus === LocalTransactionStatus.PENDING
-  const { canExecute, canCancel } = useTransactionActions(transaction)
+  const currentUser = useSelector(userAccountSelector)
 
   if (loading) {
     return (
@@ -130,7 +131,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
       >
         <TxOwners txDetails={data} isPending={isPending} />
       </div>
-      {!isPending && !data.executedAt && txLocation !== 'history' && (canExecute || canCancel) && (
+      {!isPending && !data.executedAt && txLocation !== 'history' && !!currentUser && (
         <div className={cn('tx-details-actions', { 'will-be-replaced': willBeReplaced })}>
           <TxExpandedActions transaction={transaction} />
         </div>


### PR DESCRIPTION
## What it solves
Resolves #3252

## How this PR fixes it
The transaction 'actions' were not showing correctly because they referenced whether a user could execute or reject. If a transaction had been rejected, it would therefore not show actions because it, of course, could not be executed either.

This previous change was removed and the conditional rendering of the action buttons now depends on whether the user has connected their wallet.

## How to test it
1. Create a transaction on a 2/? threshold Safe.
2. Reject said transaction.
3. Observe that the actions displayed.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/148234967-1bc660cb-db71-48fa-9758-f3f9119fd012.png)
