### PR TITLE
fix: add PENDING_FAILED to the awaiting execution logic

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -36,7 +36,7 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
   const txStatus = useLocalTxStatus(transaction)
 
   const getTitle = () => {
-    if (txStatus === LocalTransactionStatus.AWAITING_EXECUTION) {
+    if (txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED) {
       return (transaction.executionInfo as MultisigExecutionInfo)?.nonce === nonce
         ? 'Execute'
         : `Transaction with nonce ${nonce} needs to be executed first`
@@ -57,7 +57,11 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
             onMouseLeave={handleOnMouseLeave}
           >
             <Icon
-              type={txStatus === LocalTransactionStatus.AWAITING_EXECUTION ? 'rocket' : 'check'}
+              type={
+                txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED
+                  ? 'rocket'
+                  : 'check'
+              }
               color="primary"
               size="sm"
             />

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -35,8 +35,10 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
 
+  const isAwaitingExecution =
+    txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED
   const getTitle = () => {
-    if (txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED) {
+    if (isAwaitingExecution) {
       return (transaction.executionInfo as MultisigExecutionInfo)?.nonce === nonce
         ? 'Execute'
         : `Transaction with nonce ${nonce} needs to be executed first`
@@ -56,15 +58,7 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
             onMouseEnter={handleOnMouseEnter}
             onMouseLeave={handleOnMouseLeave}
           >
-            <Icon
-              type={
-                txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED
-                  ? 'rocket'
-                  : 'check'
-              }
-              color="primary"
-              size="sm"
-            />
+            <Icon type={isAwaitingExecution ? 'rocket' : 'check'} color="primary" size="sm" />
           </IconButton>
         </span>
       </Tooltip>

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -24,7 +24,8 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   } = useActionButtonsHandlers(transaction)
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
-  const isAwaitingExecution = txStatus === LocalTransactionStatus.AWAITING_EXECUTION
+  const isAwaitingExecution =
+    txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED
 
   const onExecuteOrConfirm = (event) => {
     handleOnMouseLeave()


### PR DESCRIPTION
## What it solves
Resolves unaccurate "Confirm" copies when the tx failed to execute

<img width="913" alt="Screen Shot 2022-01-10 at 10 39 34" src="https://user-images.githubusercontent.com/32431609/148745396-c02a76aa-c79d-4924-bde4-44b8f7dd0988.png">
<img width="359" alt="Screen Shot 2022-01-10 at 10 39 42" src="https://user-images.githubusercontent.com/32431609/148745411-9103ebda-a193-4085-bc87-7ea45b84204c.png">

## How this PR fixes it
Adds local tx status `PENDING_FAILED` to the "awaiting execution" logic

## How to test it
1. Create a tx and reject executing it in Metamask
2. In the Next Queue you shall see the "Execute" copies instead of the "Confirm"

## Screenshots
<img width="910" alt="Screen Shot 2022-01-10 at 10 46 38" src="https://user-images.githubusercontent.com/32431609/148745810-7d7b6827-bb2f-4ea7-b41a-bb8a2aa99c8c.png">

