### PR TITLE
Append error message to notification upon rejection

### DIFF
--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -34,6 +34,7 @@ import { getGasParam } from '../../transactions/gas'
 import { getLastTransaction } from '../selectors/gatewayTransactions'
 import { getRecommendedNonce } from '../../api/fetchSafeTxGasEstimation'
 import { LocalTransactionStatus } from '../models/types/gateway.d'
+import { isTxPendingError } from 'src/logic/wallets/getWeb3'
 
 interface ProcessTransactionArgs {
   approveAndExecute: boolean
@@ -190,7 +191,12 @@ export const processTransaction =
         dispatch(updateTransactionStatus({ safeTxHash: tx.safeTxHash, status: LocalTransactionStatus.PENDING_FAILED }))
       }
 
-      const notification = NOTIFICATIONS.TX_PENDING_MSG
+      const notification = isTxPendingError(err)
+        ? NOTIFICATIONS.TX_PENDING_MSG
+        : {
+            ...notificationsQueue.afterExecutionError,
+            message: `${notificationsQueue.afterExecutionError.message} - ${err.message}`,
+          }
 
       dispatch(enqueueSnackbar({ key: err.code, ...notification }))
     }


### PR DESCRIPTION
## What it solves
Resolves #3263

## How this PR fixes it
The thrown error message is appending to the error notification as it originally was before errors were retrieved from the contract.

## How to test it
- Reject a transaction via MetaMask and observe the rejection error message in the notification.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/148770069-bdf1b8cd-2bea-44b4-b186-0115223818f5.png)
