### PR TITLE
Add module details to module transactions

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -94,6 +94,20 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
   const isPending = txStatus === LocalTransactionStatus.PENDING
   const currentUser = useSelector(userAccountSelector)
   const hasModule = transaction.txDetails && isModuleExecutionInfo(transaction.txDetails.detailedExecutionInfo)
+  const isMultiSend = data && isMultiSendTxInfo(data.txInfo)
+
+  // To avoid prop drilling into TxDataGroup, module details are positioned here accordingly
+  const getModuleDetails = () => {
+    if (!transaction.txDetails || !isModuleExecutionInfo(transaction.txDetails.detailedExecutionInfo)) {
+      return null
+    }
+
+    return (
+      <div className="tx-module">
+        <TxModuleInfo detailedExecutionInfo={transaction.txDetails?.detailedExecutionInfo} />
+      </div>
+    )
+  }
 
   if (loading) {
     return (
@@ -118,21 +132,17 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
       <div className={cn('tx-summary', { 'will-be-replaced': willBeReplaced })}>
         <TxSummary txDetails={data} />
       </div>
+      {isMultiSend && getModuleDetails()}
       <div
         className={cn('tx-details', {
-          'no-padding': isMultiSendTxInfo(data.txInfo),
+          'no-padding': isMultiSend,
           'not-executed': !data.executedAt,
           'will-be-replaced': willBeReplaced,
         })}
       >
         <TxDataGroup txDetails={data} />
       </div>
-      {/* Cannot use hasModule due to type inference */}
-      {transaction.txDetails && isModuleExecutionInfo(transaction.txDetails.detailedExecutionInfo) && (
-        <div className="tx-module">
-          <TxModuleInfo detailedExecutionInfo={transaction.txDetails?.detailedExecutionInfo} />
-        </div>
-      )}
+      {!isMultiSend && getModuleDetails()}
       <div
         className={cn('tx-owners', {
           'will-be-replaced': willBeReplaced,

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import {
   ExpandedTxDetails,
+  isModuleExecutionInfo,
   isMultiSendTxInfo,
   isMultiSigExecutionDetails,
   isSettingsChangeTxInfo,
@@ -24,6 +25,7 @@ import { isCancelTxDetails, NOT_AVAILABLE } from './utils'
 import useLocalTxStatus from 'src/logic/hooks/useLocalTxStatus'
 import { useSelector } from 'react-redux'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
+import TxModuleInfo from './TxModuleInfo'
 
 const NormalBreakingText = styled(Text)`
   line-break: normal;
@@ -91,6 +93,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
   const willBeReplaced = txStatus === LocalTransactionStatus.WILL_BE_REPLACED
   const isPending = txStatus === LocalTransactionStatus.PENDING
   const currentUser = useSelector(userAccountSelector)
+  const hasModule = transaction.txDetails && isModuleExecutionInfo(transaction.txDetails.detailedExecutionInfo)
 
   if (loading) {
     return (
@@ -111,7 +114,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
   }
 
   return (
-    <TxDetailsContainer>
+    <TxDetailsContainer ownerRows={hasModule ? 3 : 2}>
       <div className={cn('tx-summary', { 'will-be-replaced': willBeReplaced })}>
         <TxSummary txDetails={data} />
       </div>
@@ -124,6 +127,12 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
       >
         <TxDataGroup txDetails={data} />
       </div>
+      {/* Cannot use hasModule due to type inference */}
+      {transaction.txDetails && isModuleExecutionInfo(transaction.txDetails.detailedExecutionInfo) && (
+        <div className="tx-module">
+          <TxModuleInfo detailedExecutionInfo={transaction.txDetails?.detailedExecutionInfo} />
+        </div>
+      )}
       <div
         className={cn('tx-owners', {
           'will-be-replaced': willBeReplaced,

--- a/src/routes/safe/components/Transactions/TxList/TxModuleInfo.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxModuleInfo.tsx
@@ -1,0 +1,17 @@
+import { ReactElement } from 'react'
+import { ModuleExecutionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
+
+import { AddressInfo } from './AddressInfo'
+import { InfoDetails } from './InfoDetails'
+
+const TxModuleInfo = ({ detailedExecutionInfo }: { detailedExecutionInfo: ModuleExecutionDetails }): ReactElement => {
+  const { value, name, logoUri } = detailedExecutionInfo.address
+
+  return (
+    <InfoDetails title="Module:">
+      <AddressInfo address={value} name={name || undefined} avatarUrl={logoUri || undefined} />
+    </InfoDetails>
+  )
+}
+
+export default TxModuleInfo

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -13,7 +13,6 @@ import {
 import { InlineEthHashInfo } from './styled'
 import { NOT_AVAILABLE } from './utils'
 import TxShareButton from './TxShareButton'
-import { IS_PRODUCTION } from 'src/utils/constants'
 import TxInfoMultiSend from './TxInfoMultiSend'
 import DelegateCallWarning from './DelegateCallWarning'
 
@@ -28,7 +27,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
 
   return (
     <>
-      {!IS_PRODUCTION && isMultiSigExecutionDetails(txDetails.detailedExecutionInfo) && (
+      {isMultiSigExecutionDetails(txDetails.detailedExecutionInfo) && (
         <div className="tx-share">
           <TxShareButton safeTxHash={txDetails.detailedExecutionInfo.safeTxHash} />
         </div>

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -339,7 +339,7 @@ export const DisclaimerContainer = styled(StyledTransaction)`
   }
 `
 
-export const TxDetailsContainer = styled.div`
+export const TxDetailsContainer = styled.div<{ ownerRows?: number }>`
   ${willBeReplaced};
 
   background-color: ${({ theme }) => theme.colors.separator} !important;
@@ -379,7 +379,7 @@ export const TxDetailsContainer = styled.div`
   .tx-owners {
     padding: 24px;
     grid-column-start: 2;
-    grid-row-end: span 2;
+    grid-row-end: span ${({ ownerRows }) => ownerRows || 2};
     grid-row-start: 1;
   }
 


### PR DESCRIPTION
## What it solves
Resolves #2990

## How this PR fixes it
The module address and name, when in the address book or known, is now displayed when module-related transactions are expanded.

## How to test it
1. Open Safe `eth:0x1f8eaD1e6e10e6856d68be2217EDDC71D8b4eC87` on production CGW.
2. View historical transactions (all of which are module induced).
3. Observe module details below transaction data.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/148783687-2c402499-71f9-462d-ba80-68d96a304936.png)