### PR TITLE
Remove unnecessary transaction proposal

### DIFF
--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -163,6 +163,14 @@ export const processTransaction =
             aboutToExecuteTx.setNonce(txArgs.nonce)
           }
 
+          if (!isExecution) {
+            try {
+              await saveTxToHistory({ ...txArgs })
+            } catch (e) {
+              logError(Errors._804, e.message)
+            }
+          }
+
           dispatch(fetchTransactions(chainId, safeAddress))
         })
         .then(async (receipt) => {

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -170,8 +170,6 @@ export const processTransaction =
               logError(Errors._804, e.message)
             }
           }
-
-          dispatch(fetchTransactions(chainId, safeAddress))
         })
         .then(async (receipt) => {
           dispatch(fetchTransactions(chainId, safeAddress))

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -160,18 +160,10 @@ export const processTransaction =
 
           if (isExecution) {
             dispatch(updateTransactionStatus({ safeTxHash: tx.safeTxHash, status: LocalTransactionStatus.PENDING }))
+            aboutToExecuteTx.setNonce(txArgs.nonce)
           }
 
-          try {
-            await saveTxToHistory({ ...txArgs })
-
-            // store the pending transaction's nonce
-            isExecution && aboutToExecuteTx.setNonce(txArgs.nonce)
-
-            dispatch(fetchTransactions(chainId, safeAddress))
-          } catch (e) {
-            logError(Errors._804, e.message)
-          }
+          dispatch(fetchTransactions(chainId, safeAddress))
         })
         .then(async (receipt) => {
           dispatch(fetchTransactions(chainId, safeAddress))


### PR DESCRIPTION
## What it solves
Resolves #3261

## How this PR fixes it
Transactions need only be proposed if it is not immediately executing. The unnecessary proposal has been removed.

## How to test it
1. Create a transaction and ensure that it has sufficient confirmations, but do not execute it.
2. Execute it as a non-owner and expect it to be successful and not show an error in the console.