### PR TITLE
Add optional chaining in transaction reducer

### DIFF
--- a/src/logic/safe/store/reducer/gatewayTransactions.ts
+++ b/src/logic/safe/store/reducer/gatewayTransactions.ts
@@ -121,7 +121,7 @@ export const gatewayTransactionsReducer = handleActions<GatewayTransactionsState
 
         if (!label) {
           const oldNext = state[chainId]?.[safeAddress]?.queued?.next
-          label = oldNext[txNonce] ? 'next' : 'queued'
+          label = oldNext?.[txNonce] ? 'next' : 'queued'
         }
 
         const newTx = value.transaction


### PR DESCRIPTION
## What it solves
Occasional app crash when queued transactions have not loaded quick enough

## How this PR fixes it
Optional chaining was added to the store interaction.