### PR TITLE
Show a meaningful error message on Safe creation

### DIFF
--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -56,7 +56,12 @@ export const SafeDeployment = ({
       if (isTxPendingError(err)) {
         dispatch(enqueueSnackbar({ ...NOTIFICATIONS.TX_PENDING_MSG }))
       } else {
-        dispatch(enqueueSnackbar({ ...NOTIFICATIONS.CREATE_SAFE_FAILED_MSG }))
+        dispatch(
+          enqueueSnackbar({
+            ...NOTIFICATIONS.CREATE_SAFE_FAILED_MSG,
+            message: `${NOTIFICATIONS.CREATE_SAFE_FAILED_MSG.message} – ${err.message}`,
+          }),
+        )
       }
     },
     [dispatch],


### PR DESCRIPTION
It was saying just "Safe creation failed". I've added an actual error message.

<img width="647" alt="Screenshot 2022-01-10 at 16 59 22" src="https://user-images.githubusercontent.com/381895/148797283-77e97683-1bba-4ed0-90ea-e6ce28e229ba.png">
