### PR TITLE
Add non-owner error message for Safe Apps

### DIFF
--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -9,6 +9,7 @@ import InfoIcon from 'src/assets/icons/info_red.svg'
 import { useSelector } from 'react-redux'
 import { currentSafeThreshold } from 'src/logic/safe/store/selectors'
 import { shouldSwitchWalletChain } from 'src/logic/wallets/store/selectors'
+import { grantedSelector } from 'src/routes/safe/container/selector'
 
 const styles = createStyles({
   executionWarningRow: {
@@ -34,6 +35,7 @@ export const TransactionFailText = ({
   const classes = useStyles()
   const threshold = useSelector(currentSafeThreshold)
   const isWrongChain = useSelector(shouldSwitchWalletChain)
+  const isGranted = useSelector(grantedSelector)
 
   if (txEstimationExecutionStatus !== EstimationStatus.FAILURE) {
     return null
@@ -51,10 +53,12 @@ export const TransactionFailText = ({
     <Row align="center">
       <Paragraph color="error" className={classes.executionWarningRow}>
         <Img alt="Info Tooltip" height={16} src={InfoIcon} className={classes.warningIcon} />
-        {isWrongChain ? (
+        {isGranted ? (
+          <>This transaction will most likely fail. {errorMessage}</>
+        ) : isWrongChain ? (
           <>Your wallet is connected to the wrong chain.</>
         ) : (
-          <>This transaction will most likely fail. {errorMessage}</>
+          <>You are currently not an owner of this Safe and won&apos;t be able to submit this tx.</>
         )}
       </Paragraph>
     </Row>

--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -41,25 +41,25 @@ export const TransactionFailText = ({
     return null
   }
 
-  let errorMessage = 'To save gas costs, avoid creating the transaction.'
+  let errorDesc = 'To save gas costs, avoid creating the transaction.'
   if (isExecution) {
-    errorMessage =
+    errorDesc =
       threshold && threshold > 1
         ? `To save gas costs, reject this transaction`
         : `To save gas costs, avoid executing the transaction.`
   }
 
+  const error = isGranted
+    ? `This transaction will most likely fail. ${errorDesc}`
+    : isWrongChain
+    ? 'Your wallet is connected to the wrong chain.'
+    : 'You are currently not an owner of this Safe and won&apos;t be able to submit this transaction.'
+
   return (
     <Row align="center">
       <Paragraph color="error" className={classes.executionWarningRow}>
         <Img alt="Info Tooltip" height={16} src={InfoIcon} className={classes.warningIcon} />
-        {isGranted ? (
-          <>This transaction will most likely fail. {errorMessage}</>
-        ) : isWrongChain ? (
-          <>Your wallet is connected to the wrong chain.</>
-        ) : (
-          <>You are currently not an owner of this Safe and won&apos;t be able to submit this tx.</>
-        )}
+        {error}
       </Paragraph>
     </Row>
   )

--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -53,7 +53,7 @@ export const TransactionFailText = ({
     ? `This transaction will most likely fail. ${errorDesc}`
     : isWrongChain
     ? 'Your wallet is connected to the wrong chain.'
-    : 'You are currently not an owner of this Safe and won&apos;t be able to submit this transaction.'
+    : "You are currently not an owner of this Safe and won't be able to submit this transaction."
 
   return (
     <Row align="center">


### PR DESCRIPTION
## What it solves
Resolves #3197

## How this PR fixes it
When a transaction estimation status suggests that it will fail, the error now takes into whether the current user is granted and adjusts the error message accordingly:

```
  isGranted
    ? This transaction will most likely fail. {{description}}
      : isWrongChain
      ? Your wallet is connected to the wrong chain.
    : You are currently not an owner of this Safe and won't be able to submit this tx.
```

## How to test it
Attempt to make a transaction via a Safe App as a non-owner and observe the error message.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/148812394-e623f563-4188-4bd4-a7b1-e6078b6c32f3.png)