### PR TITLE
Show deeplink share on production

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -13,7 +13,6 @@ import {
 import { InlineEthHashInfo } from './styled'
 import { NOT_AVAILABLE } from './utils'
 import TxShareButton from './TxShareButton'
-import { IS_PRODUCTION } from 'src/utils/constants'
 import TxInfoMultiSend from './TxInfoMultiSend'
 import DelegateCallWarning from './DelegateCallWarning'
 
@@ -28,7 +27,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
 
   return (
     <>
-      {!IS_PRODUCTION && isMultiSigExecutionDetails(txDetails.detailedExecutionInfo) && (
+      {isMultiSigExecutionDetails(txDetails.detailedExecutionInfo) && (
         <div className="tx-share">
           <TxShareButton safeTxHash={txDetails.detailedExecutionInfo.safeTxHash} />
         </div>


### PR DESCRIPTION
## What it solves
Resolves #3275

## How this PR fixes it
The deeplink share button was only shown when `!IS_PRODUCTION`. This flag has been removed.

## How to test it
1. Open a Safe (on the PR, ensuring that it is the production environment).
2. View the transaction history and observe the share button on outgoing transacitons.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/148899867-537836ad-b19c-4a23-8e4c-bc81a756fe91.png)