### PR TITLE
Fix: "Send 0 eth to" -> "Interact with"

### DIFF
--- a/src/components/DecodeTxs/index.tsx
+++ b/src/components/DecodeTxs/index.tsx
@@ -10,9 +10,10 @@ import get from 'lodash/get'
 import { Text, CopyToClipboardBtn, IconText, FixedIcon } from '@gnosis.pm/safe-react-components'
 import { hexToBytes } from 'web3-utils'
 
-import { getExplorerInfo, getNativeCurrency } from 'src/config'
+import { getExplorerInfo } from 'src/config'
 import { DecodedTxDetail } from 'src/routes/safe/components/Apps/components/ConfirmTxModal'
 import PrefixedEthHashInfo from '../PrefixedEthHashInfo'
+import { getInteractionTitle } from 'src/routes/safe/components/Transactions/helpers/utils'
 
 const FlexWrapper = styled.div<{ margin: number }>`
   display: flex;
@@ -80,14 +81,12 @@ export const BasicTxInfo = ({
   txValue: string
   recipientName?: string
 }): ReactElement => {
-  const nativeCurrency = getNativeCurrency()
-
   return (
     <BasicTxInfoWrapper>
       {/* TO */}
       <>
         <Text size="lg" strong>
-          {`Send ${txValue} ${nativeCurrency.symbol} to:`}
+          {getInteractionTitle(txValue)}
         </Text>
         <PrefixedEthHashInfo
           hash={txRecipient}

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
@@ -58,7 +58,7 @@ describe('ConfirmTxModal Component', () => {
       />,
     )
 
-    expect(screen.getByText('Send 2 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText('Interact with (and send 2 ETH to):')).toBeInTheDocument()
     expect(screen.getByText(txs[0].to)).toBeInTheDocument()
   })
 
@@ -92,7 +92,7 @@ describe('ConfirmTxModal Component', () => {
     )
 
     // No ETH value should be sent to the multisend address
-    expect(screen.getByText('Send 0 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText('Interact with:')).toBeInTheDocument()
     expect(screen.getByText(MULTISEND_ADDRESS)).toBeInTheDocument()
   })
 
@@ -239,7 +239,7 @@ describe('ConfirmTxModal Component', () => {
       />,
     )
 
-    expect(screen.getByText('Send 0 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText('Interact with:')).toBeInTheDocument()
   })
 
   test('Accepts value equal 2 eth as a number (backward compatibility with the legacy v0.x SDKs)', () => {
@@ -267,7 +267,7 @@ describe('ConfirmTxModal Component', () => {
       />,
     )
 
-    expect(screen.getByText('Send 2 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText('Interact with (and send 2 ETH to):')).toBeInTheDocument()
   })
 
   test('Accepts value as a number in multisend transactions (backward compatibility with the legacy v0.x SDKs)', () => {
@@ -301,7 +301,7 @@ describe('ConfirmTxModal Component', () => {
     )
 
     // No ETH value should be sent to the multisend address
-    expect(screen.getByText('Send 0 ETH to:')).toBeInTheDocument()
+    expect(screen.getByText('Interact with:')).toBeInTheDocument()
     expect(screen.getByText(MULTISEND_ADDRESS)).toBeInTheDocument()
   })
 })

--- a/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
@@ -4,6 +4,7 @@ import { ReactElement, ReactNode } from 'react'
 
 import { getNativeCurrency } from 'src/config'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
+import { getInteractionTitle } from '../helpers/utils'
 import DelegateCallWarning from './DelegateCallWarning'
 import { HexEncodedData } from './HexEncodedData'
 import { MethodDetails } from './MethodDetails'
@@ -69,7 +70,7 @@ export const MultiSendDetails = ({ txData }: { txData: TransactionData }): React
 
         const actionTitle = `Action ${index + 1} ${dataDecoded ? `(${dataDecoded.method})` : ''}`
         const amount = value ? fromTokenUnit(value, nativeCurrency.decimals) : 0
-        const title = `Send ${amount} ${nativeCurrency.symbol} to:`
+        const title = getInteractionTitle(amount)
 
         if (dataDecoded) {
           // Backend decoded data

--- a/src/routes/safe/components/Transactions/TxList/TxData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxData.tsx
@@ -16,6 +16,7 @@ import { HexEncodedData } from './HexEncodedData'
 import { MethodDetails } from './MethodDetails'
 import { MultiSendDetails } from './MultiSendDetails'
 import { TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { getInteractionTitle } from '../helpers/utils'
 
 type DetailsWithTxInfoProps = {
   children: ReactNode
@@ -36,13 +37,7 @@ const DetailsWithTxInfo = ({ children, txData, txInfo }: DetailsWithTxInfoProps)
 
   return (
     <>
-      <TxInfoDetails
-        address={txData.to.value}
-        name={name}
-        avatarUrl={avatarUrl}
-        title={`Send ${amount} ${nativeCurrency.symbol} to:`}
-      />
-
+      <TxInfoDetails address={txData.to.value} name={name} avatarUrl={avatarUrl} title={getInteractionTitle(amount)} />
       {children}
     </>
   )

--- a/src/routes/safe/components/Transactions/__tests__/utils.test.ts
+++ b/src/routes/safe/components/Transactions/__tests__/utils.test.ts
@@ -1,0 +1,18 @@
+import { getInteractionTitle } from '../helpers/utils'
+
+describe('getInteractionTitle', () => {
+  it('should return no amount relevant title for a numeric 0 amount', () => {
+    expect(getInteractionTitle(0)).toEqual('Interact with:')
+  })
+  it('should return no amount relevant title for a string 0 amount', () => {
+    expect(getInteractionTitle('0')).toEqual('Interact with:')
+  })
+  it('should return an amount relevant title for a numeric amount', () => {
+    expect(getInteractionTitle(1)).toEqual(`Interact with (and send 1 ETH to):`)
+    expect(getInteractionTitle(0.1)).toEqual(`Interact with (and send 0.1 ETH to):`)
+  })
+  it('should return an amount relevant title for a string amount', () => {
+    expect(getInteractionTitle('1')).toEqual(`Interact with (and send 1 ETH to):`)
+    expect(getInteractionTitle('0.1')).toEqual(`Interact with (and send 0.1 ETH to):`)
+  })
+})

--- a/src/routes/safe/components/Transactions/helpers/utils.ts
+++ b/src/routes/safe/components/Transactions/helpers/utils.ts
@@ -20,7 +20,7 @@ export const ethereumTxParametersTitle = (isExecution: boolean): string => {
 }
 
 export const getInteractionTitle = (value: number | string): string => {
-  if (value === 0 || (typeof value === 'string' && parseFloat(value) === 0)) {
+  if (Number(value) === 0) {
     return 'Interact with:'
   }
 

--- a/src/routes/safe/components/Transactions/helpers/utils.ts
+++ b/src/routes/safe/components/Transactions/helpers/utils.ts
@@ -1,3 +1,5 @@
+import { getNativeCurrency } from 'src/config'
+
 export type ParametersStatus = 'ENABLED' | 'DISABLED' | 'SAFE_DISABLED' | 'ETH_HIDDEN' | 'CANCEL_TRANSACTION'
 
 export const areEthereumParamsVisible = (parametersStatus: ParametersStatus): boolean => {
@@ -15,4 +17,13 @@ export const areSafeParamsEnabled = (parametersStatus: ParametersStatus): boolea
 
 export const ethereumTxParametersTitle = (isExecution: boolean): string => {
   return `Owner transaction ${isExecution ? '(Execution)' : '(On-chain approval)'}`
+}
+
+export const getInteractionTitle = (value: number | string): string => {
+  if (value === 0 || (typeof value === 'string' && parseInt(value) === 0)) {
+    return 'Interact with:'
+  }
+
+  const { symbol } = getNativeCurrency()
+  return `Interact with (and send ${value} ${symbol} to):`
 }

--- a/src/routes/safe/components/Transactions/helpers/utils.ts
+++ b/src/routes/safe/components/Transactions/helpers/utils.ts
@@ -20,7 +20,7 @@ export const ethereumTxParametersTitle = (isExecution: boolean): string => {
 }
 
 export const getInteractionTitle = (value: number | string): string => {
-  if (value === 0 || (typeof value === 'string' && parseInt(value) === 0)) {
+  if (value === 0 || (typeof value === 'string' && parseFloat(value) === 0)) {
     return 'Interact with:'
   }
 


### PR DESCRIPTION
## What it solves
Resolves #3254

## How this PR fixes it
All instances of "Send 0 {{symbol}} to:" have been changed to "Interact with:" and "Send {{amount}} {{symbol}} to:" changed to "Interact with (and send {{amount}} {{symbol}} to):"

## How to test it
1. Create/execute a contract interaction of 0 cost and observe the new title.
2. Create/execute a transaction of >0 cost and observe the new title.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/148921393-353c1e1f-962e-4b36-8986-d62ea6b6554d.png)