### PR TITLE
Chore: don't check CLA for release branches

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'CLA Assistant'
-        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: github.base_ref != 'main' && ((github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target')
         # Alpha Release
         uses: gnosis/github-action@master
         # GitHub token, automatically provided to the action


### PR DESCRIPTION
Commits that go to main should have already been checked, so no need to run it again.