### PR TITLE
Adjust awaiting execution status check

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
@@ -24,7 +24,7 @@ import { TokenTransferAmount } from './TokenTransferAmount'
 import { TxsInfiniteScrollContext } from './TxsInfiniteScroll'
 import { TxLocationContext } from './TxLocationProvider'
 import { CalculatedVotes } from './TxQueueCollapsed'
-import { getTxTo, isCancelTxDetails } from './utils'
+import { getTxTo, isAwaitingExecution, isCancelTxDetails } from './utils'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { useKnownAddress } from './hooks/useKnownAddress'
 import useLocalTxStatus from 'src/logic/hooks/useLocalTxStatus'
@@ -189,8 +189,9 @@ export const TxCollapsed = ({
           <Loader size="xs" color="pending" />
         </CircularProgressPainter>
       ) : (
-        (txStatus === LocalTransactionStatus.AWAITING_EXECUTION ||
-          txStatus === LocalTransactionStatus.AWAITING_CONFIRMATIONS) && <SmallDot color={status.color} />
+        (isAwaitingExecution(txStatus) || txStatus === LocalTransactionStatus.AWAITING_CONFIRMATIONS) && (
+          <SmallDot color={status.color} />
+        )
       )}
       <Text size="md" color={status.color} className="col" strong>
         {status.text}

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -6,9 +6,10 @@ import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 
 import { currentSafeNonce } from 'src/logic/safe/store/selectors'
-import { LocalTransactionStatus, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
+import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { useActionButtonsHandlers } from './hooks/useActionButtonsHandlers'
 import useLocalTxStatus from 'src/logic/hooks/useLocalTxStatus'
+import { isAwaitingExecution } from './utils'
 
 const IconButton = styled(MuiIconButton)`
   padding: 8px !important;
@@ -34,13 +35,10 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
   } = useActionButtonsHandlers(transaction)
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
-  const isAwaitingExecution = [
-    LocalTransactionStatus.AWAITING_EXECUTION,
-    LocalTransactionStatus.PENDING_FAILED,
-  ].includes(txStatus)
+  const isAwaitingEx = isAwaitingExecution(txStatus)
 
   const getTitle = () => {
-    if (isAwaitingExecution) {
+    if (isAwaitingEx) {
       return (transaction.executionInfo as MultisigExecutionInfo)?.nonce === nonce
         ? 'Execute'
         : `Transaction with nonce ${nonce} needs to be executed first`
@@ -60,7 +58,7 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
             onMouseEnter={handleOnMouseEnter}
             onMouseLeave={handleOnMouseLeave}
           >
-            <Icon type={isAwaitingExecution ? 'rocket' : 'check'} color="primary" size="sm" />
+            <Icon type={isAwaitingEx ? 'rocket' : 'check'} color="primary" size="sm" />
           </IconButton>
         </span>
       </Tooltip>

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -36,7 +36,7 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
   const txStatus = useLocalTxStatus(transaction)
 
   const isAwaitingExecution =
-    txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED
+    txStatus === (LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED)
   const getTitle = () => {
     if (isAwaitingExecution) {
       return (transaction.executionInfo as MultisigExecutionInfo)?.nonce === nonce

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -34,9 +34,11 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
   } = useActionButtonsHandlers(transaction)
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
+  const isAwaitingExecution = [
+    LocalTransactionStatus.AWAITING_EXECUTION,
+    LocalTransactionStatus.PENDING_FAILED,
+  ].includes(txStatus)
 
-  const isAwaitingExecution =
-    txStatus === (LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED)
   const getTitle = () => {
     if (isAwaitingExecution) {
       return (transaction.executionInfo as MultisigExecutionInfo)?.nonce === nonce

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -24,8 +24,10 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   } = useActionButtonsHandlers(transaction)
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
-  const isAwaitingExecution =
-    txStatus === (LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED)
+  const isAwaitingExecution = [
+    LocalTransactionStatus.AWAITING_EXECUTION,
+    LocalTransactionStatus.PENDING_FAILED,
+  ].includes(txStatus)
 
   const onExecuteOrConfirm = (event) => {
     handleOnMouseLeave()

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -24,8 +24,9 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   } = useActionButtonsHandlers(transaction)
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
+  console.log({ txStatus })
   const isAwaitingExecution =
-    txStatus === LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED
+    txStatus === (LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED)
 
   const onExecuteOrConfirm = (event) => {
     handleOnMouseLeave()

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -4,9 +4,10 @@ import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
 
 import { currentSafeNonce } from 'src/logic/safe/store/selectors'
-import { LocalTransactionStatus, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
+import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { useActionButtonsHandlers } from 'src/routes/safe/components/Transactions/TxList/hooks/useActionButtonsHandlers'
 import useLocalTxStatus from 'src/logic/hooks/useLocalTxStatus'
+import { isAwaitingExecution } from './utils'
 
 type TxExpandedActionsProps = {
   transaction: Transaction
@@ -24,10 +25,7 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   } = useActionButtonsHandlers(transaction)
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
-  const isAwaitingExecution = [
-    LocalTransactionStatus.AWAITING_EXECUTION,
-    LocalTransactionStatus.PENDING_FAILED,
-  ].includes(txStatus)
+  const isAwaitingEx = isAwaitingExecution(txStatus)
 
   const onExecuteOrConfirm = (event) => {
     handleOnMouseLeave()
@@ -35,7 +33,7 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   }
 
   const getConfirmTooltipTitle = () => {
-    if (isAwaitingExecution) {
+    if (isAwaitingEx) {
       return (transaction.executionInfo as MultisigExecutionInfo)?.nonce === nonce
         ? 'Execute'
         : `Transaction with nonce ${nonce} needs to be executed first`
@@ -58,7 +56,7 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
             onMouseLeave={handleOnMouseLeave}
             className="primary"
           >
-            {isAwaitingExecution ? 'Execute' : 'Confirm'}
+            {isAwaitingEx ? 'Execute' : 'Confirm'}
           </Button>
         </span>
       </Tooltip>

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -24,7 +24,6 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   } = useActionButtonsHandlers(transaction)
   const nonce = useSelector(currentSafeNonce)
   const txStatus = useLocalTxStatus(transaction)
-  console.log({ txStatus })
   const isAwaitingExecution =
     txStatus === (LocalTransactionStatus.AWAITING_EXECUTION || LocalTransactionStatus.PENDING_FAILED)
 

--- a/src/routes/safe/components/Transactions/TxList/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/utils.ts
@@ -18,6 +18,7 @@ import {
   isMultiSigExecutionDetails,
   isTransferTxInfo,
   isTxQueued,
+  LocalTransactionStatus,
   Transaction,
 } from 'src/logic/safe/store/models/types/gateway.d'
 import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
@@ -194,3 +195,7 @@ export const isDeeplinkedTx = (): boolean => {
 
   return !txMatch && !!deeplinkMatch?.params?.[TRANSACTION_ID_SLUG]
 }
+
+export const isAwaitingExecution = (
+  txStatus: typeof LocalTransactionStatus[keyof typeof LocalTransactionStatus],
+): boolean => [LocalTransactionStatus.AWAITING_EXECUTION, LocalTransactionStatus.PENDING_FAILED].includes(txStatus)


### PR DESCRIPTION
## What it solves
Resolves #3280

## How this PR fixes it
The status checking logic was fixed to compare it against both `AWAITING_EXECUTION` AND `PENDING_FAILED`.

## How to test it
1. Create a transaction on a 2/? threshold Safe
2. Observe that the action button is 'Confirm', not 'Execute'

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/148943800-934781a5-2d5e-4fe7-89e3-bffb3ca79f39.png)
