### PR TITLE
Fix: Change tx queued copy

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -7,11 +7,10 @@ The status of a transaction can vary depending on whether it has just been submi
 | Status                                                                       | Description                                                              |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
 | Needs your confirmation /<br>Needs confirmations<br>`AWAITING_CONFIRMATIONS` | The transaction still requires confirmations.                            |
-| Needs execution<br>`AWAITING_EXECUTION`                                      | The transaction has sufficient confirmations but has yet to be executed. |
+| Needs execution<br>`AWAITING_EXECUTION` /<br>`PENDING_FAILED`\*                                      | The transaction has sufficient confirmations but has yet to be executed.<br><br>The requested execution was rejected by the user but it can be attempted again.* |
 | Cancelled<br>`CANCELLED`                                                     | The transaction was cancelled.                                           |
 | Failed<br>`FAILED`                                                           | The transaction failed.                                                  |
-| Pending\*<br>`PENDING`                                                       | The transaction has been submitted and is waiting to be mined.           |
-| Execution Failed\*<br>`PENDING_FAILED`                                       | The requested execution failed but it can be attempted again.            |
+| Pending<br>`PENDING`\*                                                       | The transaction has been submitted and is waiting to be mined.*           |
 | Success<br>`SUCCESS`                                                         | The transaction was successfully executed.                               |
 | Transaction will be replaced<br>`WILL_BE_REPLACED`                           | A corresponding rejection transaction has been created.                  |
 

--- a/src/routes/safe/components/Transactions/TxList/hooks/useTransactionStatus.ts
+++ b/src/routes/safe/components/Transactions/TxList/hooks/useTransactionStatus.ts
@@ -39,13 +39,11 @@ export const useTransactionStatus = (transaction: Transaction): TransactionStatu
         setStatus({ color: 'rinkeby', text })
         break
       case LocalTransactionStatus.AWAITING_EXECUTION:
+      case LocalTransactionStatus.PENDING_FAILED:
         setStatus({ color: 'rinkeby', text: 'Needs execution' })
         break
       case LocalTransactionStatus.PENDING:
         setStatus({ color: 'rinkeby', text: 'Pending' })
-        break
-      case LocalTransactionStatus.PENDING_FAILED:
-        setStatus({ color: 'rinkeby', text: 'Execution failed' })
         break
     }
   }, [setStatus, txStatus, currentUser, executionInfo])


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react/issues/3286

## How this PR fixes it
Changes the TxDetails copy when the tx is rejected by the user

## How to test it
1. Try to execute a transaction
2. Reject with MetaMask
3. Check the "Next Queued" tx status copy

## Screenshots
<img width="900" alt="Screen Shot 2022-01-11 at 16 19 09" src="https://user-images.githubusercontent.com/32431609/148970065-0b336972-4975-4e2c-ace2-b477af5f7c65.png">

