### PR TITLE
Fix: CSS in modal header

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,7 +1,8 @@
-import { Button, Icon, Loader, theme, Title as TitleSRC } from '@gnosis.pm/safe-react-components'
+import { Button, Loader, theme, Title as TitleSRC } from '@gnosis.pm/safe-react-components'
 import { ButtonProps as ButtonPropsMUI, Modal as ModalMUI } from '@material-ui/core'
 import cn from 'classnames'
-import { ReactElement, ReactNode, ReactNodeArray } from 'react'
+import { ReactElement, ReactNode } from 'react'
+import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import styled from 'styled-components'
 
 type Theme = typeof theme
@@ -86,36 +87,6 @@ export default GnoModal
 /* Generic Modal */
 /*****************/
 
-/*** Header ***/
-const HeaderSection = styled.div`
-  display: flex;
-  padding: 24px 18px 24px 24px;
-  border-bottom: 2px solid ${({ theme }) => theme.colors.separator};
-
-  h5 {
-    color: ${({ theme }) => theme.colors.text};
-  }
-
-  .close-button {
-    align-self: flex-end;
-    background: none;
-    border: none;
-    padding: 5px;
-    width: 26px;
-    height: 26px;
-
-    span {
-      margin-right: 0;
-    }
-
-    :hover {
-      background: ${({ theme }) => theme.colors.separator};
-      border-radius: 16px;
-      cursor: pointer;
-    }
-  }
-`
-
 const TitleStyled = styled(TitleSRC)`
   display: flex;
   align-items: center;
@@ -148,21 +119,11 @@ const Title = ({ children, ...props }: TitleProps): ReactElement => (
 
 interface HeaderProps {
   children?: ReactNode
-  onClose?: (event: any) => void
+  onClose?: () => unknown
 }
 
-const Header = ({ children, onClose }: HeaderProps): ReactElement => {
-  return (
-    <HeaderSection className="modal-header">
-      {children}
-
-      {onClose && (
-        <button className="close-button" onClick={onClose}>
-          <Icon size="sm" type="cross" />
-        </button>
-      )}
-    </HeaderSection>
-  )
+const Header = ({ children = '', onClose = () => null }: HeaderProps): ReactElement => {
+  return <ModalHeader title={children} onClose={onClose} />
 }
 
 Header.Title = Title
@@ -174,7 +135,7 @@ const BodySection = styled.div<{ withoutPadding: BodyProps['withoutPadding'] }>`
 `
 
 interface BodyProps {
-  children: ReactNode | ReactNodeArray
+  children: ReactNode
   withoutPadding?: boolean
 }
 
@@ -281,7 +242,7 @@ const Buttons = ({ cancelButtonProps = {}, confirmButtonProps = {} }: ButtonsPro
 }
 
 interface FooterProps {
-  children: ReactNode | ReactNodeArray
+  children: ReactNode
   withoutBorder?: boolean
 }
 

--- a/src/routes/safe/components/Balances/SendModal/screens/ModalHeader/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ModalHeader/index.tsx
@@ -1,7 +1,7 @@
 import IconButton from '@material-ui/core/IconButton'
 import { makeStyles } from '@material-ui/core/styles'
 import Close from '@material-ui/icons/Close'
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 import ChainIndicator from 'src/components/ChainIndicator'
 import Paragraph from 'src/components/layout/Paragraph'
@@ -12,9 +12,9 @@ import { styles } from './style'
 const useStyles = makeStyles(styles)
 
 interface HeaderProps {
-  onClose: () => void
+  onClose: () => unknown
   subTitle?: string
-  title: string
+  title: ReactNode
   iconUrl?: string
 }
 
@@ -24,11 +24,11 @@ export const ModalHeader = ({ onClose, subTitle, title, iconUrl }: HeaderProps):
 
   return (
     <Row align="center" className={classes.heading} grow>
-      {iconUrl && <img className={classes.icon} alt={title} src={iconUrl} />}
+      {iconUrl && <img className={classes.icon} alt={typeof title === 'string' ? title : undefined} src={iconUrl} />}
       <Paragraph className={classes.headingText} noMargin weight="bolder">
         {title}
       </Paragraph>
-      <Paragraph className={classes.annotation}>{subTitle ? subTitle : ''}</Paragraph>
+      <Paragraph className={classes.annotation}>{subTitle}</Paragraph>
       <Row className={classes.chainIndicator}>
         {connectedNetwork.chainId && <ChainIndicator chainId={connectedNetwork.chainId} />}
       </Row>

--- a/src/routes/safe/components/Balances/SendModal/screens/ModalHeader/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ModalHeader/style.ts
@@ -3,19 +3,23 @@ import { createStyles } from '@material-ui/core'
 
 export const styles = createStyles({
   heading: {
-    padding: `${md} ${lg}`,
+    padding: `${md} ${lg} 12px`,
     justifyContent: 'flex-start',
     boxSizing: 'border-box',
     maxHeight: '74px',
+    flexWrap: 'nowrap',
   },
   annotation: {
     letterSpacing: '-1px',
     color: secondaryText,
     marginRight: 'auto',
     marginLeft: '20px',
+    whiteSpace: 'nowrap',
+    flex: 1,
   },
   headingText: {
     fontSize: lg,
+    whiteSpace: 'nowrap',
   },
   closeIcon: {
     height: '35px',
@@ -25,6 +29,8 @@ export const styles = createStyles({
     padding: `0 ${md}`,
     height: '20px',
     alignItems: 'center',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
   },
   icon: {
     width: '20px',


### PR DESCRIPTION
## What it solves
Resolves #3288

## How this PR fixes it
Adds `nowrap` to the modal header and and `overflow: hidden` to the ChainIndicator

## Screenshots
 
<img width="608" alt="Screenshot 2022-01-11 at 17 22 00" src="https://user-images.githubusercontent.com/381895/148981710-0fa6701a-a414-4b5d-b23d-b5eaf9b24861.png">

<img width="640" alt="Screenshot 2022-01-11 at 17 22 10" src="https://user-images.githubusercontent.com/381895/148981738-28779502-e256-4647-8e9f-8ce6f3f61f8b.png">

When there's not enough space, the ChainIndicator will be cut off:
<img width="650" alt="Screenshot 2022-01-11 at 17 22 05" src="https://user-images.githubusercontent.com/381895/148981763-3fe787cd-643d-44ac-bd37-4d2e3b0d0cad.png">

