### PR TITLE
Update transaction docs link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For support requests, please open up a [bug issue](https://github.com/gnosis/saf
 
 ## Transactions
 
-Please see the [transaction](docs/transaction.md) notes for more information about transaction details.
+Please see the [transaction](docs/transactions.md) notes for more information about transaction details.
 
 ## Related repos
 


### PR DESCRIPTION
## What it solves
Incorrect docs link.

## How this PR fixes it
The relative path of the transactions docs was incorrect. It has been updated to match the document name.

## How to test it
Click the link in the readme and ensure that it navigates to the docs/transactions.md file.