### PR TITLE
Display MethodDetails content on smaller screens

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
@@ -3,7 +3,7 @@ import { Text } from '@gnosis.pm/safe-react-components'
 import styled from 'styled-components'
 
 import { isArrayParameter } from 'src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils'
-import Value from 'src/routes/safe/components/Transactions/TxList/MethodValue'
+import Value, { ValueWrapper } from 'src/routes/safe/components/Transactions/TxList/MethodValue'
 import { DataDecoded } from '@gnosis.pm/safe-react-gateway-sdk'
 
 const TxDetailsMethodParam = styled.div<{ isArrayParameter: boolean }>`
@@ -38,7 +38,9 @@ export const MethodDetails = ({ data }: { data: DataDecoded }): React.ReactEleme
           <StyledMethodName size="xl" strong>
             {param.name}({param.type}):
           </StyledMethodName>
-          <Value method={data.method} type={param.type} value={param.value as string} />
+          <ValueWrapper>
+            <Value method={data.method} type={param.type} value={param.value as string} />
+          </ValueWrapper>
         </TxDetailsMethodParam>
       ))}
     </TxInfo>

--- a/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
@@ -22,10 +22,6 @@ const TxInfo = styled.div`
   overflow-x: auto;
 `
 
-const StyledMethodName = styled(Text)`
-  white-space: nowrap;
-`
-
 const ValueWrapper = styled.div`
   min-width: 50%;
   flex-shrink: 0;
@@ -40,9 +36,9 @@ export const MethodDetails = ({ data }: { data: DataDecoded }): React.ReactEleme
 
       {data.parameters?.map((param, index) => (
         <TxDetailsMethodParam key={`${data.method}_param-${index}`} isArrayParameter={isArrayParameter(param.type)}>
-          <StyledMethodName size="xl" strong>
+          <Text size="xl" strong>
             {param.name}({param.type}):
-          </StyledMethodName>
+          </Text>
           <ValueWrapper>
             <Value method={data.method} type={param.type} value={param.value as string} />
           </ValueWrapper>

--- a/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
@@ -18,6 +18,7 @@ const TxDetailsMethodParam = styled.div<{ isArrayParameter: boolean }>`
 
 const TxInfo = styled.div`
   padding: 8px 0;
+  overflow-x: auto;
 `
 
 const StyledMethodName = styled(Text)`

--- a/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
@@ -10,6 +10,7 @@ const TxDetailsMethodParam = styled.div<{ isArrayParameter: boolean }>`
   padding-left: 24px;
   display: ${({ isArrayParameter }) => (isArrayParameter ? 'block' : 'flex')};
   align-items: center;
+  flex-wrap: wrap;
 
   p:first-of-type {
     margin-right: ${({ isArrayParameter }) => (isArrayParameter ? '0' : '4px')};

--- a/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodDetails.tsx
@@ -3,7 +3,7 @@ import { Text } from '@gnosis.pm/safe-react-components'
 import styled from 'styled-components'
 
 import { isArrayParameter } from 'src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils'
-import Value, { ValueWrapper } from 'src/routes/safe/components/Transactions/TxList/MethodValue'
+import Value from 'src/routes/safe/components/Transactions/TxList/MethodValue'
 import { DataDecoded } from '@gnosis.pm/safe-react-gateway-sdk'
 
 const TxDetailsMethodParam = styled.div<{ isArrayParameter: boolean }>`
@@ -24,6 +24,11 @@ const TxInfo = styled.div`
 
 const StyledMethodName = styled(Text)`
   white-space: nowrap;
+`
+
+const ValueWrapper = styled.div`
+  min-width: 50%;
+  flex-shrink: 0;
 `
 
 export const MethodDetails = ({ data }: { data: DataDecoded }): React.ReactElement => {

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -13,7 +13,7 @@ const NestedWrapper = styled.div`
   padding-left: 4px;
 `
 
-const GenericValueWrapper = styled.div`
+const ValueWrapper = styled.div`
   min-width: 50%;
   flex-shrink: 0;
 `
@@ -25,10 +25,14 @@ interface RenderValueProps {
 }
 
 const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactElement => {
-  const getTextValue = (value: string) => <HexEncodedData limit={60} hexData={value} />
+  const getTextValue = (value: string) => (
+    <ValueWrapper>
+      <HexEncodedData limit={60} hexData={value} />
+    </ValueWrapper>
+  )
 
   const getArrayValue = (parentId: string, value: string[] | string) => (
-    <GenericValueWrapper>
+    <ValueWrapper>
       [
       <NestedWrapper>
         {(value as string[]).map((currentValue, index) => {
@@ -43,7 +47,7 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
         })}
       </NestedWrapper>
       ]
-    </GenericValueWrapper>
+    </ValueWrapper>
   )
 
   if (isArrayParameter(type) || Array.isArray(value)) {
@@ -56,7 +60,7 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
 const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
   if (isArrayParameter(type) && isAddress(type)) {
     return (
-      <div>
+      <ValueWrapper>
         [
         <NestedWrapper>
           {(props.value as string[]).map((address) => {
@@ -67,7 +71,7 @@ const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
           })}
         </NestedWrapper>
         ]
-      </div>
+      </ValueWrapper>
     )
   }
 

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -13,6 +13,11 @@ const NestedWrapper = styled.div`
   padding-left: 4px;
 `
 
+const GenericValueWrapper = styled.div`
+  min-width: 50%;
+  flex-shrink: 0;
+`
+
 interface RenderValueProps {
   method: string
   type: string
@@ -23,7 +28,7 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
   const getTextValue = (value: string) => <HexEncodedData limit={60} hexData={value} />
 
   const getArrayValue = (parentId: string, value: string[] | string) => (
-    <div>
+    <GenericValueWrapper>
       [
       <NestedWrapper>
         {(value as string[]).map((currentValue, index) => {
@@ -38,7 +43,7 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
         })}
       </NestedWrapper>
       ]
-    </div>
+    </GenericValueWrapper>
   )
 
   if (isArrayParameter(type) || Array.isArray(value)) {

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -13,11 +13,6 @@ const NestedWrapper = styled.div`
   padding-left: 4px;
 `
 
-export const ValueWrapper = styled.div`
-  min-width: 50%;
-  flex-shrink: 0;
-`
-
 interface RenderValueProps {
   method: string
   type: string

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -13,7 +13,7 @@ const NestedWrapper = styled.div`
   padding-left: 4px;
 `
 
-const ValueWrapper = styled.div`
+export const ValueWrapper = styled.div`
   min-width: 50%;
   flex-shrink: 0;
 `
@@ -25,14 +25,10 @@ interface RenderValueProps {
 }
 
 const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactElement => {
-  const getTextValue = (value: string) => (
-    <ValueWrapper>
-      <HexEncodedData limit={60} hexData={value} />
-    </ValueWrapper>
-  )
+  const getTextValue = (value: string) => <HexEncodedData limit={60} hexData={value} />
 
   const getArrayValue = (parentId: string, value: string[] | string) => (
-    <ValueWrapper>
+    <>
       [
       <NestedWrapper>
         {(value as string[]).map((currentValue, index) => {
@@ -47,7 +43,7 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
         })}
       </NestedWrapper>
       ]
-    </ValueWrapper>
+    </>
   )
 
   if (isArrayParameter(type) || Array.isArray(value)) {
@@ -60,7 +56,7 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
 const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
   if (isArrayParameter(type) && isAddress(type)) {
     return (
-      <ValueWrapper>
+      <>
         [
         <NestedWrapper>
           {(props.value as string[]).map((address) => {
@@ -71,7 +67,7 @@ const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
           })}
         </NestedWrapper>
         ]
-      </ValueWrapper>
+      </>
     )
   }
 


### PR DESCRIPTION
## What it solves
Resolves #3284

## How this PR fixes it
Adds line breaks to labels and values within `MethodDetails` if there is not enough space left and adds horizontal scroll.

## How to test it
1. Open https://pr3309--safereact.review-safe.gnosisdev.com/app/eth:0x4FeE396c8d940B801747CA84632580f917690E87/transactions/0x33eb21a8639f9411ae96a388f41b7af573e118771628b5d57c08f96817349ac9
2. Observe that `MethodDetails` data is visible/scrollable on smaller screens

## Screenshots
![Screenshot 2022-01-17 at 12 31 27](https://user-images.githubusercontent.com/5880855/149762226-d8d9cc34-0b76-46c2-ba86-eb8ac4d2e47b.png)


