### PR TITLE
Instantiate contracts via `chainId` from loaded config

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -28,6 +28,8 @@ import useAddressBookSync from 'src/logic/addressBook/hooks/useAddressBookSync'
 import { extractSafeAddress } from 'src/routes/routes'
 import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStorage'
 import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
+import { _getChainId } from 'src/config'
+import { setChainId } from 'src/logic/config/utils'
 
 const notificationStyles = {
   success: {
@@ -78,6 +80,7 @@ const App: React.FC = ({ children }) => {
   // Load the Safes from LS just once,
   // they'll be reloaded on network change
   useEffect(() => {
+    setChainId(_getChainId())
     dispatch(loadSafesFromStorage())
     dispatch(loadCurrentSessionFromStorage())
   }, [dispatch])

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,7 +1,7 @@
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { SnackbarProvider } from 'notistack'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 
 import AlertIcon from 'src/assets/icons/alert.svg'
@@ -26,10 +26,6 @@ import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
 import useAddressBookSync from 'src/logic/addressBook/hooks/useAddressBookSync'
 import { extractSafeAddress } from 'src/routes/routes'
-import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStorage'
-import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
-import { _getChainId } from 'src/config'
-import { setChainId } from 'src/logic/config/utils'
 
 const notificationStyles = {
   success: {
@@ -64,7 +60,6 @@ const App: React.FC = ({ children }) => {
   const currentCurrency = useSelector(currentCurrencySelector)
   const granted = useSelector(grantedSelector)
   const sidebarItems = useSidebarItems()
-  const dispatch = useDispatch()
   useLoadSafe(addressFromUrl) // load initially
   useSafeScheduledUpdates(addressFromUrl) // load every X seconds
   useAddressBookSync()
@@ -76,14 +71,6 @@ const App: React.FC = ({ children }) => {
 
   const onReceiveShow = () => onShow('Receive')
   const onReceiveHide = () => onHide('Receive')
-
-  // Load the Safes from LS just once,
-  // they'll be reloaded on network change
-  useEffect(() => {
-    setChainId(_getChainId())
-    dispatch(loadSafesFromStorage())
-    dispatch(loadCurrentSessionFromStorage())
-  }, [dispatch])
 
   return (
     <Frame>

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -21,7 +21,6 @@ import { loadChains } from 'src/config/cache/chains'
 import { isValidChainId, _getChainId } from 'src/config'
 import { DEFAULT_CHAIN_ID } from 'src/utils/constants'
 import { setChainId } from 'src/logic/config/utils'
-import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 
 // Preloader is rendered outside of '#root' and acts as a loading spinner
 // for the app and then chains loading
@@ -41,8 +40,6 @@ const RootConsumer = (): React.ReactElement | null => {
           // Contracts are instantiated in config middleware upon id change
           setChainId(DEFAULT_CHAIN_ID)
           history.push(WELCOME_ROUTE)
-        } else {
-          instantiateSafeContracts()
         }
         setHasChains(true)
       } catch (err) {

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -38,7 +38,7 @@ const RootConsumer = (): React.ReactElement | null => {
       try {
         await loadChains()
         if (!isValidChainId(_getChainId())) {
-          // Contracts are instantiated in setChainId
+          // Contracts are instantiated in config middleware upon id change
           setChainId(DEFAULT_CHAIN_ID)
           history.push(WELCOME_ROUTE)
         } else {

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -37,7 +37,6 @@ const RootConsumer = (): React.ReactElement | null => {
       try {
         await loadChains()
         if (!isValidChainId(_getChainId())) {
-          // Contracts are instantiated in config middleware upon id change
           setChainId(DEFAULT_CHAIN_ID)
           history.push(WELCOME_ROUTE)
         }
@@ -48,6 +47,9 @@ const RootConsumer = (): React.ReactElement | null => {
       }
     }
     initChains()
+
+    // Set store chainId and init contracts/session
+    setChainId(_getChainId())
   }, [])
 
   // Chains failed to load

--- a/src/components/Root/index.tsx
+++ b/src/components/Root/index.tsx
@@ -21,6 +21,7 @@ import { loadChains } from 'src/config/cache/chains'
 import { isValidChainId, _getChainId } from 'src/config'
 import { DEFAULT_CHAIN_ID } from 'src/utils/constants'
 import { setChainId } from 'src/logic/config/utils'
+import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 
 // Preloader is rendered outside of '#root' and acts as a loading spinner
 // for the app and then chains loading
@@ -37,8 +38,11 @@ const RootConsumer = (): React.ReactElement | null => {
       try {
         await loadChains()
         if (!isValidChainId(_getChainId())) {
+          // Contracts are instantiated in setChainId
           setChainId(DEFAULT_CHAIN_ID)
           history.push(WELCOME_ROUTE)
+        } else {
+          instantiateSafeContracts()
         }
         setHasChains(true)
       } catch (err) {

--- a/src/logic/config/store/middleware/index.ts
+++ b/src/logic/config/store/middleware/index.ts
@@ -1,6 +1,5 @@
 import { Action } from 'redux'
 import { _setChainId } from 'src/config'
-import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 
 import { clearCurrentSession } from 'src/logic/currentSession/store/actions/clearCurrentSession'
 import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
@@ -21,9 +20,6 @@ export const configMiddleware =
     switch (action.type) {
       case CONFIG_ACTIONS.SET_CHAIN_ID: {
         _setChainId(currentChainId(state))
-
-        // Relies of _chainId, which is set by _setChainId
-        instantiateSafeContracts()
 
         dispatch(clearSafeList())
         dispatch(clearCurrentSession())

--- a/src/logic/config/store/middleware/index.ts
+++ b/src/logic/config/store/middleware/index.ts
@@ -1,4 +1,6 @@
 import { Action } from 'redux'
+import { _setChainId } from 'src/config'
+import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 
 import { clearCurrentSession } from 'src/logic/currentSession/store/actions/clearCurrentSession'
 import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
@@ -6,15 +8,23 @@ import { clearSafeList } from 'src/logic/safe/store/actions/clearSafeList'
 import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStorage'
 import { Dispatch } from 'src/logic/safe/store/actions/types'
 import { CONFIG_ACTIONS } from '../actions'
+import { currentChainId } from '../selectors'
+import { store as reduxStore } from 'src/store'
 
 export const configMiddleware =
-  ({ dispatch }) =>
+  ({ dispatch, getState }: typeof reduxStore) =>
   (next: Dispatch) =>
   async (action: Action<typeof CONFIG_ACTIONS.SET_CHAIN_ID>) => {
     const handledAction = next(action)
 
+    const state = getState()
     switch (action.type) {
       case CONFIG_ACTIONS.SET_CHAIN_ID: {
+        _setChainId(currentChainId(state))
+
+        // Relies of _chainId, which is set by _setChainId
+        instantiateSafeContracts()
+
         dispatch(clearSafeList())
         dispatch(clearCurrentSession())
         dispatch(loadSafesFromStorage())

--- a/src/logic/config/store/middleware/index.ts
+++ b/src/logic/config/store/middleware/index.ts
@@ -1,5 +1,4 @@
 import { Action } from 'redux'
-import { _setChainId } from 'src/config'
 
 import { clearCurrentSession } from 'src/logic/currentSession/store/actions/clearCurrentSession'
 import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
@@ -7,20 +6,16 @@ import { clearSafeList } from 'src/logic/safe/store/actions/clearSafeList'
 import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStorage'
 import { Dispatch } from 'src/logic/safe/store/actions/types'
 import { CONFIG_ACTIONS } from '../actions'
-import { currentChainId } from '../selectors'
 import { store as reduxStore } from 'src/store'
 
 export const configMiddleware =
-  ({ dispatch, getState }: typeof reduxStore) =>
+  ({ dispatch }: typeof reduxStore) =>
   (next: Dispatch) =>
   async (action: Action<typeof CONFIG_ACTIONS.SET_CHAIN_ID>) => {
     const handledAction = next(action)
 
-    const state = getState()
     switch (action.type) {
       case CONFIG_ACTIONS.SET_CHAIN_ID: {
-        _setChainId(currentChainId(state))
-
         dispatch(clearSafeList())
         dispatch(clearCurrentSession())
         dispatch(loadSafesFromStorage())

--- a/src/logic/config/utils/index.ts
+++ b/src/logic/config/utils/index.ts
@@ -1,4 +1,3 @@
-import { _getChainId } from 'src/config'
 import { ChainId } from 'src/config/chain.d'
 import { store } from 'src/store'
 import { setChainIdAction } from 'src/logic/config/store/actions'

--- a/src/logic/config/utils/index.ts
+++ b/src/logic/config/utils/index.ts
@@ -2,8 +2,10 @@ import { _getChainId, _setChainId } from 'src/config'
 import { ChainId } from 'src/config/chain.d'
 import { store } from 'src/store'
 import { setChainIdAction } from 'src/logic/config/store/actions'
+import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 
 export const setChainId = (newChainId: ChainId) => {
   _setChainId(newChainId)
   store.dispatch(setChainIdAction(newChainId))
+  instantiateSafeContracts()
 }

--- a/src/logic/config/utils/index.ts
+++ b/src/logic/config/utils/index.ts
@@ -1,7 +1,9 @@
 import { ChainId } from 'src/config/chain.d'
 import { store } from 'src/store'
 import { setChainIdAction } from 'src/logic/config/store/actions'
+import { _setChainId } from 'src/config'
 
 export const setChainId = (newChainId: ChainId) => {
+  _setChainId(newChainId)
   store.dispatch(setChainIdAction(newChainId))
 }

--- a/src/logic/config/utils/index.ts
+++ b/src/logic/config/utils/index.ts
@@ -1,11 +1,8 @@
-import { _getChainId, _setChainId } from 'src/config'
+import { _getChainId } from 'src/config'
 import { ChainId } from 'src/config/chain.d'
 import { store } from 'src/store'
 import { setChainIdAction } from 'src/logic/config/store/actions'
-import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 
 export const setChainId = (newChainId: ChainId) => {
-  _setChainId(newChainId)
   store.dispatch(setChainIdAction(newChainId))
-  instantiateSafeContracts()
 }

--- a/src/logic/contracts/safeContracts.ts
+++ b/src/logic/contracts/safeContracts.ts
@@ -194,9 +194,9 @@ export const getMasterCopyAddressFromProxyAddress = async (proxyAddress: string)
   return masterCopyAddress
 }
 
-export const instantiateSafeContracts = async () => {
+export const instantiateSafeContracts = () => {
   const web3 = getWeb3()
-  const chainId = (await getChainIdFrom(web3)).toString() as ChainId
+  const chainId = _getChainId()
 
   // Create ProxyFactory Master Copy
   proxyFactoryMaster = getProxyFactoryContractInstance(web3, chainId)
@@ -211,8 +211,8 @@ export const instantiateSafeContracts = async () => {
   multiSend = getMultiSendContractInstance(web3, chainId)
 }
 
-export const getSafeMasterContract = async () => {
-  await instantiateSafeContracts()
+export const getSafeMasterContract = () => {
+  instantiateSafeContracts()
   return safeMaster
 }
 

--- a/src/logic/contracts/safeContracts.ts
+++ b/src/logic/contracts/safeContracts.ts
@@ -15,7 +15,7 @@ import { getChainById, _getChainId } from 'src/config'
 import { ChainId } from 'src/config/chain.d'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { calculateGasOf, EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
-import { getWeb3, getChainIdFrom } from 'src/logic/wallets/getWeb3'
+import { getWeb3, getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { GnosisSafe } from 'src/types/contracts/gnosis_safe.d'
 import { ProxyFactory } from 'src/types/contracts/proxy_factory.d'
 import { CompatibilityFallbackHandler } from 'src/types/contracts/compatibility_fallback_handler.d'
@@ -195,7 +195,7 @@ export const getMasterCopyAddressFromProxyAddress = async (proxyAddress: string)
 }
 
 export const instantiateSafeContracts = () => {
-  const web3 = getWeb3()
+  const web3 = getWeb3ReadOnly()
   const chainId = _getChainId()
 
   // Create ProxyFactory Master Copy

--- a/src/logic/contracts/safeContracts.ts
+++ b/src/logic/contracts/safeContracts.ts
@@ -15,7 +15,7 @@ import { getChainById, _getChainId } from 'src/config'
 import { ChainId } from 'src/config/chain.d'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { calculateGasOf, EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
-import { getWeb3, getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { GnosisSafe } from 'src/types/contracts/gnosis_safe.d'
 import { ProxyFactory } from 'src/types/contracts/proxy_factory.d'
 import { CompatibilityFallbackHandler } from 'src/types/contracts/compatibility_fallback_handler.d'
@@ -195,7 +195,7 @@ export const getMasterCopyAddressFromProxyAddress = async (proxyAddress: string)
 }
 
 export const instantiateSafeContracts = () => {
-  const web3 = getWeb3ReadOnly()
+  const web3 = getWeb3()
   const chainId = _getChainId()
 
   // Create ProxyFactory Master Copy

--- a/src/logic/safe/utils/safeVersion.ts
+++ b/src/logic/safe/utils/safeVersion.ts
@@ -68,7 +68,7 @@ export const checkIfSafeNeedsUpdate = async (
 export const getCurrentMasterContractLastVersion = async (): Promise<string> => {
   let safeMasterVersion: string
   try {
-    const safeMaster = await getSafeMasterContract()
+    const safeMaster = getSafeMasterContract()
     safeMasterVersion = await safeMaster.methods.VERSION().call()
   } catch (err) {
     // Default in case that it's not possible to obtain the version from the contract, returns a hardcoded value or an

--- a/src/logic/wallets/store/middlewares/providerWatcher.ts
+++ b/src/logic/wallets/store/middlewares/providerWatcher.ts
@@ -1,10 +1,13 @@
+import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 import closeSnackbar from 'src/logic/notifications/store/actions/closeSnackbar'
 import { getProviderInfo, getWeb3 } from 'src/logic/wallets/getWeb3'
 import { fetchProvider } from 'src/logic/wallets/store/actions'
 import { ADD_PROVIDER } from 'src/logic/wallets/store/actions/addProvider'
 import { REMOVE_PROVIDER } from 'src/logic/wallets/store/actions/removeProvider'
-
 import { loadFromStorage, removeFromStorage, saveToStorage } from 'src/utils/storage'
+import { store as reduxStore } from 'src/store'
+import { Dispatch } from 'redux'
+import { ProviderState } from '../reducer/provider'
 
 const watchedActions = [ADD_PROVIDER, REMOVE_PROVIDER]
 
@@ -16,50 +19,60 @@ export const loadLastUsedProvider = async (): Promise<string | undefined> => {
   return lastUsedProvider
 }
 
-let watcherInterval
-const providerWatcherMware = (store) => (next) => async (action) => {
-  const handledAction = next(action)
-
-  if (watchedActions.includes(action.type)) {
-    switch (action.type) {
-      case ADD_PROVIDER: {
-        const currentProviderProps = action.payload.toJS()
-
-        if (watcherInterval) {
-          clearInterval(watcherInterval)
-        }
-
-        saveToStorage(LAST_USED_PROVIDER_KEY, currentProviderProps.name)
-
-        watcherInterval = setInterval(async () => {
-          const web3 = getWeb3()
-          const providerInfo = await getProviderInfo(web3)
-
-          const networkChanged = currentProviderProps.network !== providerInfo.network
-
-          if (networkChanged) {
-            store.dispatch(closeSnackbar({ dismissAll: true }))
-          }
-
-          if (currentProviderProps.account !== providerInfo.account || networkChanged) {
-            store.dispatch(fetchProvider(currentProviderProps.name))
-          }
-        }, 2000)
-
-        break
-      }
-      case REMOVE_PROVIDER:
-        clearInterval(watcherInterval)
-        if (!action.payload?.keepStorageKey) {
-          removeFromStorage(LAST_USED_PROVIDER_KEY)
-        }
-        break
-      default:
-        break
-    }
-  }
-
-  return handledAction
+type ProviderWatcherAction = {
+  type: string
+  payload: ProviderState
 }
+
+let watcherInterval: NodeJS.Timer
+const providerWatcherMware =
+  (store: typeof reduxStore) =>
+  (next: Dispatch) =>
+  async (action: ProviderWatcherAction): Promise<ProviderWatcherAction> => {
+    const handledAction = next(action)
+
+    if (watchedActions.includes(action.type)) {
+      switch (action.type) {
+        case ADD_PROVIDER: {
+          const currentProviderProps = action.payload.toJS()
+
+          if (watcherInterval) {
+            clearInterval(watcherInterval)
+          }
+
+          instantiateSafeContracts()
+
+          saveToStorage(LAST_USED_PROVIDER_KEY, currentProviderProps.name)
+
+          watcherInterval = setInterval(async () => {
+            const web3 = getWeb3()
+            const providerInfo = await getProviderInfo(web3)
+
+            const networkChanged = currentProviderProps.network !== providerInfo.network
+
+            if (networkChanged) {
+              store.dispatch(closeSnackbar({ dismissAll: true }))
+            }
+
+            if (currentProviderProps.account !== providerInfo.account || networkChanged) {
+              store.dispatch(fetchProvider(currentProviderProps.name))
+            }
+          }, 2000)
+
+          break
+        }
+        case REMOVE_PROVIDER:
+          clearInterval(watcherInterval)
+          if (!action.payload?.keepStorageKey) {
+            removeFromStorage(LAST_USED_PROVIDER_KEY)
+          }
+          break
+        default:
+          break
+      }
+    }
+
+    return handledAction
+  }
 
 export default providerWatcherMware

--- a/src/logic/wallets/store/reducer/provider.ts
+++ b/src/logic/wallets/store/reducer/provider.ts
@@ -6,7 +6,7 @@ import { makeProvider, ProviderRecord, ProviderProps } from 'src/logic/wallets/s
 
 export const PROVIDER_REDUCER_ID = 'providers'
 
-export type ProviderState = ProviderRecord
+export type ProviderState = ProviderRecord & { keepStorageKey?: boolean }
 
 const providerReducer = handleActions(
   {

--- a/src/routes/CreateSafePage/CreateSafePage.tsx
+++ b/src/routes/CreateSafePage/CreateSafePage.tsx
@@ -37,6 +37,7 @@ import { loadFromStorage, saveToStorage } from 'src/utils/storage'
 import SafeCreationProcess from './components/SafeCreationProcess'
 import SelectWalletAndNetworkStep, { selectWalletAndNetworkStepLabel } from './steps/SelectWalletAndNetworkStep'
 import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
+import { currentChainId } from 'src/logic/config/store/selectors'
 
 function CreateSafePage(): ReactElement {
   const [safePendingToBeCreated, setSafePendingToBeCreated] = useState<CreateSafeFormValues>()
@@ -44,6 +45,7 @@ function CreateSafePage(): ReactElement {
   const providerName = useSelector(providerNameSelector)
   const isWrongNetwork = useSelector(shouldSwitchWalletChain)
   const provider = !!providerName && !isWrongNetwork
+  const chainId = useSelector(currentChainId)
 
   useEffect(() => {
     const checkIfSafeIsPendingToBeCreated = async (): Promise<void> => {
@@ -55,14 +57,14 @@ function CreateSafePage(): ReactElement {
         loadFromStorage<CreateSafeFormValues>(SAFE_PENDING_CREATION_STORAGE_KEY),
       )
 
-      if (provider) {
-        await instantiateSafeContracts()
+      if (provider && chainId) {
+        instantiateSafeContracts()
         setSafePendingToBeCreated(safePendingToBeCreated)
       }
       setIsLoading(false)
     }
     checkIfSafeIsPendingToBeCreated()
-  }, [provider])
+  }, [provider, chainId])
 
   const userWalletAddress = useSelector(userAccountSelector)
   const addressBook = useSelector(currentNetworkAddressBookAsMap)

--- a/src/routes/CreateSafePage/CreateSafePage.tsx
+++ b/src/routes/CreateSafePage/CreateSafePage.tsx
@@ -36,8 +36,6 @@ import ReviewNewSafeStep, { reviewNewSafeStepLabel } from './steps/ReviewNewSafe
 import { loadFromStorage, saveToStorage } from 'src/utils/storage'
 import SafeCreationProcess from './components/SafeCreationProcess'
 import SelectWalletAndNetworkStep, { selectWalletAndNetworkStepLabel } from './steps/SelectWalletAndNetworkStep'
-import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
-import { currentChainId } from 'src/logic/config/store/selectors'
 
 function CreateSafePage(): ReactElement {
   const [safePendingToBeCreated, setSafePendingToBeCreated] = useState<CreateSafeFormValues>()
@@ -45,7 +43,6 @@ function CreateSafePage(): ReactElement {
   const providerName = useSelector(providerNameSelector)
   const isWrongNetwork = useSelector(shouldSwitchWalletChain)
   const provider = !!providerName && !isWrongNetwork
-  const chainId = useSelector(currentChainId)
 
   useEffect(() => {
     const checkIfSafeIsPendingToBeCreated = async (): Promise<void> => {
@@ -57,14 +54,13 @@ function CreateSafePage(): ReactElement {
         loadFromStorage<CreateSafeFormValues>(SAFE_PENDING_CREATION_STORAGE_KEY),
       )
 
-      if (provider && chainId) {
-        instantiateSafeContracts()
+      if (provider) {
         setSafePendingToBeCreated(safePendingToBeCreated)
       }
       setIsLoading(false)
     }
     checkIfSafeIsPendingToBeCreated()
-  }, [provider, chainId])
+  }, [provider])
 
   const userWalletAddress = useSelector(userAccountSelector)
   const addressBook = useSelector(currentNetworkAddressBookAsMap)

--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -10,7 +10,6 @@ import Button from 'src/components/layout/Button'
 import Heading from 'src/components/layout/Heading'
 import Img from 'src/components/layout/Img'
 import Paragraph from 'src/components/layout/Paragraph'
-import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { getWeb3, isTxPendingError } from 'src/logic/wallets/getWeb3'
 import { background, connected, fontColor } from 'src/theme/variables'
@@ -24,7 +23,6 @@ import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { NOTIFICATIONS } from 'src/logic/notifications'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
 import { getNewSafeAddressFromLogs } from 'src/routes/opening/utils/getSafeAddressFromLogs'
-import { currentChainId } from 'src/logic/config/store/selectors'
 
 export const SafeDeployment = ({
   creationTxHash,
@@ -43,7 +41,6 @@ export const SafeDeployment = ({
   const [waitingSafeDeployed, setWaitingSafeDeployed] = useState(false)
   const [continueButtonDisabled, setContinueButtonDisabled] = useState(false)
   const provider = useSelector(providerNameSelector)
-  const chainId = useSelector(currentChainId)
   const dispatch = useDispatch()
 
   const confirmationStep = isConfirmationStep(stepIndex)
@@ -96,11 +93,10 @@ export const SafeDeployment = ({
   }
 
   useEffect(() => {
-    if (provider && chainId) {
-      instantiateSafeContracts()
+    if (provider) {
       setLoading(false)
     }
-  }, [provider, chainId])
+  }, [provider])
 
   // creating safe from from submission
   useEffect(() => {

--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -24,6 +24,7 @@ import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { NOTIFICATIONS } from 'src/logic/notifications'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
 import { getNewSafeAddressFromLogs } from 'src/routes/opening/utils/getSafeAddressFromLogs'
+import { currentChainId } from 'src/logic/config/store/selectors'
 
 export const SafeDeployment = ({
   creationTxHash,
@@ -42,6 +43,7 @@ export const SafeDeployment = ({
   const [waitingSafeDeployed, setWaitingSafeDeployed] = useState(false)
   const [continueButtonDisabled, setContinueButtonDisabled] = useState(false)
   const provider = useSelector(providerNameSelector)
+  const chainId = useSelector(currentChainId)
   const dispatch = useDispatch()
 
   const confirmationStep = isConfirmationStep(stepIndex)
@@ -94,15 +96,11 @@ export const SafeDeployment = ({
   }
 
   useEffect(() => {
-    const loadContracts = async () => {
-      await instantiateSafeContracts()
+    if (provider && chainId) {
+      instantiateSafeContracts()
       setLoading(false)
     }
-
-    if (provider) {
-      loadContracts()
-    }
-  }, [provider])
+  }, [provider, chainId])
 
   // creating safe from from submission
   useEffect(() => {


### PR DESCRIPTION
## What it solves
Resolves #3311

## How this PR fixes it
Contracts were being instantiated via the `web3` object, meaning that the `chainId` could be stale, i.e. the user is connected to Rinkeby but the unified app is on Avalanche.

Instead of relying on the `chainId` from the `web3` object, `_chainId` (a local mirror of that from the store) is used instead. This is kept in sync with the current network displayed in the UI via the config middleware (where the contracts are initiated).

## How to test it
1. Open a Safe on Rinkeby.
2. Create a MultiSend transaction via the Transaction Builder.
3. Switch to Avalanche (which uses a different addressed MultiSendOnly contract when compared to Rinkeby) via the network selector in the top right but do not connect via MetaMask.
4. Submit the transaction and observe that it does not show an unexpected deligate call, instead the known one.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/149758378-46ead336-1412-490d-a5f7-520e5a2e2031.png)
