### PR TITLE
Execute depending on approval

### DIFF
--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -120,8 +120,8 @@ export class TxSender {
         txDetails = await saveTxToHistory({ ...txArgs, signature, origin })
       } catch (err) {
         logError(Errors._816, err.message)
+        return
       }
-      return
     }
 
     notifications.closePending()

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -120,8 +120,8 @@ export class TxSender {
         txDetails = await saveTxToHistory({ ...txArgs, signature, origin })
       } catch (err) {
         logError(Errors._816, err.message)
-        return
       }
+      return
     }
 
     notifications.closePending()

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -56,7 +56,7 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
       safeAddress: props.safeAddress,
       to: tx.to,
       txData: tx.data ?? EMPTY_DATA,
-      txNonce: '',
+      txNonce: tx.nonce,
       valueInWei: tx.value,
       safeTxGas: tx.safeTxGas,
       ethParameters: props.ethParameters,

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -86,6 +86,7 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
     }
 
     sender.safeTxHash = tx.safeTxHash
+    sender.isExecution = props.approveAndExecute || sender.isExecution
 
     sender.submitTx(state)
   }

--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -86,7 +86,6 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
     }
 
     sender.safeTxHash = tx.safeTxHash
-    sender.isExecution = props.approveAndExecute || sender.isExecution
 
     sender.submitTx(state)
   }


### PR DESCRIPTION
## What it solves
Resolves #3305

## How this PR fixes it
The logic behind whether the transaction should execute now takes into account whether it is an approval transaction or not.

## How to test it
1. Create a transaction but do not execute it.
2. Execute it and observe that it doesn't request an off-chain signature, instead an execution.