### PR TITLE
Updated @gnosis.pm/safe-react-gateway-sdk to fix SafeAppsResponse types

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@gnosis.pm/safe-core-sdk": "^1.1.1",
     "@gnosis.pm/safe-deployments": "^1.5.0",
     "@gnosis.pm/safe-react-components": "^0.9.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "2.8.1",
+    "@gnosis.pm/safe-react-gateway-sdk": "2.8.2",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.20.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.0",

--- a/src/routes/safe/components/Apps/components/AppsList.test.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.test.tsx
@@ -51,8 +51,6 @@ beforeEach(() => {
   )
 
   jest.spyOn(safeAppsGatewaySDK, 'getSafeApps').mockReturnValueOnce(
-    // remove this after update the bug in the types in the safe-react-gateway-sdk
-    // @ts-ignore
     Promise.resolve([
       {
         id: 13,
@@ -63,7 +61,7 @@ beforeEach(() => {
         chainIds: ['1', '4'],
         provider: undefined,
         accessControl: {
-          type: 'NO_RESTRICTIONS',
+          type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.NoRestrictions,
         },
       },
       {
@@ -76,7 +74,7 @@ beforeEach(() => {
         chainIds: ['1', '4'],
         provider: undefined,
         accessControl: {
-          type: 'DOMAIN_ALLOWLIST',
+          type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.DomainAllowlist,
           value: ['https://gnosis-safe.io'],
         },
       },
@@ -89,7 +87,7 @@ beforeEach(() => {
         chainIds: ['1', '4'],
         provider: undefined,
         accessControl: {
-          type: 'NO_RESTRICTIONS',
+          type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.NoRestrictions,
         },
       },
       {
@@ -100,9 +98,8 @@ beforeEach(() => {
         description: 'A Safe app to compose custom transactions',
         chainIds: ['1', '4', '56', '100', '137', '246', '73799'],
         provider: undefined,
-
         accessControl: {
-          type: 'DOMAIN_ALLOWLIST',
+          type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.DomainAllowlist,
           value: ['https://gnosis-safe.io'],
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,10 +1978,10 @@
     react-media "^1.10.0"
     web3-utils "^1.6.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.1.tgz#3ed166fb49fa19837c9ce8d9ba4f29a14755e9c4"
-  integrity sha512-J6gJT6sbXvEPqhrWepEEgwYseo4UVUU3wNS9GNIpGMuh0zi7ZU0Gld+yXqSAoZWtS3hCntg7lyuM8W31AEjQLQ==
+"@gnosis.pm/safe-react-gateway-sdk@2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.2.tgz#10c8158a9f3f0296ad1ee52e16f9fb41fa82f350"
+  integrity sha512-UJa7wLd9CvtPhnO+o1nLcURIfdEpVBB2XeHU0oU100y45DdVnCGsLcrSdmslIRH/odhhs3JYpXOJCzlfJQW+2A==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 


### PR DESCRIPTION
## What it solves
Resolves [this minor issue with the types in the gateway-sdk](https://github.com/gnosis/safe-react-apps/issues/286)

## How this PR fixes it

Updated `@gnosis.pm/safe-react-gateway-sdk` to `2.8.2` version and removed the `@ts-ignore` in the `AppList.test.js`
