### PR TITLE
fix: transaction stage-relative execution

### DIFF
--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -11,6 +11,8 @@ import { Dispatch, DispatchReturn } from './types'
 import { Confirmation } from 'src/logic/safe/store/models/types/confirmation'
 import { TxSender } from './createTransaction'
 import { logError, Errors } from 'src/logic/exceptions/CodedException'
+import { getLastTransaction } from '../selectors/gatewayTransactions'
+import { shouldExecuteTransaction } from './utils'
 
 interface ProcessTransactionArgs {
   approveAndExecute: boolean
@@ -60,7 +62,6 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
       valueInWei: tx.value,
       safeTxGas: tx.safeTxGas,
       ethParameters: props.ethParameters,
-      delayExecution: !props.approveAndExecute,
     }
 
     // Populate instance vars
@@ -71,7 +72,12 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
       return
     }
 
-    const preApprovingOwner = txProps.delayExecution && !props.thresholdReached ? props.userAddress : undefined
+    // Execute right away?
+    sender.isExecution =
+      props.approveAndExecute ||
+      (await shouldExecuteTransaction(sender.safeInstance, sender.nonce, getLastTransaction(state)))
+
+    const preApprovingOwner = props.approveAndExecute && !props.thresholdReached ? props.userAddress : undefined
 
     sender.txArgs = {
       ...tx, // Merge previous tx with new data


### PR DESCRIPTION
## What it solves
Resolves #3305

## How this PR fixes it
Instead of blanket establishing `isExecution` within `TxSender`, the logic is now extracted into the respective transaction creation/processing function as the previous logic was before the refactor.

On top of this, the transaction proposal to backend now depends on whether the user is an owner.

## How to test it
Every variation of transaction is affected by this. The cases are as follows:

#### 1/? threshold:
1. Create and execute transaction immediately.
2. Queue transaction and execute later by owner.
3. Queue transaction and execute by non-owner.

#### 2+/? threshold:
1. Create and confirm transaction then execute by owner(s).
2. Create and confirm transaction then execute by non-owner.

#### Safe creation
1. Create Safe successfully.