### PR TITLE
fix: remove unnecessary transaction proposals

### DIFF
--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -48,7 +48,7 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
     // Selectors
     const state = getState()
 
-    const { tx } = props
+    const { tx, approveAndExecute } = props
 
     const txProps = {
       navigateToTransactionsTab: false,
@@ -74,10 +74,12 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
 
     // Execute right away?
     sender.isExecution =
-      props.approveAndExecute ||
+      approveAndExecute ||
       (await shouldExecuteTransaction(sender.safeInstance, sender.nonce, getLastTransaction(state)))
 
-    const preApprovingOwner = props.approveAndExecute && !props.thresholdReached ? props.userAddress : undefined
+    sender.approveAndExecute = approveAndExecute
+
+    const preApprovingOwner = approveAndExecute && !props.thresholdReached ? props.userAddress : undefined
 
     sender.txArgs = {
       ...tx, // Merge previous tx with new data


### PR DESCRIPTION
## What it solves
Resolves #3326

## How this PR fixes it
Transaction proposal now takes whether the transaction is being immediately created and executed into account. Proposals now only occur when a transaction is being created, created and immediately executed (1 threshold) or confirmed. (Execution should not propose).

An extra flag is now passed from `processTransaction` to our `TxSender`: `approveAndExecute`. This flag is referenced to determine `isImmediateExecution` (a 1/? threshold Safe creating and immediately execution a transaction):

```ts
    // Creation or confirmation
    const isOffChainSigning = !isExecution && signature

    // 1/? Safe is creating and executing transaction immediately
    const isOnChainSigning = isExecution && !signature
    const isImmediateExecution = isOnChainSigning && !approveAndExecute

    if (isOffChainSigning || isImmediateExecution) {
      // Propose
    }
```

## How to test it
Please bear in mind that this touches upon all transaction types.

All [reference data cases ](https://github.com/gnosis/safe-react/issues/3326) in the issue HAVE been successfully tested, but it should also be verified on hardware wallets.

There should be NO backend proposal network call when executing the following
- A confirmed transaction on a 1/? Safe by a (non-)owner
- A confirmed transaction on a 2+/? Safe by a (non-)owner