### PR TITLE
feat: show ERC-721 token ids

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/hooks/useAssetInfo.ts
+++ b/src/routes/safe/components/Transactions/TxList/hooks/useAssetInfo.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 
 import { getNativeCurrency } from 'src/config'
 import { isCustomTxInfo, isSettingsChangeTxInfo, isTransferTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
-import { getTxAmount, NOT_AVAILABLE } from 'src/routes/safe/components/Transactions/TxList/utils'
+import { getTokenIdLabel, getTxAmount, NOT_AVAILABLE } from 'src/routes/safe/components/Transactions/TxList/utils'
 
 export type TokenTransferAsset = {
   type: 'Transfer'
@@ -53,7 +53,7 @@ export const useAssetInfo = (txInfo: TransactionInfo): AssetInfo | undefined => 
         case TokenType.ERC721: {
           setAsset({
             type: 'Transfer',
-            name: transferInfo.tokenName ?? defaultTokenTransferAsset.name,
+            name: `${transferInfo.tokenName ?? defaultTokenTransferAsset.name} ${getTokenIdLabel(transferInfo)}`,
             logoUri: transferInfo.logoUri ?? defaultTokenTransferAsset.logoUri,
             directionSign: directionSign,
             amountWithSymbol,

--- a/src/routes/safe/components/Transactions/TxList/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/utils.ts
@@ -6,6 +6,7 @@ import {
   TransactionDetails,
   MultisigExecutionDetails,
   MultisigExecutionInfo,
+  Erc721Transfer,
 } from '@gnosis.pm/safe-react-gateway-sdk'
 import { BigNumber } from 'bignumber.js'
 import { matchPath } from 'react-router-dom'
@@ -43,6 +44,10 @@ const getAmountWithSymbol = (
   return `${txAmount} ${symbol}`
 }
 
+export const getTokenIdLabel = ({ tokenId }: Erc721Transfer): string => {
+  return tokenId ? `(#${tokenId})` : ''
+}
+
 export const getTxAmount = (txInfo?: TransactionInfo, formatted = true): string => {
   if (!txInfo || !isTransferTxInfo(txInfo)) {
     return NOT_AVAILABLE
@@ -60,7 +65,7 @@ export const getTxAmount = (txInfo?: TransactionInfo, formatted = true): string 
       )
     case TokenType.ERC721:
       // simple workaround to avoid displaying unexpected values for incoming NFT transfer
-      return `1 ${txInfo.transferInfo.tokenSymbol}`
+      return `1 ${txInfo.transferInfo.tokenSymbol} ${getTokenIdLabel(txInfo.transferInfo)}`
     case TokenType.NATIVE_COIN: {
       const nativeCurrency = getNativeCurrency()
       return getAmountWithSymbol(


### PR DESCRIPTION
## What it solves
Resolves #3241

## How this PR fixes it
ERC-721 token `name`s and `amountWithSymbol`s are now appended with a `(#tokenId)`.

## How to test it
1. Queue a ERC-721 token transfer.
2. Observe the token id appended to the title and transaction info.

This should also be present on receipts as well.

## Screenshots

#### Receipt
![image](https://user-images.githubusercontent.com/20442784/150165447-e0c314e9-4ad1-4cb1-8475-5201754a6118.png)

#### Send
![image](https://user-images.githubusercontent.com/20442784/150165505-29567a2d-8be3-4029-9d0d-fc467cff0c0f.png)
