### PR TITLE
fix: NFT image from uri

### DIFF
--- a/src/logic/collectibles/sources/Gnosis.ts
+++ b/src/logic/collectibles/sources/Gnosis.ts
@@ -2,7 +2,6 @@ import { SafeCollectibleResponse, TokenType } from '@gnosis.pm/safe-react-gatewa
 
 import { Collectibles, NFTAsset, NFTAssets, NFTTokens } from 'src/logic/collectibles/sources/collectibles.d'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
-import NFTIcon from 'src/routes/safe/components/Balances/assets/nft_icon.png'
 import { fetchSafeCollectibles } from 'src/logic/tokens/api/fetchSafeCollectibles'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
@@ -57,7 +56,7 @@ class Gnosis {
     return {
       address: mainAssetAddress,
       description: asset.name,
-      image: asset.logoUri || NFTIcon,
+      image: asset.logoUri,
       name: asset.name,
       numberOfTokens,
       slug: `${mainAssetAddress}_${asset.name}`,
@@ -84,7 +83,8 @@ class Gnosis {
       assetAddress: token.address,
       color: 'red',
       description: token.description || '',
-      image: token.imageUri || NFTIcon,
+      image: token.imageUri,
+      uri: token.uri,
       name: token.name || '',
       tokenId: token.id,
     }))

--- a/src/logic/collectibles/sources/collectibles.d.ts
+++ b/src/logic/collectibles/sources/collectibles.d.ts
@@ -41,6 +41,7 @@ export interface NFTToken {
   color: string
   description: string
   image: string
+  uri: string
   name: string
   tokenId: number | string
 }

--- a/src/routes/safe/components/Balances/Collectibles/components/Item.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/components/Item.tsx
@@ -1,12 +1,14 @@
 import { makeStyles } from '@material-ui/core/styles'
 // import CallMade from '@material-ui/icons/CallMade'
 import cn from 'classnames'
-import { ReactElement } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import Button from 'src/components/layout/Button'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import { fontColor, sm, xs } from 'src/theme/variables'
+import NFTIcon from 'src/routes/safe/components/Balances/assets/nft_icon.png'
+import axios from 'axios'
 
 const useStyles = makeStyles({
   item: {
@@ -98,14 +100,29 @@ const useStyles = makeStyles({
   },
 } as any)
 
+const fetchImage = async (uri: string): Promise<string> => {
+  try {
+    const { data: json } = await axios.get<{ image?: string }>(uri)
+    return json.image || ''
+  } catch (e) {
+    return ''
+  }
+}
+
 const Item = ({ data, onSend }): ReactElement => {
   const granted = useSelector(grantedSelector)
   const classes = useStyles({ backgroundColor: data.color, granted })
+  const [image, setImage] = useState<string>(data.image || '')
+
+  useEffect(() => {
+    if (image || !data.uri) return
+    fetchImage(data.uri).then(setImage)
+  }, [image, setImage, data.uri])
 
   return (
     <div className={classes.item}>
       <div className={classes.mainContent}>
-        <div className={classes.image} style={{ backgroundImage: `url(${data.image})` }} />
+        <div className={classes.image} style={{ backgroundImage: `url(${image || NFTIcon})` }} />
         <div className={classes.textContainer}>
           {data.name && (
             <h3 className={classes.title} title={data.name}>

--- a/src/routes/safe/components/Balances/Collectibles/components/Item.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/components/Item.tsx
@@ -9,6 +9,7 @@ import { grantedSelector } from 'src/routes/safe/container/selector'
 import { fontColor, sm, xs } from 'src/theme/variables'
 import NFTIcon from 'src/routes/safe/components/Balances/assets/nft_icon.png'
 import axios from 'axios'
+import { NFTToken } from 'src/logic/collectibles/sources/collectibles'
 
 const useStyles = makeStyles({
   item: {
@@ -102,14 +103,14 @@ const useStyles = makeStyles({
 
 const fetchImage = async (uri: string): Promise<string> => {
   try {
-    const { data: json } = await axios.get<{ image?: string }>(uri)
-    return json.image || ''
+    const { data } = await axios.get<{ image?: string }>(uri)
+    return data.image || ''
   } catch (e) {
     return ''
   }
 }
 
-const Item = ({ data, onSend }): ReactElement => {
+const Item = ({ data, onSend }: { data: NFTToken; onSend: () => unknown }): ReactElement => {
   const granted = useSelector(grantedSelector)
   const classes = useStyles({ backgroundColor: data.color, granted })
   const [image, setImage] = useState<string>(data.image || '')

--- a/src/routes/safe/components/Balances/Collectibles/components/Item.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/components/Item.tsx
@@ -101,38 +101,49 @@ const useStyles = makeStyles({
   },
 } as any)
 
-const fetchImage = async (uri: string): Promise<string> => {
+interface Metadata {
+  image: string
+  name: string
+  description: string
+}
+
+const fetchMetadata = async (uri: string): Promise<Metadata | null> => {
   try {
-    const { data } = await axios.get<{ image?: string }>(uri)
-    return data.image || ''
+    const { data } = await axios.get<Metadata>(uri)
+    return data || null
   } catch (e) {
-    return ''
+    return null
   }
 }
 
 const Item = ({ data, onSend }: { data: NFTToken; onSend: () => unknown }): ReactElement => {
   const granted = useSelector(grantedSelector)
   const classes = useStyles({ backgroundColor: data.color, granted })
-  const [image, setImage] = useState<string>(data.image || '')
+  const [metadata, setMetadata] = useState<Metadata | null>(null)
+  const name = data.name || metadata?.name || ''
+  const desc = data.description || metadata?.description || ''
 
   useEffect(() => {
-    if (image || !data.uri) return
-    fetchImage(data.uri).then(setImage)
-  }, [image, setImage, data.uri])
+    if (metadata || !data.uri) return
+    fetchMetadata(data.uri).then(setMetadata)
+  }, [metadata, setMetadata, data.uri])
 
   return (
     <div className={classes.item}>
       <div className={classes.mainContent}>
-        <div className={classes.image} style={{ backgroundImage: `url(${image || NFTIcon})` }} />
+        <div
+          className={classes.image}
+          style={{ backgroundImage: `url(${data.image || metadata?.image || NFTIcon})` }}
+        />
         <div className={classes.textContainer}>
-          {data.name && (
-            <h3 className={classes.title} title={data.name}>
-              {data.name}
+          {name && (
+            <h3 className={classes.title} title={name}>
+              {name}
             </h3>
           )}
-          {data.description && (
-            <p className={classes.text} title={data.description}>
-              {data.description}
+          {desc && (
+            <p className={classes.text} title={desc}>
+              {desc}
             </p>
           )}
         </div>

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles(
     },
     cardOuter: {
       boxShadow: '1px 2px 10px 0 rgba(212, 212, 211, 0.59)',
+      marginBottom: '15px',
     },
     gridRow: {
       boxSizing: 'border-box',


### PR DESCRIPTION
## What it solves
Resolves #3325

## How this PR fixes it
Fetches the JSON from `uri` and grabs the metadata from there
[Example URI](data:application/json;base64,eyJuYW1lIjogIlpvcmIgIzE1IiwgImRlc2NyaXB0aW9uIjogIlpvcmJzIHdlcmUgZGlzdHJpYnV0ZWQgZm9yIGZyZWUgYnkgWk9SQSBvbiBOZXcgWWVhcuKAmXMgMjAyMi4gRWFjaCBORlQgaW1idWVzIHRoZSBwcm9wZXJ0aWVzIG9mIGl0cyB3YWxsZXQgaG9sZGVyLCBhbmQgd2hlbiBzZW50IHRvIHNvbWVvbmUgZWxzZSwgd2lsbCB0cmFuc2Zvcm0uXG5cblZpZXcgdGhpcyBORlQgYXQgW3pvcmIuZGV2L25mdC8xNV0oaHR0cHM6Ly96b3JiLmRldi9uZnQvMTUpIiwgImltYWdlIjogImRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIWnBaWGRDYjNnOUlqQWdNQ0F4TVRBZ01URXdJajQ4WkdWbWN6NDhjbUZrYVdGc1IzSmhaR2xsYm5RZ2FXUTlJbWQ2Y2lJZ1ozSmhaR2xsYm5SVWNtRnVjMlp2Y20wOUluUnlZVzV6YkdGMFpTZzJOaTQwTlRjNElESTBMak0xTnpVcElITmpZV3hsS0RjMUxqSTVNRGdwSWlCbmNtRmthV1Z1ZEZWdWFYUnpQU0oxYzJWeVUzQmhZMlZQYmxWelpTSWdjajBpTVNJZ1kzZzlJakFpSUdONVBTSXdKU0krUEhOMGIzQWdiMlptYzJWMFBTSXhOUzQyTWlVaUlITjBiM0F0WTI5c2IzSTlJbWh6YkNneU5UUXNJRGN6SlN3Z09EVWxLU0lnTHo0OGMzUnZjQ0J2Wm1aelpYUTlJak01TGpVNEpTSWdjM1J2Y0MxamIyeHZjajBpYUhOc0tESTFOQ3dnT0RBbExDQTNPU1VwSWlBdlBqeHpkRzl3SUc5bVpuTmxkRDBpTnpJdU9USWxJaUJ6ZEc5d0xXTnZiRzl5UFNKb2Myd29Nams1TENBNU1DVXNJRFk0SlNraUlDOCtQSE4wYjNBZ2IyWm1jMlYwUFNJNU1DNDJNeVVpSUhOMGIzQXRZMjlzYjNJOUltaHpiQ2d6TURNc0lEazFKU3dnTlRrbEtTSWdMejQ4YzNSdmNDQnZabVp6WlhROUlqRXdNQ1VpSUhOMGIzQXRZMjlzYjNJOUltaHpiQ2d6TURNc0lEazFKU3dnTlRnbEtTSWdMejQ4TDNKaFpHbGhiRWR5WVdScFpXNTBQand2WkdWbWN6NDhaeUIwY21GdWMyWnZjbTA5SW5SeVlXNXpiR0YwWlNnMUxEVXBJajQ4Y0dGMGFDQmtQU0pOTVRBd0lEVXdRekV3TUNBeU1pNHpPRFU0SURjM0xqWXhORElnTUNBMU1DQXdRekl5TGpNNE5UZ2dNQ0F3SURJeUxqTTROVGdnTUNBMU1FTXdJRGMzTGpZeE5ESWdNakl1TXpnMU9DQXhNREFnTlRBZ01UQXdRemMzTGpZeE5ESWdNVEF3SURFd01DQTNOeTQyTVRReUlERXdNQ0ExTUZvaUlHWnBiR3c5SW5WeWJDZ2paM3B5S1NJZ0x6NDhjR0YwYUNCemRISnZhMlU5SW5KblltRW9NQ3d3TERBc01DNHdOelVwSWlCbWFXeHNQU0owY21GdWMzQmhjbVZ1ZENJZ2MzUnliMnRsTFhkcFpIUm9QU0l4SWlCa1BTSk5OVEFzTUM0MVl6STNMak1zTUN3ME9TNDFMREl5TGpJc05Ea3VOU3cwT1M0MVV6YzNMak1zT1RrdU5TdzFNQ3c1T1M0MVV6QXVOU3czTnk0ekxEQXVOU3cxTUZNeU1pNDNMREF1TlN3MU1Dd3dMalY2SWlBdlBqd3ZaejQ4TDNOMlp6ND0ifQ==)

The metadata fields are then used as fallback values from the top-level metadata

In case of Zorbs, it's the name, description and image. I.e. all of the fields.

<img width="278" alt="Screenshot 2022-01-19 at 19 25 33" src="https://user-images.githubusercontent.com/381895/150191731-63e01b5e-8f87-4ce1-80de-73a1ebd60fbc.png">

## How to test it
@francovenica, I've sent you an NFT that doesn't display an image w/o this fix.
To your `0x9913B9180C20C6b0F21B6480c84422F6ebc4B808` Safe.

## Screenshots
|Before|After|
|------|------|
|<img width="403" alt="Screenshot 2022-01-19 at 16 58 17" src="https://user-images.githubusercontent.com/381895/150170487-06b938c0-f155-4be8-a11e-8bdc119ab6e4.png">|<img width="408" alt="Screenshot 2022-01-19 at 16 58 23" src="https://user-images.githubusercontent.com/381895/150170502-19d60cb0-e3f0-4502-8567-0eb7a8d40895.png">|

