### PR TITLE
Fix apps using legacy chain name as key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -85,6 +85,23 @@ const safeAppWeb3Provider = new Web3.providers.HttpProvider(getSafeAppsRpcServic
 const URL_NOT_PROVIDED_ERROR = 'App url No provided or it is invalid.'
 const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be a problem with the App provider.'
 
+// Some apps still need chain name, as they didn't update to chainId based SDK versions
+// This apps expect a network name in UPPERCASE
+// With naming changing in the config service some names aren't the expected ones
+// Ex: Ethereum -> MAINNET, Gnosis Chain -> XDAI
+const getLegacyChainName = (chainName: string) => {
+  let network = chainName.toUpperCase()
+  switch (chainName) {
+    case 'Ethereum':
+      network = 'MAINNET'
+      break
+    case 'Gnosis Chain':
+      network = 'XDAI'
+  }
+
+  return network
+}
+
 const AppFrame = ({ appUrl }: Props): ReactElement => {
   const { address: safeAddress, ethBalance, owners, threshold } = useSelector(currentSafe)
   const { nativeCurrency, chainId, chainName, shortName } = getChainInfo()
@@ -182,7 +199,8 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
 
     communicator?.on(Methods.getSafeInfo, () => ({
       safeAddress,
-      network: chainName,
+      // FIXME `network` is deprecated. we should find how many apps are still using it
+      network: getLegacyChainName(chainName),
       chainId: parseInt(chainId, 10),
       owners,
       threshold,

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -88,13 +88,13 @@ const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be 
 // Some apps still need chain name, as they didn't update to chainId based SDK versions
 // With naming changing in the config service some names aren't the expected ones
 // Ex: Ethereum -> MAINNET, Gnosis Chain -> XDAI
-const getLegacyChainName = (chainName: string) => {
+const getLegacyChainName = (chainName: string, chainId: string) => {
   let network = chainName
-  switch (chainName) {
-    case 'Ethereum':
+  switch (chainId) {
+    case '1':
       network = 'MAINNET'
       break
-    case 'Gnosis Chain':
+    case '100':
       network = 'XDAI'
   }
 
@@ -176,11 +176,11 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
       data: {
         safeAddress: safeAddress as string,
         // FIXME `network` is deprecated. we should find how many apps are still using it
-        network: getLegacyChainName(chainName).toLowerCase() as LowercaseNetworks,
+        network: getLegacyChainName(chainName, chainId).toLowerCase() as LowercaseNetworks,
         ethBalance: ethBalance as string,
       },
     })
-  }, [chainName, ethBalance, safeAddress, appUrl, sendMessageToIframe])
+  }, [chainName, chainId, ethBalance, safeAddress, appUrl, sendMessageToIframe])
 
   const communicator = useAppCommunicator(iframeRef, safeApp)
 
@@ -201,7 +201,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
       safeAddress,
       // FIXME `network` is deprecated. we should find how many apps are still using it
       // Apps using this property expect this to be in UPPERCASE
-      network: getLegacyChainName(chainName).toUpperCase(),
+      network: getLegacyChainName(chainName, chainId).toUpperCase(),
       chainId: parseInt(chainId, 10),
       owners,
       threshold,

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -23,7 +23,7 @@ import { LoadingContainer } from 'src/components/LoaderContainer/index'
 import { SAFE_POLLING_INTERVAL } from 'src/utils/constants'
 import { ConfirmTxModal } from './ConfirmTxModal'
 import { useIframeMessageHandler } from '../hooks/useIframeMessageHandler'
-import { getAppInfoFromUrl, getEmptySafeApp } from '../utils'
+import { getAppInfoFromUrl, getEmptySafeApp, getLegacyChainName } from '../utils'
 import { SafeApp } from '../types'
 import { useAppCommunicator } from '../communicator'
 import { fetchTokenCurrenciesBalances } from 'src/logic/safe/api/fetchTokenCurrenciesBalances'
@@ -84,22 +84,6 @@ const safeAppWeb3Provider = new Web3.providers.HttpProvider(getSafeAppsRpcServic
 
 const URL_NOT_PROVIDED_ERROR = 'App url No provided or it is invalid.'
 const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be a problem with the App provider.'
-
-// Some apps still need chain name, as they didn't update to chainId based SDK versions
-// With naming changing in the config service some names aren't the expected ones
-// Ex: Ethereum -> MAINNET, Gnosis Chain -> XDAI
-const getLegacyChainName = (chainName: string, chainId: string) => {
-  let network = chainName
-  switch (chainId) {
-    case '1':
-      network = 'MAINNET'
-      break
-    case '100':
-      network = 'XDAI'
-  }
-
-  return network
-}
 
 const AppFrame = ({ appUrl }: Props): ReactElement => {
   const { address: safeAddress, ethBalance, owners, threshold } = useSelector(currentSafe)

--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -13,10 +13,11 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffect, useCallback, MutableRefObject } from 'react'
 
-import { getChainName, getTxServiceUrl } from 'src/config/'
+import { getChainInfo, getTxServiceUrl } from 'src/config/'
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { TransactionParams } from '../components/AppFrame'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
+import { getLegacyChainName } from '../utils'
 
 type InterfaceMessageProps<T extends InterfaceMessageIds> = {
   messageId: T
@@ -36,6 +37,7 @@ const useIframeMessageHandler = (
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
   const { address: safeAddress, ethBalance, name: safeName } = useSelector(currentSafeWithNames)
   const dispatch = useDispatch()
+  const { chainId, chainName } = getChainInfo()
 
   const sendMessageToIframe = useCallback(
     function <T extends InterfaceMessageIds>(message: InterfaceMessageProps<T>, requestId?: RequestId) {
@@ -82,7 +84,7 @@ const useIframeMessageHandler = (
             messageId: INTERFACE_MESSAGES.ON_SAFE_INFO,
             data: {
               safeAddress: safeAddress as string,
-              network: getChainName().toLowerCase() as LowercaseNetworks,
+              network: getLegacyChainName(chainName, chainId).toLowerCase() as LowercaseNetworks,
               ethBalance: ethBalance as string,
             },
           }
@@ -125,6 +127,8 @@ const useIframeMessageHandler = (
       window.removeEventListener('message', onIframeMessage)
     }
   }, [
+    chainName,
+    chainId,
     closeModal,
     closeSnackbar,
     dispatch,

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -147,3 +147,19 @@ const canLoadAppImage = (path: string, timeout = 10000) =>
       resolve(false)
     }
   })
+
+// Some apps still need chain name, as they didn't update to chainId based SDK versions
+// With naming changing in the config service some names aren't the expected ones
+// Ex: Ethereum -> MAINNET, Gnosis Chain -> XDAI
+export const getLegacyChainName = (chainName: string, chainId: string): string => {
+  let network = chainName
+  switch (chainId) {
+    case '1':
+      network = 'MAINNET'
+      break
+    case '100':
+      network = 'XDAI'
+  }
+
+  return network
+}


### PR DESCRIPTION
## What it solves
Resolves #3339
https://github.com/gnosis/safe-react-apps/issues/275
https://github.com/gnosis/safe-apps-list/issues/99
https://github.com/gnosis/safe-apps-list/issues/100
https://github.com/gnosis/safe-react-apps/issues/293

## How this PR fixes it
We overwritte Ethereum or Gnosis Chain names so apps still get legacy names, MAINNET and XDAI

## How to test it
Open xDai bridge and it should be possible to use it
Same for Pool Together, OpenZeppelin, and Idle V4
