### PR TITLE
fix: reference threshold in dev tool macros

### DIFF
--- a/src/components/AppLayout/Sidebar/DevTools/index.tsx
+++ b/src/components/AppLayout/Sidebar/DevTools/index.tsx
@@ -50,9 +50,11 @@ const stopExecution = async (): Promise<void> => {
   fireEvent.click(executionCheckbox)
 }
 
-const createQueuedTx = async (address: string): Promise<void> => {
+const createQueuedTx = async (address: string, threshold = 1): Promise<void> => {
   await prepareTx(address)
-  await stopExecution()
+  if (threshold === 1) {
+    await stopExecution()
+  }
   await submitTx()
 }
 
@@ -104,7 +106,7 @@ const DevTools = (): ReactElement => {
       </List>
       <ButtonWrapper>
         <StyledButton
-          onClick={() => createQueuedTx(safeAddress)}
+          onClick={() => createQueuedTx(safeAddress, threshold)}
           size="md"
           variant="bordered"
           disabled={!isGranted || !hasSufficientFunds()}
@@ -115,7 +117,7 @@ const DevTools = (): ReactElement => {
           onClick={() => createExecutedTx(safeAddress)}
           size="md"
           variant="bordered"
-          disabled={!isGranted || !hasSufficientFunds() || !nextTx}
+          disabled={!isGranted || !hasSufficientFunds() || !nextTx || threshold > 1}
         >
           Execute Transaction
         </StyledButton>


### PR DESCRIPTION
## What it solves
Queue transaction creation on 2+/? Safe dev tooling

## How this PR fixes it
The threshold of a Safe is now referenced when creating a queued transaction via the macros on a 2+/? Safe. If it is higher than 1:
1. The queue transaction macros does not attempt to uncheck the execute checkbox.
2. The "create transaction" button is disabled.

## How to test it
1. Open a 2+/? Safe and observe that the create transaction button is disabled.
2. Clicking the "queue transaction" button does not crash the app.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/150480633-6485b063-a5aa-4f6b-bfd5-3adf638fa14e.png)