### PR TITLE
fix: adjust delegate call warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@gnosis.pm/safe-core-sdk": "^1.3.0",
     "@gnosis.pm/safe-deployments": "^1.5.0",
     "@gnosis.pm/safe-react-components": "^0.9.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "2.8.2",
+    "@gnosis.pm/safe-react-gateway-sdk": "2.8.3",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.20.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.0",

--- a/src/routes/safe/components/Transactions/TxList/DelegateCallWarning.tsx
+++ b/src/routes/safe/components/Transactions/TxList/DelegateCallWarning.tsx
@@ -1,8 +1,8 @@
 import { Text } from '@gnosis.pm/safe-react-components'
 import { ReactElement } from 'react'
 
-const DelegateCallWarning = ({ isKnown }: { isKnown: boolean }): ReactElement => {
-  if (!isKnown) {
+const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => {
+  if (showWarning) {
     return (
       <Text size="xl" strong as="span" color="error">
         ⚠️ Unexpected Delegate Call

--- a/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MultiSendDetails.tsx
@@ -27,14 +27,14 @@ type MultiSendTxGroupProps = {
 
 const MultiSendTxGroup = ({ actionTitle, children, txDetails }: MultiSendTxGroupProps): ReactElement => {
   const isDelegateCall = txDetails.operation === Operation.DELEGATE
-  const isKnown = !!txDetails.name
   return (
-    <ActionAccordion defaultExpanded={(isDelegateCall && !isKnown) || undefined}>
+    <ActionAccordion defaultExpanded={isDelegateCall || undefined}>
       <AccordionSummary>
         <IconText iconSize="sm" iconType="code" text={actionTitle} textSize="xl" />
       </AccordionSummary>
       <ColumnDisplayAccordionDetails>
-        {isDelegateCall && <DelegateCallWarning isKnown={isKnown} />}
+        {/* We always warn of nested delegate calls */}
+        {isDelegateCall && <DelegateCallWarning showWarning={isDelegateCall} />}
         {!isSpendingLimitMethod(txDetails.dataDecoded?.method) && (
           <TxInfoDetails
             title={txDetails.title}

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -6,7 +6,6 @@ import { getExplorerInfo } from 'src/config'
 import { formatDateTime } from 'src/utils/date'
 import {
   ExpandedTxDetails,
-  isCustomTxInfo,
   isMultiSendTxInfo,
   isMultiSigExecutionDetails,
 } from 'src/logic/safe/store/models/types/gateway.d'
@@ -82,7 +81,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
       </div>
       {txData?.operation === Operation.DELEGATE && (
         <div className="tx-operation">
-          <DelegateCallWarning isKnown={isCustomTxInfo(txInfo) && !!txInfo?.to?.name} />
+          <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />
         </div>
       )}
       {isMultiSendTxInfo(txInfo) && <TxInfoMultiSend txInfo={txInfo} />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,10 +1984,10 @@
     react-media "^1.10.0"
     web3-utils "^1.6.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@2.8.2":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.2.tgz#10c8158a9f3f0296ad1ee52e16f9fb41fa82f350"
-  integrity sha512-UJa7wLd9CvtPhnO+o1nLcURIfdEpVBB2XeHU0oU100y45DdVnCGsLcrSdmslIRH/odhhs3JYpXOJCzlfJQW+2A==
+"@gnosis.pm/safe-react-gateway-sdk@2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.3.tgz#413875ab6eaedf5cad6c2d6f27e503e9a7715d21"
+  integrity sha512-M0Ay+A3ea+5eHD3uSQ+Hu3h7EzAE8F8pI0mZGuFioCUmZMa3Sv1K7OFDvXoL7Na/J2MVmOpyamBlyB5CPHpGyQ==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 


### PR DESCRIPTION
## What it solves
Resolves #3099

## How this PR fixes it
The trust of a delegate is no longer based on whether it is named. We instead warn based on the `trustedDelegateCallTarget` flag and ALWAYS warn when they are nested.

## How to test it
- Observe the warning on an untrusted delegate call [here](https://pr3433--safereact.review-safe.gnosisdev.com/app/eth:0x1f7f8DA3eac80DBc0b4A49BC447A88585D8766C8/transactions/0xd880933f98f7805f5ff16a3370a4385c18a0893125b91a21329e0245840bd94e).
- Observe the default warning on nested delegate call [here](https://pr3433--safereact.review-safe.gnosisdev.com/app/rin:0x73a7AA145338587f7aB7f63c06d187C85dF4727e/transactions/0xba28109747222d6cfb7f0fb75f03d49957e343674bc116162b038e244dbcc6d6).

## Screenshots)
Untrusted warning
![image](https://user-images.githubusercontent.com/20442784/150488147-54de1035-da14-45b0-830c-cd75f87cec78.png)

Default nested warning
![image](https://user-images.githubusercontent.com/20442784/150488098-9f211a0c-0683-47e5-bef4-0307a5251e98.png)