### PR TITLE
fix: return after rejecting an off-chain transaction

### DIFF
--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -226,10 +226,11 @@ export class TxSender {
         const { hardwareWallet, smartContractWallet } = providerSelector(state)
         const signature = await this.onlyConfirm(hardwareWallet, smartContractWallet)
         this.onComplete(signature, confirmCallback)
-        return
       } catch (err) {
+        // User likely rejected transaction
         logError(Errors._814, err.message)
       }
+      return
     }
 
     // On-chain signature or execution


### PR DESCRIPTION
## What it solves
Resolves #3355

## How this PR fixes it
When a user rejects a transaction, the `onlyConfirm` function throws and it was not returning. An on-chain transaction was then being attempted.

A created, but not immediately executed transaction now returns after an error is thrown.

## How to test it
1. Attempt to queue/confirm a transaction but reject it via MM.
2. Observe that no second MM popup is displayed.