### PR TITLE
fix: hide developer tool links

### DIFF
--- a/src/components/AppLayout/Sidebar/DevTools/index.tsx
+++ b/src/components/AppLayout/Sidebar/DevTools/index.tsx
@@ -1,6 +1,5 @@
 import { ReactElement } from 'react'
 import { useSelector } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
 import { Button } from '@gnosis.pm/safe-react-components'
@@ -8,9 +7,8 @@ import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 
-import { getShortName } from 'src/config'
 import { currentSafe, currentSafeEthBalance } from 'src/logic/safe/store/selectors'
-import { extractSafeAddress, generatePrefixedAddressRoutes } from 'src/routes/routes'
+import { extractSafeAddress } from 'src/routes/routes'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { nextTransaction } from 'src/logic/safe/store/selectors/gatewayTransactions'
 import { grantedSelector } from 'src/routes/safe/container/selector'
@@ -63,12 +61,11 @@ const createExecutedTx = async (address: string): Promise<void> => {
   await submitTx()
 }
 
-const getStatusUrl = (address: string): string => {
-  return `https://rimeissner.dev/safe-status-check/#/${getShortName()}:${address}`
-}
+// const getStatusUrl = (address: string): string => {
+//   return `https://rimeissner.dev/safe-status-check/#/${getShortName()}:${address}`
+// }
 
 const DevTools = (): ReactElement => {
-  const history = useHistory()
   const { owners, threshold = 1 } = useSelector(currentSafe) ?? {}
   const safeAddress = extractSafeAddress()
   const nextTx = useSelector(nextTransaction)
@@ -83,18 +80,13 @@ const DevTools = (): ReactElement => {
     return hasFunds
   }
 
-  const { TRANSACTIONS_QUEUE, TRANSACTIONS_HISTORY } = generatePrefixedAddressRoutes({
-    shortName: getShortName(),
-    safeAddress,
-  })
-
   return (
     <>
       <List dense>
         <ListItem>
           <ListItemText primary="Developer Tools" secondary={`Threshold: ${threshold} / ${owners?.length || 0}`} />
         </ListItem>
-        <ListItem button>
+        {/* <ListItem button>
           <ListItemText onClick={() => history.push(TRANSACTIONS_QUEUE)}>Queue</ListItemText>
         </ListItem>
         <ListItem button>
@@ -102,7 +94,7 @@ const DevTools = (): ReactElement => {
         </ListItem>
         <ListItem button>
           <ListItemText onClick={() => window.open(getStatusUrl(safeAddress), '_blank')}>Safe Status</ListItemText>
-        </ListItem>
+        </ListItem> */}
       </List>
       <ButtonWrapper>
         <StyledButton
@@ -111,7 +103,7 @@ const DevTools = (): ReactElement => {
           variant="bordered"
           disabled={!isGranted || !hasSufficientFunds()}
         >
-          Queue Transaction
+          Queue
         </StyledButton>
         <StyledButton
           onClick={() => createExecutedTx(safeAddress)}
@@ -119,7 +111,7 @@ const DevTools = (): ReactElement => {
           variant="bordered"
           disabled={!isGranted || !hasSufficientFunds() || !nextTx || threshold > 1}
         >
-          Execute Transaction
+          Execute
         </StyledButton>
       </ButtonWrapper>
     </>
@@ -131,8 +123,7 @@ export default DevTools
 const StyledButton = styled(Button)`
   &.MuiButton-root {
     padding: 0 12px !important;
-    margin-top: 6px;
-    width: 100%;
+    min-width: 45% !important;
   }
 
   & .MuiButton-label {
@@ -141,5 +132,7 @@ const StyledButton = styled(Button)`
 `
 
 const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
   margin: 0 12px;
 `


### PR DESCRIPTION
## What it solves
Resolves #3357

## How this PR fixes it
The transaction tab links and Safe status page links have been temporarily hidden, as well as the macro buttons adjusted to be inline with each other.

In the future we intend to show these links again and move the developer tools to a hideable pane on the right, or wherever seems best.

## How to test it
Open the Safe and observe, on a smaller resolution (13" MacBook), that the links are hidden and buttons are inline. The Sidebar should no hide entries, not showing a scrollbar.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/150778544-28abbd41-3a07-4c8c-a357-f367bc1084d1.png)
