### PR TITLE
fix: Dont estimate gas in ApproveTxModal if checkbox is not checked

### DIFF
--- a/src/logic/hooks/useCanTxExecute.tsx
+++ b/src/logic/hooks/useCanTxExecute.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { extractSafeAddress } from 'src/routes/routes'
 import { currentSafe } from '../safe/store/selectors'
@@ -50,27 +49,21 @@ const useCanTxExecute: UseCanTxExecuteType = (
   preApprovingOwner = '',
   txConfirmations = 0,
 ) => {
-  const [canTxExecute, setCanTxExecute] = useState(false)
   const { threshold } = useSelector(currentSafe)
 
   const safeAddress = extractSafeAddress()
   const recommendedNonce = useGetRecommendedNonce(safeAddress)
   const { nonce: currentSafeNonce } = useSelector(currentSafe)
 
-  useEffect(() => {
-    const result = calculateCanTxExecute(
-      currentSafeNonce,
-      preApprovingOwner,
-      threshold,
-      txConfirmations,
-      recommendedNonce,
-      isExecution,
-      manualSafeNonce,
-    )
-    setCanTxExecute(result)
-  }, [currentSafeNonce, preApprovingOwner, recommendedNonce, threshold, txConfirmations, isExecution, manualSafeNonce])
-
-  return canTxExecute
+  return calculateCanTxExecute(
+    currentSafeNonce,
+    preApprovingOwner,
+    threshold,
+    txConfirmations,
+    recommendedNonce,
+    isExecution,
+    manualSafeNonce,
+  )
 }
 
 export default useCanTxExecute

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -19,8 +19,7 @@ import { Confirmation } from 'src/logic/safe/store/models/types/confirmation'
 import { checkIfOffChainSignatureIsPossible } from 'src/logic/safe/safeTxSigner'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { sameString } from 'src/utils/strings'
-import { calculateCanTxExecute } from './useCanTxExecute'
-import useGetRecommendedNonce from 'src/logic/hooks/useGetRecommendedNonce'
+import useCanTxExecute from './useCanTxExecute'
 
 export enum EstimationStatus {
   LOADING = 'LOADING',
@@ -112,18 +111,7 @@ export const useEstimateTransactionGas = ({
   const { address: safeAddress = '', threshold = 1, currentVersion: safeVersion = '' } = useSelector(currentSafe) ?? {}
   const { account: from, smartContractWallet, name: providerName } = useSelector(providerSelector)
 
-  const recommendedNonce = useGetRecommendedNonce(safeAddress)
-  const { nonce: currentSafeNonce } = useSelector(currentSafe)
-
-  const canTxExecute = calculateCanTxExecute(
-    currentSafeNonce,
-    preApprovingOwner ?? '',
-    threshold,
-    txConfirmations?.size ?? 0,
-    recommendedNonce,
-    isExecution,
-    manualSafeNonce,
-  )
+  const canTxExecute = useCanTxExecute(isExecution, manualSafeNonce, preApprovingOwner, txConfirmations?.size)
 
   useEffect(() => {
     const estimateGas = async () => {

--- a/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
@@ -226,6 +226,8 @@ export const ApproveTxModal = ({
   const isTheTxReadyToBeExecuted = oneConfirmationLeft ? true : thresholdReached
   const [manualGasPrice, setManualGasPrice] = useState<string | undefined>()
   const [manualGasLimit, setManualGasLimit] = useState<string | undefined>()
+  const willExecute = isExecution && shouldExecute
+
   const {
     confirmations,
     data,
@@ -259,9 +261,8 @@ export const ApproveTxModal = ({
     operation,
     manualGasPrice,
     manualGasLimit,
-    isExecution,
+    isExecution: willExecute,
   })
-  const willExecute = isExecution && shouldExecute
   const [buttonStatus] = useEstimationStatus(txEstimationExecutionStatus)
 
   const approveTx = (txParameters: TxParameters) => {


### PR DESCRIPTION
## What it solves
Resolves #3358

## How this PR fixes it
When approving a queued Transaction we only estimate gas when also executing it via checkbox.

## How to test it

1. Open a Multi Owner, 2+/n policy safe
2. Create a transaction without executing it
3. Switch to a different owner and confirm the queued transaction

## Screenshots
![c](https://user-images.githubusercontent.com/5880855/150837796-99e8b3b3-546a-45b1-a95e-2a29a16e9dc9.png)

