### PR TITLE
Change Safe App name TextField from readonly to disabled

### DIFF
--- a/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
@@ -1,9 +1,8 @@
-import { Icon, Link, Loader, Text, TextField } from '@gnosis.pm/safe-react-components'
+import { theme, Icon, Link, Loader, Text, TextField } from '@gnosis.pm/safe-react-components'
 import { useState, ReactElement, useCallback, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
-
 import GnoForm from 'src/components/forms/GnoForm'
 import Img from 'src/components/layout/Img'
 import { Modal } from 'src/components/Modal'
@@ -19,6 +18,22 @@ const FORM_ID = 'add-apps-form'
 const StyledTextFileAppName = styled(TextField)`
   && {
     width: 385px;
+    .MuiFormLabel-root {
+      &.Mui-disabled {
+        color: rgba(0, 0, 0, 0.54);
+        &.Mui-error {
+          color: ${theme.colors.error};
+        }
+      }
+    }
+    .MuiInputBase-root {
+      .MuiFilledInput-input {
+        color: rgba(0, 0, 0, 0.54);
+      }
+      &:before {
+        border-bottom-style: inset;
+      }
+    }
   }
 `
 
@@ -141,7 +156,7 @@ const AddApp = ({ appList, closeModal, onAddApp }: AddAppProps): ReactElement =>
               )}
               <StyledTextFileAppName
                 label="App name"
-                readOnly
+                disabled
                 meta={{ error: fetchError }}
                 value={isLoading ? 'Loading...' : appInfo.name === DEFAULT_APP_INFO.name ? '' : appInfo.name}
                 onChange={() => {}}

--- a/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
+++ b/src/routes/safe/components/Apps/components/AddAppForm/index.tsx
@@ -1,4 +1,4 @@
-import { theme, Icon, Link, Loader, Text, TextField } from '@gnosis.pm/safe-react-components'
+import { Icon, Link, Loader, Text, TextField } from '@gnosis.pm/safe-react-components'
 import { useState, ReactElement, useCallback, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
@@ -22,7 +22,7 @@ const StyledTextFileAppName = styled(TextField)`
       &.Mui-disabled {
         color: rgba(0, 0, 0, 0.54);
         &.Mui-error {
-          color: ${theme.colors.error};
+          color: ${(props) => props.theme.colors.error};
         }
       }
     }


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/272

## How this PR fixes it
By changing the textfield from readOnly to disabled and tweaking some styles

## How to test it
Try to add a custom app and click in the safe app name field. Nothing should happen. The label remains in the same place and no animation is performed

Make the app fail for manifest not found. The label should be red and when you click nothing happens
