### PR TITLE
feat: add more advanced params to modals

### DIFF
--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -66,9 +66,13 @@ const StyledDivider = styled(Divider)`
 `
 
 type TxParam = string | ReactElement
-type TxParameterProps = { name: TxParam; value: TxParam; color?: ThemeColors } & ColoredTextProps
-const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement => {
-  const getEl = (prop: TxParam) => {
+type TxParameterProps = { name: TxParam; value?: TxParam | null; color?: ThemeColors } & ColoredTextProps
+const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement | null => {
+  if (value == null || value === '') {
+    return null
+  }
+
+  const getEl = (prop?: TxParam) => {
     return typeof prop === 'string' ? (
       <ColoredText size="lg" {...rest}>
         {prop}
@@ -77,6 +81,7 @@ const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement =
       prop
     )
   }
+
   return (
     <TxParameterWrapper>
       {getEl(name)}
@@ -186,13 +191,11 @@ const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
   return (
     <>
       <StyledDivider />
-
-      {value && <TxParameter name="value" value={value} />}
-
-      {to?.value && (
-        <TxParameter
-          name="to"
-          value={
+      <TxParameter name="value" value={value} />
+      <TxParameter
+        name="to"
+        value={
+          to?.value && (
             <PrefixedEthHashInfo
               textSize="lg"
               hash={to.value}
@@ -200,39 +203,28 @@ const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
               explorerUrl={getExplorerInfo(to.value)}
               shortenHash={8}
             />
-          }
-        />
-      )}
-
-      {safeTxHash && (
-        <TxParameter
-          name="safeTxHash"
-          value={<EthHashInfo textSize="lg" hash={safeTxHash} showCopyBtn shortenHash={8} />}
-        />
-      )}
-
+          )
+        }
+      />
+      <TxParameter
+        name="safeTxHash"
+        value={safeTxHash && <EthHashInfo textSize="lg" hash={safeTxHash} showCopyBtn shortenHash={8} />}
+      />
       {Object.values(Operation).includes(operation) && (
         <TxParameter name="Operation" value={`${operation} (${Operation[operation].toLowerCase()})`} />
       )}
-
-      {baseGas && <TxParameter name="baseGas" value={baseGas} />}
-
-      {gasPrice && <TxParameter name="gasPrice" value={gasPrice} />}
-
-      {gasToken && (
-        <TxParameter
-          name="gasToken"
-          value={<EthHashInfo textSize="lg" hash={gasToken} showCopyBtn shortenHash={8} />}
-        />
-      )}
-
-      {refundReceiver?.value && (
-        <TxParameter
-          name="refundReceiver"
-          value={<EthHashInfo textSize="lg" hash={refundReceiver.value} showCopyBtn shortenHash={8} />}
-        />
-      )}
-
+      <TxParameter name="baseGas" value={baseGas} />
+      <TxParameter name="gasPrice" value={gasPrice} />
+      <TxParameter
+        name="gasToken"
+        value={gasToken && <EthHashInfo textSize="lg" hash={gasToken} showCopyBtn shortenHash={8} />}
+      />
+      <TxParameter
+        name="refundReceiver"
+        value={
+          refundReceiver?.value && <EthHashInfo textSize="lg" hash={refundReceiver.value} showCopyBtn shortenHash={8} />
+        }
+      />
       {confirmations
         ?.filter(({ signature }) => signature)
         .map(({ signature }, i) => (
@@ -249,7 +241,6 @@ const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
             }
           />
         ))}
-
       <TxParameter
         name="hexData"
         value={

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -23,6 +23,7 @@ import { isMultiSigExecutionDetails, Transaction } from 'src/logic/safe/store/mo
 import { getExplorerInfo } from 'src/config'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { getByteLength } from 'src/utils/getByteLength'
+import { md } from 'src/theme/variables'
 
 const TxParameterWrapper = styled.div`
   display: flex;
@@ -52,8 +53,8 @@ const StyledButtonLink = styled(ButtonLink)`
 `
 
 const StyledDivider = styled(Divider)`
-  margin-right: -16px;
-  margin-left: -16px;
+  margin-right: -${md};
+  margin-left: -${md};
 `
 
 type Props = {

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -12,6 +12,7 @@ import {
   CopyToClipboardBtn,
 } from '@gnosis.pm/safe-react-components'
 import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
+import { ThemeColors } from '@gnosis.pm/safe-react-components/dist/theme'
 
 import { currentSafe, currentSafeThreshold } from 'src/logic/safe/store/selectors'
 import { getLastTxNonce, getTransactionsByNonce } from 'src/logic/safe/store/selectors/gatewayTransactions'
@@ -45,8 +46,9 @@ const StyledText = styled(Text)`
   margin: 8px 0 0 0;
 `
 
-const ColoredText = styled(Text)<{ isOutOfOrder: boolean }>`
-  color: ${(props) => (props.isOutOfOrder ? props.theme.colors.error : props.color)};
+type ColoredTextProps = { isError?: boolean }
+const ColoredText = styled(Text)<ColoredTextProps>`
+  color: ${(props) => (props.isError ? props.theme.colors.error : props.color)};
 `
 
 const StyledButtonLink = styled(ButtonLink)`
@@ -64,9 +66,16 @@ const StyledDivider = styled(Divider)`
 `
 
 type TxParam = string | ReactElement
-const TxParameter = ({ name, value }: { name: TxParam; value: TxParam }): ReactElement => {
+type TxParameterProps = { name: TxParam; value: TxParam; color?: ThemeColors } & ColoredTextProps
+const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement => {
   const getEl = (prop: TxParam) => {
-    return typeof prop === 'string' ? <Text size="lg">{prop}</Text> : prop
+    return typeof prop === 'string' ? (
+      <ColoredText size="lg" {...rest}>
+        {prop}
+      </ColoredText>
+    ) : (
+      prop
+    )
   }
   return (
     <TxParameterWrapper>
@@ -146,32 +155,13 @@ export const TxParametersDetail = ({
             Safe transaction parameters
           </StyledText>
           <TxParameter
-            name={
-              <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
-                Safe nonce
-              </ColoredText>
-            }
-            value={
-              <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
-                {txParameters.safeNonce}
-              </ColoredText>
-            }
+            name="Safe nonce"
+            value={txParameters.safeNonce || ''}
+            isError={isTxNonceOutOfOrder}
+            color={color}
           />
 
-          {showSafeTxGas && (
-            <TxParameter
-              name={
-                <Text size="lg" color={color}>
-                  SafeTxGas
-                </Text>
-              }
-              value={
-                <Text size="lg" color={color}>
-                  {txParameters.safeTxGas}
-                </Text>
-              }
-            />
-          )}
+          {showSafeTxGas && <TxParameter name="SafeTxGas" value={txParameters.safeTxGas || '0'} color={color} />}
           <StyledButtonLink color="primary" textSize="xl" onClick={onEdit}>
             Edit
           </StyledButtonLink>

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -240,23 +240,19 @@ const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
         </TxParameterWrapper>
       )}
 
-      {confirmations?.map((confirmation, i) => {
-        if (!confirmation?.signature) {
-          return null
-        }
-        const { signature } = confirmation
-        return (
+      {confirmations
+        ?.filter(({ signature }) => signature)
+        .map(({ signature }, i) => (
           <TxParameterWrapper key={signature}>
             <Text size="lg">Signature {`${i + 1}`}</Text>
             <TxParameterEndWrapper>
               <Text size="lg" as="span">
                 {signature ? getByteLength(signature) : 0} bytes
               </Text>
-              <CopyToClipboardBtn textToCopy={signature} />
+              {signature && <CopyToClipboardBtn textToCopy={signature} />}
             </TxParameterEndWrapper>
           </TxParameterWrapper>
-        )
-      })}
+        ))}
 
       <TxParameterWrapper>
         <Text size="lg">hexData</Text>

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -206,7 +206,7 @@ const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
         <TxParameterWrapper>
           <Text size="lg">Operation</Text>
           <Text size="lg">
-            {operation} {`(${operation === Operation.DELEGATE ? 'delegate' : 'call'})`}
+            {operation} {`(${Operation[operation].toLowerCase()})`}
           </Text>
         </TxParameterWrapper>
       )}

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -1,13 +1,28 @@
 import { ReactElement, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
-import { Text, Accordion, AccordionSummary, AccordionDetails, ButtonLink } from '@gnosis.pm/safe-react-components'
+import {
+  Text,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  ButtonLink,
+  Divider,
+  EthHashInfo,
+  CopyToClipboardBtn,
+} from '@gnosis.pm/safe-react-components'
+import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { currentSafe, currentSafeThreshold } from 'src/logic/safe/store/selectors'
-import { getLastTxNonce } from 'src/logic/safe/store/selectors/gatewayTransactions'
+import { getLastTxNonce, getTransactionsByNonce } from 'src/logic/safe/store/selectors/gatewayTransactions'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
-import { ParametersStatus, areSafeParamsEnabled } from '../utils'
+import { ParametersStatus, areSafeParamsEnabled } from 'src/routes/safe/components/Transactions/helpers/utils'
 import useSafeTxGas from 'src/routes/safe/components/Transactions/helpers/useSafeTxGas'
+import { AppReduxState } from 'src/store'
+import { isMultiSigExecutionDetails, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
+import { getExplorerInfo } from 'src/config'
+import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
+import { getByteLength } from 'src/utils/getByteLength'
 
 const TxParameterWrapper = styled.div`
   display: flex;
@@ -34,6 +49,11 @@ const StyledButtonLink = styled(ButtonLink)`
   > p {
     margin-left: 0;
   }
+`
+
+const StyledDivider = styled(Divider)`
+  width: calc(100% + 32px);
+  margin-left: -16px;
 `
 
 type Props = {
@@ -66,9 +86,12 @@ export const TxParametersDetail = ({
   const safeNonceNumber = parseInt(safeNonce, 10)
   const lastQueuedTxNonce = useSelector(getLastTxNonce)
   const showSafeTxGas = useSafeTxGas()
+  const storedTx = useSelector((state: AppReduxState) => getTransactionsByNonce(state, safeNonceNumber || 0))
 
   useEffect(() => {
-    if (Number.isNaN(safeNonceNumber) || safeNonceNumber === nonce) return
+    if (Number.isNaN(safeNonceNumber) || safeNonceNumber === nonce) {
+      return
+    }
     if (lastQueuedTxNonce === undefined && safeNonceNumber !== nonce) {
       setIsAccordionExpanded(true)
       setIsTxNonceOutOfOrder(true)
@@ -87,6 +110,10 @@ export const TxParametersDetail = ({
     setIsAccordionExpanded(!isAccordionExpanded)
   }
 
+  const getColor = () => {
+    return areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'
+  }
+
   return (
     <Accordion compact={compact} expanded={isAccordionExpanded} onChange={onChangeExpand}>
       <AccordionSummary>
@@ -99,34 +126,20 @@ export const TxParametersDetail = ({
           </StyledText>
 
           <TxParameterWrapper>
-            <ColoredText
-              size="lg"
-              isOutOfOrder={isTxNonceOutOfOrder}
-              color={areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'}
-            >
+            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={getColor()}>
               Safe nonce
             </ColoredText>
-            <ColoredText
-              size="lg"
-              isOutOfOrder={isTxNonceOutOfOrder}
-              color={areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'}
-            >
+            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={getColor()}>
               {txParameters.safeNonce}
             </ColoredText>
           </TxParameterWrapper>
 
           {showSafeTxGas && (
             <TxParameterWrapper>
-              <Text
-                size="lg"
-                color={areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'}
-              >
+              <Text size="lg" color={getColor()}>
                 SafeTxGas
               </Text>
-              <Text
-                size="lg"
-                color={areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'}
-              >
+              <Text size="lg" color={getColor()}>
                 {txParameters.safeTxGas}
               </Text>
             </TxParameterWrapper>
@@ -134,8 +147,124 @@ export const TxParametersDetail = ({
           <StyledButtonLink color="primary" textSize="xl" onClick={onEdit}>
             Edit
           </StyledButtonLink>
+          {storedTx?.length > 0 && <TxAdvancedParametersDetail tx={storedTx[0]} />}
         </AccordionDetailsWrapper>
       </AccordionDetails>
     </Accordion>
+  )
+}
+
+const TxParameterEndWrapper = styled.span`
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px; // EthHashInfo uses a gap between the address and copy button
+`
+
+const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
+  const { txData, detailedExecutionInfo } = tx?.txDetails || {}
+
+  if (!txData || !detailedExecutionInfo) {
+    return null
+  }
+
+  return (
+    <>
+      <StyledDivider />
+
+      {txData.value && (
+        <TxParameterWrapper>
+          <Text size="lg">value</Text>
+          <Text size="lg">{txData.value}</Text>
+        </TxParameterWrapper>
+      )}
+
+      {txData.to.value && (
+        <TxParameterWrapper>
+          <Text size="lg">to</Text>
+          <PrefixedEthHashInfo
+            textSize="lg"
+            hash={txData.to.value}
+            showCopyBtn
+            explorerUrl={getExplorerInfo(txData.to.value)}
+            shortenHash={8}
+          />
+        </TxParameterWrapper>
+      )}
+
+      {isMultiSigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo.safeTxHash && (
+        <TxParameterWrapper>
+          <Text size="lg">safeTxHash</Text>
+          <EthHashInfo textSize="lg" hash={detailedExecutionInfo.safeTxHash} showCopyBtn shortenHash={8} />
+        </TxParameterWrapper>
+      )}
+
+      {Object.values(Operation).includes(txData.operation) && (
+        <TxParameterWrapper>
+          <Text size="lg">Operation</Text>
+          <Text size="lg">
+            {txData.operation} {`(${txData.operation === Operation.DELEGATE ? 'delegate' : 'call'})`}
+          </Text>
+        </TxParameterWrapper>
+      )}
+
+      {isMultiSigExecutionDetails(detailedExecutionInfo) && (
+        <TxParameterWrapper>
+          <Text size="lg">baseGas</Text>
+          <Text size="lg">{detailedExecutionInfo.baseGas}</Text>
+        </TxParameterWrapper>
+      )}
+
+      {isMultiSigExecutionDetails(detailedExecutionInfo) && (
+        <TxParameterWrapper>
+          <Text size="lg">gasPrice</Text>
+          <Text size="lg">{detailedExecutionInfo.gasPrice}</Text>
+        </TxParameterWrapper>
+      )}
+
+      {isMultiSigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo.gasToken && (
+        <TxParameterWrapper>
+          <Text size="lg">gasToken</Text>
+          <EthHashInfo textSize="lg" hash={detailedExecutionInfo.gasToken} showCopyBtn shortenHash={8} />
+        </TxParameterWrapper>
+      )}
+
+      {isMultiSigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo.refundReceiver.value && (
+        <TxParameterWrapper>
+          <Text size="lg">refundReceiver</Text>
+          <EthHashInfo textSize="lg" hash={detailedExecutionInfo.refundReceiver.value} showCopyBtn shortenHash={8} />
+        </TxParameterWrapper>
+      )}
+
+      {isMultiSigExecutionDetails(detailedExecutionInfo) &&
+        detailedExecutionInfo.confirmations?.map((confirmation, i) => {
+          if (!confirmation?.signature) {
+            return null
+          }
+          const { signature } = confirmation
+          return (
+            <TxParameterWrapper key={signature}>
+              <Text size="lg">Signature {`${i + 1}`}</Text>
+              <TxParameterEndWrapper>
+                <Text size="lg" as="span">
+                  {signature ? getByteLength(signature) : 0} bytes
+                </Text>
+                <CopyToClipboardBtn textToCopy={signature} />
+              </TxParameterEndWrapper>
+            </TxParameterWrapper>
+          )
+        })}
+
+      {txData.hexData && (
+        <TxParameterWrapper>
+          <Text size="lg">hexData</Text>
+          <TxParameterEndWrapper>
+            <Text size="lg" as="span">
+              {txData.hexData ? getByteLength(txData.hexData) : 0} bytes{' '}
+            </Text>
+            <CopyToClipboardBtn textToCopy={txData.hexData} />
+          </TxParameterEndWrapper>
+        </TxParameterWrapper>
+      )}
+    </>
   )
 }

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -30,6 +30,12 @@ const TxParameterWrapper = styled.div`
   justify-content: space-between;
 `
 
+const TxParameterEndWrapper = styled.span`
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px; // EthHashInfo uses a gap between the address and copy button
+`
+
 const AccordionDetailsWrapper = styled.div`
   width: 100%;
   display: flex;
@@ -56,6 +62,19 @@ const StyledDivider = styled(Divider)`
   margin-right: -${md};
   margin-left: -${md};
 `
+
+type TxParam = string | ReactElement
+const TxParameter = ({ name, value }: { name: TxParam; value: TxParam }): ReactElement => {
+  const getEl = (prop: TxParam) => {
+    return typeof prop === 'string' ? <Text size="lg">{prop}</Text> : prop
+  }
+  return (
+    <TxParameterWrapper>
+      {getEl(name)}
+      {getEl(value)}
+    </TxParameterWrapper>
+  )
+}
 
 type Props = {
   txParameters: TxParameters
@@ -87,7 +106,7 @@ export const TxParametersDetail = ({
   const safeNonceNumber = parseInt(safeNonce, 10)
   const lastQueuedTxNonce = useSelector(getLastTxNonce)
   const showSafeTxGas = useSafeTxGas()
-  const storedTx = useSelector((state: AppReduxState) => getTransactionsByNonce(state, safeNonceNumber || 0))
+  const storedTx = useSelector((state: AppReduxState) => getTransactionsByNonce(state, safeNonceNumber))
 
   useEffect(() => {
     if (Number.isNaN(safeNonceNumber) || safeNonceNumber === nonce) {
@@ -126,25 +145,32 @@ export const TxParametersDetail = ({
           <StyledText size="md" color="placeHolder">
             Safe transaction parameters
           </StyledText>
-
-          <TxParameterWrapper>
-            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
-              Safe nonce
-            </ColoredText>
-            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
-              {txParameters.safeNonce}
-            </ColoredText>
-          </TxParameterWrapper>
+          <TxParameter
+            name={
+              <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
+                Safe nonce
+              </ColoredText>
+            }
+            value={
+              <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
+                {txParameters.safeNonce}
+              </ColoredText>
+            }
+          />
 
           {showSafeTxGas && (
-            <TxParameterWrapper>
-              <Text size="lg" color={color}>
-                SafeTxGas
-              </Text>
-              <Text size="lg" color={color}>
-                {txParameters.safeTxGas}
-              </Text>
-            </TxParameterWrapper>
+            <TxParameter
+              name={
+                <Text size="lg" color={color}>
+                  SafeTxGas
+                </Text>
+              }
+              value={
+                <Text size="lg" color={color}>
+                  {txParameters.safeTxGas}
+                </Text>
+              }
+            />
           )}
           <StyledButtonLink color="primary" textSize="xl" onClick={onEdit}>
             Edit
@@ -155,12 +181,6 @@ export const TxParametersDetail = ({
     </Accordion>
   )
 }
-
-const TxParameterEndWrapper = styled.span`
-  display: flex;
-  justify-content: flex-end;
-  gap: 4px; // EthHashInfo uses a gap between the address and copy button
-`
 
 const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
   const { txData, detailedExecutionInfo } = tx?.txDetails || {}
@@ -177,93 +197,80 @@ const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
     <>
       <StyledDivider />
 
-      {value && (
-        <TxParameterWrapper>
-          <Text size="lg">value</Text>
-          <Text size="lg">{value}</Text>
-        </TxParameterWrapper>
-      )}
+      {value && <TxParameter name="value" value={value} />}
 
       {to?.value && (
-        <TxParameterWrapper>
-          <Text size="lg">to</Text>
-          <PrefixedEthHashInfo
-            textSize="lg"
-            hash={to.value}
-            showCopyBtn
-            explorerUrl={getExplorerInfo(to.value)}
-            shortenHash={8}
-          />
-        </TxParameterWrapper>
+        <TxParameter
+          name="to"
+          value={
+            <PrefixedEthHashInfo
+              textSize="lg"
+              hash={to.value}
+              showCopyBtn
+              explorerUrl={getExplorerInfo(to.value)}
+              shortenHash={8}
+            />
+          }
+        />
       )}
 
       {safeTxHash && (
-        <TxParameterWrapper>
-          <Text size="lg">safeTxHash</Text>
-          <EthHashInfo textSize="lg" hash={safeTxHash} showCopyBtn shortenHash={8} />
-        </TxParameterWrapper>
+        <TxParameter
+          name="safeTxHash"
+          value={<EthHashInfo textSize="lg" hash={safeTxHash} showCopyBtn shortenHash={8} />}
+        />
       )}
 
       {Object.values(Operation).includes(operation) && (
-        <TxParameterWrapper>
-          <Text size="lg">Operation</Text>
-          <Text size="lg">
-            {operation} {`(${Operation[operation].toLowerCase()})`}
-          </Text>
-        </TxParameterWrapper>
+        <TxParameter name="Operation" value={`${operation} (${Operation[operation].toLowerCase()})`} />
       )}
 
-      {baseGas && (
-        <TxParameterWrapper>
-          <Text size="lg">baseGas</Text>
-          <Text size="lg">{baseGas}</Text>
-        </TxParameterWrapper>
-      )}
+      {baseGas && <TxParameter name="baseGas" value={baseGas} />}
 
-      {gasPrice && (
-        <TxParameterWrapper>
-          <Text size="lg">gasPrice</Text>
-          <Text size="lg">{gasPrice}</Text>
-        </TxParameterWrapper>
-      )}
+      {gasPrice && <TxParameter name="gasPrice" value={gasPrice} />}
 
       {gasToken && (
-        <TxParameterWrapper>
-          <Text size="lg">gasToken</Text>
-          <EthHashInfo textSize="lg" hash={gasToken} showCopyBtn shortenHash={8} />
-        </TxParameterWrapper>
+        <TxParameter
+          name="gasToken"
+          value={<EthHashInfo textSize="lg" hash={gasToken} showCopyBtn shortenHash={8} />}
+        />
       )}
 
       {refundReceiver?.value && (
-        <TxParameterWrapper>
-          <Text size="lg">refundReceiver</Text>
-          <EthHashInfo textSize="lg" hash={refundReceiver.value} showCopyBtn shortenHash={8} />
-        </TxParameterWrapper>
+        <TxParameter
+          name="refundReceiver"
+          value={<EthHashInfo textSize="lg" hash={refundReceiver.value} showCopyBtn shortenHash={8} />}
+        />
       )}
 
       {confirmations
         ?.filter(({ signature }) => signature)
         .map(({ signature }, i) => (
-          <TxParameterWrapper key={signature}>
-            <Text size="lg">Signature {`${i + 1}`}</Text>
-            <TxParameterEndWrapper>
-              <Text size="lg" as="span">
-                {signature ? getByteLength(signature) : 0} bytes
-              </Text>
-              {signature && <CopyToClipboardBtn textToCopy={signature} />}
-            </TxParameterEndWrapper>
-          </TxParameterWrapper>
+          <TxParameter
+            name={`Signature ${i + 1}`}
+            key={signature}
+            value={
+              <TxParameterEndWrapper>
+                <Text size="lg" as="span">
+                  {signature ? getByteLength(signature) : 0} bytes
+                </Text>
+                {signature && <CopyToClipboardBtn textToCopy={signature} />}
+              </TxParameterEndWrapper>
+            }
+          />
         ))}
 
-      <TxParameterWrapper>
-        <Text size="lg">hexData</Text>
-        <TxParameterEndWrapper>
-          <Text size="lg" as="span">
-            {hexData ? getByteLength(hexData) : 0} bytes
-          </Text>
-          {hexData && <CopyToClipboardBtn textToCopy={hexData} />}
-        </TxParameterEndWrapper>
-      </TxParameterWrapper>
+      <TxParameter
+        name="hexData"
+        value={
+          <TxParameterEndWrapper>
+            <Text size="lg" as="span">
+              {hexData ? getByteLength(hexData) : 0} bytes
+            </Text>
+            {hexData && <CopyToClipboardBtn textToCopy={hexData} />}
+          </TxParameterEndWrapper>
+        }
+      />
     </>
   )
 }

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -167,104 +167,105 @@ const TxAdvancedParametersDetail = ({ tx }: { tx: Transaction }) => {
     return null
   }
 
+  const { value, to, operation, hexData } = txData
+  const { safeTxHash, baseGas, gasPrice, gasToken, refundReceiver, confirmations } =
+    (isMultiSigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo) || {}
+
   return (
     <>
       <StyledDivider />
 
-      {txData.value && (
+      {value && (
         <TxParameterWrapper>
           <Text size="lg">value</Text>
-          <Text size="lg">{txData.value}</Text>
+          <Text size="lg">{value}</Text>
         </TxParameterWrapper>
       )}
 
-      {txData.to.value && (
+      {to?.value && (
         <TxParameterWrapper>
           <Text size="lg">to</Text>
           <PrefixedEthHashInfo
             textSize="lg"
-            hash={txData.to.value}
+            hash={to.value}
             showCopyBtn
-            explorerUrl={getExplorerInfo(txData.to.value)}
+            explorerUrl={getExplorerInfo(to.value)}
             shortenHash={8}
           />
         </TxParameterWrapper>
       )}
 
-      {isMultiSigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo.safeTxHash && (
+      {safeTxHash && (
         <TxParameterWrapper>
           <Text size="lg">safeTxHash</Text>
-          <EthHashInfo textSize="lg" hash={detailedExecutionInfo.safeTxHash} showCopyBtn shortenHash={8} />
+          <EthHashInfo textSize="lg" hash={safeTxHash} showCopyBtn shortenHash={8} />
         </TxParameterWrapper>
       )}
 
-      {Object.values(Operation).includes(txData.operation) && (
+      {Object.values(Operation).includes(operation) && (
         <TxParameterWrapper>
           <Text size="lg">Operation</Text>
           <Text size="lg">
-            {txData.operation} {`(${txData.operation === Operation.DELEGATE ? 'delegate' : 'call'})`}
+            {operation} {`(${operation === Operation.DELEGATE ? 'delegate' : 'call'})`}
           </Text>
         </TxParameterWrapper>
       )}
 
-      {isMultiSigExecutionDetails(detailedExecutionInfo) && (
+      {baseGas && (
         <TxParameterWrapper>
           <Text size="lg">baseGas</Text>
-          <Text size="lg">{detailedExecutionInfo.baseGas}</Text>
+          <Text size="lg">{baseGas}</Text>
         </TxParameterWrapper>
       )}
 
-      {isMultiSigExecutionDetails(detailedExecutionInfo) && (
+      {gasPrice && (
         <TxParameterWrapper>
           <Text size="lg">gasPrice</Text>
-          <Text size="lg">{detailedExecutionInfo.gasPrice}</Text>
+          <Text size="lg">{gasPrice}</Text>
         </TxParameterWrapper>
       )}
 
-      {isMultiSigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo.gasToken && (
+      {gasToken && (
         <TxParameterWrapper>
           <Text size="lg">gasToken</Text>
-          <EthHashInfo textSize="lg" hash={detailedExecutionInfo.gasToken} showCopyBtn shortenHash={8} />
+          <EthHashInfo textSize="lg" hash={gasToken} showCopyBtn shortenHash={8} />
         </TxParameterWrapper>
       )}
 
-      {isMultiSigExecutionDetails(detailedExecutionInfo) && detailedExecutionInfo.refundReceiver.value && (
+      {refundReceiver?.value && (
         <TxParameterWrapper>
           <Text size="lg">refundReceiver</Text>
-          <EthHashInfo textSize="lg" hash={detailedExecutionInfo.refundReceiver.value} showCopyBtn shortenHash={8} />
+          <EthHashInfo textSize="lg" hash={refundReceiver.value} showCopyBtn shortenHash={8} />
         </TxParameterWrapper>
       )}
 
-      {isMultiSigExecutionDetails(detailedExecutionInfo) &&
-        detailedExecutionInfo.confirmations?.map((confirmation, i) => {
-          if (!confirmation?.signature) {
-            return null
-          }
-          const { signature } = confirmation
-          return (
-            <TxParameterWrapper key={signature}>
-              <Text size="lg">Signature {`${i + 1}`}</Text>
-              <TxParameterEndWrapper>
-                <Text size="lg" as="span">
-                  {signature ? getByteLength(signature) : 0} bytes
-                </Text>
-                <CopyToClipboardBtn textToCopy={signature} />
-              </TxParameterEndWrapper>
-            </TxParameterWrapper>
-          )
-        })}
+      {confirmations?.map((confirmation, i) => {
+        if (!confirmation?.signature) {
+          return null
+        }
+        const { signature } = confirmation
+        return (
+          <TxParameterWrapper key={signature}>
+            <Text size="lg">Signature {`${i + 1}`}</Text>
+            <TxParameterEndWrapper>
+              <Text size="lg" as="span">
+                {signature ? getByteLength(signature) : 0} bytes
+              </Text>
+              <CopyToClipboardBtn textToCopy={signature} />
+            </TxParameterEndWrapper>
+          </TxParameterWrapper>
+        )
+      })}
 
-      {txData.hexData && (
-        <TxParameterWrapper>
-          <Text size="lg">hexData</Text>
-          <TxParameterEndWrapper>
-            <Text size="lg" as="span">
-              {txData.hexData ? getByteLength(txData.hexData) : 0} bytes{' '}
-            </Text>
-            <CopyToClipboardBtn textToCopy={txData.hexData} />
-          </TxParameterEndWrapper>
-        </TxParameterWrapper>
-      )}
+      <TxParameterWrapper>
+        <Text size="lg">hexData</Text>
+        <TxParameterEndWrapper>
+          <Text size="lg" as="span">
+            {hexData ? getByteLength(hexData) : 0} bytes
+          </Text>
+          {hexData && <CopyToClipboardBtn textToCopy={hexData} />}
+        </TxParameterEndWrapper>
+      </TxParameterWrapper>
     </>
   )
 }

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import {
@@ -52,7 +52,7 @@ const StyledButtonLink = styled(ButtonLink)`
 `
 
 const StyledDivider = styled(Divider)`
-  width: calc(100% + 32px);
+  margin-right: -16px;
   margin-left: -16px;
 `
 
@@ -102,16 +102,17 @@ export const TxParametersDetail = ({
     }
   }, [lastQueuedTxNonce, nonce, safeNonceNumber])
 
+  const color = useMemo(
+    () => (areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'),
+    [parametersStatus, defaultParameterStatus],
+  )
+
   if (!isTransactionExecution && !isTransactionCreation && isOffChainSignature) {
     return null
   }
 
   const onChangeExpand = () => {
     setIsAccordionExpanded(!isAccordionExpanded)
-  }
-
-  const getColor = () => {
-    return areSafeParamsEnabled(parametersStatus || defaultParameterStatus) ? 'text' : 'secondaryLight'
   }
 
   return (
@@ -126,20 +127,20 @@ export const TxParametersDetail = ({
           </StyledText>
 
           <TxParameterWrapper>
-            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={getColor()}>
+            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
               Safe nonce
             </ColoredText>
-            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={getColor()}>
+            <ColoredText size="lg" isOutOfOrder={isTxNonceOutOfOrder} color={color}>
               {txParameters.safeNonce}
             </ColoredText>
           </TxParameterWrapper>
 
           {showSafeTxGas && (
             <TxParameterWrapper>
-              <Text size="lg" color={getColor()}>
+              <Text size="lg" color={color}>
                 SafeTxGas
               </Text>
-              <Text size="lg" color={getColor()}>
+              <Text size="lg" color={color}>
                 {txParameters.safeTxGas}
               </Text>
             </TxParameterWrapper>


### PR DESCRIPTION
## What it solves
Resolves #3061

## How this PR fixes it
More advanced parameters are now shown in the modals when they are present.

The order and render of them (whether they are `EthHashInfo` or copiable bytes) is based off of the 'Advanced Details' added to `TxSummary` a while back.

## How to test it
Expand the 'Advanced paramters' accordion on the transaction review modal and observe new parameters that correspond to the available information of the transaction.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/151353247-6937052b-2979-4d57-940d-d48ae686b6f6.png)