### PR TITLE
Fix: don't log ENS errors

### DIFF
--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -9,7 +9,6 @@ enum ErrorCodes {
   _100 = '100: Invalid input in the address field',
   _101 = '101: Failed to resolve the address',
   _102 = '102: Error getting an address checksum',
-  _103 = '103: Error retrieving ENS Name for address',
   _300 = '300: Error switching the wallet network',
   _301 = '301: Error adding a new wallet network',
   _600 = '600: Error fetching token list',

--- a/src/logic/safe/store/actions/__tests__/fetchSafe.test.ts
+++ b/src/logic/safe/store/actions/__tests__/fetchSafe.test.ts
@@ -10,10 +10,13 @@ import { UPDATE_SAFE } from 'src/logic/safe/store/actions/updateSafe'
 import { inMemoryPartialSafeInformation, localSafesInfo, remoteSafeInfoWithoutModules } from '../mocks/safeInformation'
 import * as gateway from '@gnosis.pm/safe-react-gateway-sdk'
 
-jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
-  __esModule: true,
-  getSafeInfo: jest.fn(),
-}))
+jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => {
+  const originalModule = jest.requireActual('@gnosis.pm/safe-react-gateway-sdk')
+  return {
+    ...originalModule,
+    getSafeInfo: jest.fn(),
+  }
+})
 
 jest.mock('src/utils/storage/index')
 

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -12,7 +12,6 @@ import { getRpcServiceUrl, _getChainId } from 'src/config'
 import { CHAIN_ID, ChainId } from 'src/config/chain.d'
 import { isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { getAddressFromUnstoppableDomain } from './utils/unstoppableDomains'
-import { Errors, logError } from '../exceptions/CodedException'
 import { Contract } from 'web3-eth-contract'
 
 // This providers have direct relation with name assigned in bnc-onboard configuration
@@ -128,8 +127,7 @@ export const reverseENSLookup = async (address: string): Promise<string> => {
   try {
     ResolverContract = await web3.eth.ens.getResolver(lookup)
   } catch (err) {
-    logError(Errors._103, err.message)
-    return name
+    return ''
   }
 
   let verifiedAddress = ''
@@ -137,7 +135,7 @@ export const reverseENSLookup = async (address: string): Promise<string> => {
     name = await ResolverContract.methods.name(nh).call()
     verifiedAddress = await web3.eth.ens.getAddress(name)
   } catch (err) {
-    logError(Errors._103, err.message)
+    return ''
   }
 
   return verifiedAddress === address ? name : ''

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -13,6 +13,8 @@ import { CHAIN_ID, ChainId } from 'src/config/chain.d'
 import { isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { getAddressFromUnstoppableDomain } from './utils/unstoppableDomains'
 import { Contract } from 'web3-eth-contract'
+import { hasFeature } from '../safe/utils/safeVersion'
+import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 // This providers have direct relation with name assigned in bnc-onboard configuration
 export enum WALLET_PROVIDER {
@@ -118,6 +120,10 @@ export const getAddressFromDomain = (name: string): Promise<string> => {
 }
 
 export const reverseENSLookup = async (address: string): Promise<string> => {
+  if (!hasFeature(FEATURES.DOMAIN_LOOKUP)) {
+    return ''
+  }
+
   const web3 = getWeb3ReadOnly()
   const lookup = address.toLowerCase().substr(2) + '.addr.reverse'
   const nh = namehash(lookup)

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -1,9 +1,11 @@
 import semverSatisfies from 'semver/functions/satisfies'
 import Web3 from 'web3'
+import { Contract } from 'web3-eth-contract'
 import { provider as Provider } from 'web3-core'
 import { ContentHash } from 'web3-eth-ens'
 import { namehash } from '@ethersproject/hash'
 import Safe, { Web3Adapter } from '@gnosis.pm/safe-core-sdk'
+import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { sameAddress, ZERO_ADDRESS } from './ethAddresses'
 import { EMPTY_DATA } from './ethTransactions'
@@ -12,9 +14,7 @@ import { getRpcServiceUrl, _getChainId } from 'src/config'
 import { CHAIN_ID, ChainId } from 'src/config/chain.d'
 import { isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { getAddressFromUnstoppableDomain } from './utils/unstoppableDomains'
-import { Contract } from 'web3-eth-contract'
-import { hasFeature } from '../safe/utils/safeVersion'
-import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
+import { hasFeature } from 'src/logic/safe/utils/safeVersion'
 
 // This providers have direct relation with name assigned in bnc-onboard configuration
 export enum WALLET_PROVIDER {


### PR DESCRIPTION
## What it solves
Removing logs when we cannot resolve ENS to have less noise in the console.
