### PR TITLE
fix: remove sidebar scroll behaviour

### DIFF
--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -85,7 +85,7 @@ const SafeListItem = ({
 
   useEffect(() => {
     if (isCurrentSafe && shouldScrollToSafe) {
-      safeRef?.current?.scrollIntoView({ behavior: 'smooth' })
+      safeRef?.current?.scrollIntoView()
     }
   }, [isCurrentSafe, shouldScrollToSafe])
 

--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -85,7 +85,7 @@ const SafeListItem = ({
 
   useEffect(() => {
     if (isCurrentSafe && shouldScrollToSafe) {
-      safeRef?.current?.scrollIntoView()
+      safeRef?.current?.scrollIntoView({ block: 'center' })
     }
   }, [isCurrentSafe, shouldScrollToSafe])
 


### PR DESCRIPTION
## What it solves
Auto-scroll in long sidebars.

## How this PR fixes it
The scrollbar no longer scrolls to the Safe when opening the sidebar. Instead, positioning the Safe in the middle of the sidebar.

## How to test it
- Open a Safe on a network with multiple Safes.
- Ensure that the sidebar has a scrollbar (requiring scrolling to position the loaded Safe in the middle of the sidebar).
- Close and open the sidebar, observing that no scrolling occurs. The sidebar opens with the Safe in the middle of the list (if it was either in the viewport before or out of view).

## Screenshot
![scroll](https://user-images.githubusercontent.com/20442784/151775689-9d5a69e2-7d2c-40fb-a8d3-9e1ee79647d1.gif)