### PR TITLE
fix: throttle queue transaction macro

### DIFF
--- a/src/components/AppLayout/Sidebar/DevTools/index.tsx
+++ b/src/components/AppLayout/Sidebar/DevTools/index.tsx
@@ -81,7 +81,9 @@ const DevTools = (): ReactElement => {
     return hasFunds
   }
 
-  const debouncedCreatedQueuedTx = useDebounce(createQueuedTx, 1000)
+  const debouncedCreatedQueuedTx = useDebounce(() => {
+    createQueuedTx(safeAddress, threshold)
+  }, 1000)
 
   return (
     <>
@@ -101,7 +103,7 @@ const DevTools = (): ReactElement => {
       </List>
       <ButtonWrapper>
         <StyledButton
-          onClick={() => debouncedCreatedQueuedTx(safeAddress, threshold)}
+          onClick={() => debouncedCreatedQueuedTx()}
           size="md"
           variant="bordered"
           disabled={!isGranted || !hasSufficientFunds()}

--- a/src/components/AppLayout/Sidebar/DevTools/index.tsx
+++ b/src/components/AppLayout/Sidebar/DevTools/index.tsx
@@ -6,7 +6,7 @@ import { Button } from '@gnosis.pm/safe-react-components'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
-import debounce from 'lodash/debounce'
+import throttle from 'lodash/throttle'
 
 import { currentSafe, currentSafeEthBalance } from 'src/logic/safe/store/selectors'
 import { extractSafeAddress } from 'src/routes/routes'
@@ -81,7 +81,7 @@ const DevTools = (): ReactElement => {
     return hasFunds
   }
 
-  const debouncedCreatedQueuedTx = useMemo(() => debounce(createQueuedTx, 1000), [])
+  const throttledCreatedQueuedTx = useMemo(() => throttle(createQueuedTx, 1000), [])
 
   return (
     <>
@@ -101,7 +101,7 @@ const DevTools = (): ReactElement => {
       </List>
       <ButtonWrapper>
         <StyledButton
-          onClick={() => debouncedCreatedQueuedTx(safeAddress, threshold)}
+          onClick={() => throttledCreatedQueuedTx(safeAddress, threshold)}
           size="md"
           variant="bordered"
           disabled={!isGranted || !hasSufficientFunds()}

--- a/src/components/AppLayout/Sidebar/DevTools/index.tsx
+++ b/src/components/AppLayout/Sidebar/DevTools/index.tsx
@@ -12,6 +12,7 @@ import { extractSafeAddress } from 'src/routes/routes'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { nextTransaction } from 'src/logic/safe/store/selectors/gatewayTransactions'
 import { grantedSelector } from 'src/routes/safe/container/selector'
+import { useDebounce } from 'src/logic/hooks/useDebounce'
 
 const TX_AMOUNT = '0.0001'
 
@@ -80,6 +81,8 @@ const DevTools = (): ReactElement => {
     return hasFunds
   }
 
+  const debouncedCreatedQueuedTx = useDebounce(createQueuedTx, 1000)
+
   return (
     <>
       <List dense>
@@ -98,7 +101,7 @@ const DevTools = (): ReactElement => {
       </List>
       <ButtonWrapper>
         <StyledButton
-          onClick={() => createQueuedTx(safeAddress, threshold)}
+          onClick={() => debouncedCreatedQueuedTx(safeAddress, threshold)}
           size="md"
           variant="bordered"
           disabled={!isGranted || !hasSufficientFunds()}

--- a/src/components/AppLayout/Sidebar/DevTools/index.tsx
+++ b/src/components/AppLayout/Sidebar/DevTools/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
@@ -6,13 +6,13 @@ import { Button } from '@gnosis.pm/safe-react-components'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
+import debounce from 'lodash/debounce'
 
 import { currentSafe, currentSafeEthBalance } from 'src/logic/safe/store/selectors'
 import { extractSafeAddress } from 'src/routes/routes'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { nextTransaction } from 'src/logic/safe/store/selectors/gatewayTransactions'
 import { grantedSelector } from 'src/routes/safe/container/selector'
-import { useDebounce } from 'src/logic/hooks/useDebounce'
 
 const TX_AMOUNT = '0.0001'
 
@@ -81,9 +81,7 @@ const DevTools = (): ReactElement => {
     return hasFunds
   }
 
-  const debouncedCreatedQueuedTx = useDebounce(() => {
-    createQueuedTx(safeAddress, threshold)
-  }, 1000)
+  const debouncedCreatedQueuedTx = useMemo(() => debounce(createQueuedTx, 1000), [])
 
   return (
     <>
@@ -103,7 +101,7 @@ const DevTools = (): ReactElement => {
       </List>
       <ButtonWrapper>
         <StyledButton
-          onClick={() => debouncedCreatedQueuedTx()}
+          onClick={() => debouncedCreatedQueuedTx(safeAddress, threshold)}
           size="md"
           variant="bordered"
           disabled={!isGranted || !hasSufficientFunds()}


### PR DESCRIPTION
## What it solves
Preventing queue macro spam.

## How this PR fixes it
The queue transaction macro function is now throttled. Clicking it invokes the macro but subsequent clicks don't.

## How to test it
- Click the queue transaction dev tool button and observe that it does not allow the creation of a transaction repeatedly.