### PR TITLE
bug: signing fails in brave

### DIFF
--- a/src/logic/safe/transactions/offchainSigner/index.ts
+++ b/src/logic/safe/transactions/offchainSigner/index.ts
@@ -33,8 +33,12 @@ const getSupportedSigners = (isHW: boolean, safeVersion: string) => {
   return signers
 }
 
-const isKeystoneError = (err: Error): boolean => {
-  return err.message.startsWith('#ktek_error')
+const isKeystoneError = (err: unknown): boolean => {
+  if (err instanceof Error) {
+    return err.message?.startsWith('#ktek_error')
+  }
+
+  return false
 }
 
 export const tryOffChainSigning = async (


### PR DESCRIPTION
## What it solves
May solve #3388, but I couldn't reproduce the issue
Fixes error thrown while signing in brave (was reported internally in Slack) 
The error is only thrown when sending a native token. If you send ERC20 tokens, the error isn't thrown. There seems to be a problem with Brave wallet's EIP712 implementation.

## How this PR fixes it
When signing a transaction with brave wallet, if you try to sign with a non-supported signing method (`eth_signTypedData`), brave wallet throws a custom error that is not an instance of JS built-in `Error` class, but one of our error checkers expects error to be an instance of `Error` class

## How to test it
Test signing transactions in brave wallet, both tokens and native currency

## Screenshots
<img width="853" alt="Screenshot 2022-01-30 at 12 44 42" src="https://user-images.githubusercontent.com/16622558/151698919-c1411660-0c71-4439-806f-6cc79282689e.png">

