### PR TITLE
fix: Keep ENS TLD in safe creation and loading

### DIFF
--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -147,8 +147,6 @@ export const reverseENSLookup = async (address: string): Promise<string> => {
   return verifiedAddress === address ? name : ''
 }
 
-export const removeTld = (name: string): string => name.replace(/\.[^.]+$/, '')
-
 export const getContentFromENS = (name: string): Promise<ContentHash> => web3.eth.ens.getContenthash(name)
 
 export const isTxPendingError = (err: Error): boolean => {

--- a/src/routes/CreateSafePage/steps/NameNewSafeStep.tsx
+++ b/src/routes/CreateSafePage/steps/NameNewSafeStep.tsx
@@ -18,7 +18,7 @@ import {
 } from '../fields/createSafeFields'
 import { useStepper } from 'src/components/Stepper/stepperContext'
 import NetworkLabel from 'src/components/NetworkLabel/NetworkLabel'
-import { removeTld, reverseENSLookup } from 'src/logic/wallets/getWeb3'
+import { reverseENSLookup } from 'src/logic/wallets/getWeb3'
 
 export const nameNewSafeStepLabel = 'Name'
 
@@ -45,10 +45,9 @@ function NameNewSafeStep(): ReactElement {
         owners.map(async ({ addressFieldName }) => {
           const address = formValues[addressFieldName]
           const ensName = await reverseENSLookup(address)
-          const ensDomain = removeTld(ensName)
           return {
             address,
-            name: ensDomain,
+            name: ensName,
           }
         }),
       )

--- a/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
+++ b/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
@@ -38,7 +38,7 @@ import {
 import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
 import { currentNetworkAddressBookAsMap } from 'src/logic/addressBook/store/selectors'
 import NetworkLabel from 'src/components/NetworkLabel/NetworkLabel'
-import { removeTld, reverseENSLookup } from 'src/logic/wallets/getWeb3'
+import { reverseENSLookup } from 'src/logic/wallets/getWeb3'
 
 export const ownersAndConfirmationsNewSafeStepLabel = 'Owners and Confirmations'
 
@@ -89,9 +89,8 @@ function OwnersAndConfirmationsNewSafeStep(): ReactElement {
 
   const getENSName = async (address: string): Promise<void> => {
     const ensName = await reverseENSLookup(address)
-    const ensDomain = removeTld(ensName)
     const newOwnersWithENSName: Record<string, string> = Object.assign(ownersWithENSName, {
-      [address]: ensDomain,
+      [address]: ensName,
     })
     createSafeForm.change(FIELD_SAFE_OWNER_ENS_LIST, newOwnersWithENSName)
   }

--- a/src/routes/LoadSafePage/steps/LoadSafeAddressStep.tsx
+++ b/src/routes/LoadSafePage/steps/LoadSafeAddressStep.tsx
@@ -30,7 +30,7 @@ import {
 import NetworkLabel from 'src/components/NetworkLabel/NetworkLabel'
 import { getLoadSafeName } from '../fields/utils'
 import { currentChainId } from 'src/logic/config/store/selectors'
-import { removeTld, reverseENSLookup } from 'src/logic/wallets/getWeb3'
+import { reverseENSLookup } from 'src/logic/wallets/getWeb3'
 
 export const loadSafeAddressStepLabel = 'Name and address'
 
@@ -74,8 +74,7 @@ function LoadSafeAddressStep(): ReactElement {
         const ownersWithENSName = await Promise.all(
           owners.map(async ({ value: address }) => {
             const ensName = await reverseENSLookup(address)
-            const ensDomain = removeTld(ensName)
-            return makeAddressBookEntry({ address, name: ensDomain, chainId })
+            return makeAddressBookEntry({ address, name: ensName, chainId })
           }),
         )
 


### PR DESCRIPTION
After discussion we decided on keeping the TLD of the reverse ENS result when creating or loading a safe as it is more aligned with what users expect an ENS name to look like (with `.eth` at the end)

## How to test it

1. Open the Safe App
2. Create a new Safe with an owner that has a reverse ENS record
3. Load an existing Safe with an owner that has a reverse ENS record
4. Observe that the name placeholder is not shortened 

## Screenshots
![Screenshot 2022-01-31 at 15 34 50](https://user-images.githubusercontent.com/5880855/151812939-b4c9a0cf-552e-47f1-97e9-451ac067e9e7.png)

