### PR TITLE
Update eslint action dependency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: gnosis/safe-react-eslint-plus-action@main
+      - uses: gnosis/safe-react-eslint-plus-action@v3.5.0


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-apps-sdk/issues/276

## How this PR fixes it
As part of the [this ticket](v) we are updating the [safe-apps-sdk](https://github.com/gnosis/safe-apps-sdk) dependencies including the [gnosis/safe-react-eslint-plus-action](https://github.com/gnosis/safe-react-eslint-plus-action). These changes include a major `eslint` version bump from 7.x.x to 8.x.x. 

The list of affected Gnosis repos will be:

```
- https://github.com/gnosis/safe-react
- https://github.com/gnosis/safe-react-apps
- https://github.com/gnosis/safe-apps-sdk
- https://github.com/gnosis/safe-react-e2e-tests
- https://github.com/gnosis/safe-react-components
- https://github.com/gnosis/safe-react-gateway-sdk
- https://github.com/gnosis/safe-apps-dev-ui
```

ESLint 8 bring a [lot of changes](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0) to the table that can cause issues so as we have several projects using this action we are making PR’s using a concrete tag [v3.5.0](https://github.com/gnosis/safe-react-eslint-plus-action/releases/tag/v.3.5.0) for ensuring nothing is affected in the corresponding pipelines.