### PR TITLE
style: form input error label and maxPrioFee placeholder

### DIFF
--- a/src/components/forms/validator.test.ts
+++ b/src/components/forms/validator.test.ts
@@ -64,7 +64,7 @@ describe('Forms > Validators', () => {
 
   describe('minValue validator', () => {
     const getMinValueErrMsg = (minValue: number, inclusive = true): string =>
-      `Should be greater than ${inclusive ? 'or equal to ' : ''}${minValue}`
+      `Must be greater than ${inclusive ? 'or equal to ' : ''}${minValue}`
 
     it('Returns undefined for a number greater than minimum', () => {
       const minimum = Math.random()

--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -56,7 +56,7 @@ export const minValue =
       return undefined
     }
 
-    return `Should be greater than ${inclusive ? 'or equal to ' : ''}${min}`
+    return `Must be greater than ${inclusive ? 'or equal to ' : ''}${min}`
   }
 
 export const maxValue =

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -29,7 +29,7 @@ export enum EstimationStatus {
 }
 
 const DEFAULT_MAX_GAS_FEE = String(3.5e9) // 3.5 GWEI
-const DEFAULT_MAX_PRIO_FEE = String(2.5e9) // 2.5 GWEI
+export const DEFAULT_MAX_PRIO_FEE = String(2.5e9) // 2.5 GWEI
 
 export const checkIfTxIsApproveAndExecution = (
   threshold: number,

--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -4,6 +4,7 @@ import Close from '@material-ui/icons/Close'
 import { makeStyles } from '@material-ui/core/styles'
 import { Title, Text, Divider, Link, Icon } from '@gnosis.pm/safe-react-components'
 import styled from 'styled-components'
+import { fromWei } from 'web3-utils'
 
 import Field from 'src/components/forms/Field'
 import TextField from 'src/components/forms/TextField'
@@ -24,6 +25,7 @@ import useSafeTxGas from 'src/routes/safe/components/Transactions/helpers/useSaf
 import { isMaxFeeParam } from 'src/logic/safe/transactions/gas'
 import { extractSafeAddress } from 'src/routes/routes'
 import useGetRecommendedNonce from 'src/logic/hooks/useGetRecommendedNonce'
+import { DEFAULT_MAX_PRIO_FEE } from 'src/logic/hooks/useEstimateTransactionGas'
 
 const StyledDivider = styled(Divider)`
   margin: 0px;
@@ -212,7 +214,7 @@ export const EditTxParametersForm = ({
                         name="ethMaxPrioFee"
                         defaultValue={ethMaxPrioFee}
                         type="number"
-                        placeholder={`${ethMaxPrioFee} (GWEI)`}
+                        placeholder={`${fromWei(DEFAULT_MAX_PRIO_FEE, 'gwei')} (GWEI)`}
                         text="Max priority fee (GWEI)"
                         component={TextField}
                         disabled={!areEthereumParamsVisible(parametersStatus)}

--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -39,14 +39,9 @@ const SafeOptions = styled.div`
 `
 
 const EthereumOptions = styled.div`
-  display: flex;
-  /* justify-content: space-between; */
-  flex-wrap: wrap;
-  gap: 10px 20px;
-
-  div {
-    width: 216px !important;
-  }
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 `
 const StyledLink = styled(Link)`
   margin: 16px 0 0 0;
@@ -217,7 +212,7 @@ export const EditTxParametersForm = ({
                         name="ethMaxPrioFee"
                         defaultValue={ethMaxPrioFee}
                         type="number"
-                        placeholder="Max priority fee (GWEI)"
+                        placeholder={`${ethMaxPrioFee} (GWEI)`}
                         text="Max priority fee (GWEI)"
                         component={TextField}
                         disabled={!areEthereumParamsVisible(parametersStatus)}

--- a/src/routes/safe/components/Transactions/helpers/EditableTxParameters.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditableTxParameters.tsx
@@ -3,8 +3,10 @@ import { TxParameters, useTransactionParameters } from 'src/routes/safe/containe
 import { EditTxParametersForm } from 'src/routes/safe/components/Transactions/helpers/EditTxParametersForm'
 import { ParametersStatus } from './utils'
 import { useSelector } from 'react-redux'
+import { fromWei } from 'web3-utils'
 
 import { currentSafeThreshold } from 'src/logic/safe/store/selectors'
+import { DEFAULT_MAX_PRIO_FEE } from 'src/logic/hooks/useEstimateTransactionGas'
 
 type Props = {
   children: (txParameters: TxParameters, toggleStatus: (txParameters?: TxParameters) => void) => any
@@ -76,7 +78,7 @@ export const EditableTxParameters = ({
       setSafeTxGas(txParameters.safeTxGas)
       setEthGasLimit(txParameters.ethGasLimit)
       setEthGasPrice(txParameters.ethGasPrice)
-      setEthMaxPrioFee(txParameters.ethMaxPrioFee)
+      setEthMaxPrioFee(txParameters.ethMaxPrioFee || fromWei(DEFAULT_MAX_PRIO_FEE, 'gwei'))
       setEthNonce(txParameters.ethNonce)
       closeEditModalCallback && closeEditModalCallback(txParameters)
     }

--- a/src/theme/mui.ts
+++ b/src/theme/mui.ts
@@ -160,6 +160,12 @@ const theme = createTheme({
         position: 'absolute',
         top: '5px',
         zIndex: 1, // for firefox
+
+        '&.Mui-error': {
+          paddingLeft: '0',
+          width: '100%',
+          textAlign: 'center',
+        },
       },
     },
     MuiInput: {

--- a/src/theme/mui.ts
+++ b/src/theme/mui.ts
@@ -160,12 +160,6 @@ const theme = createTheme({
         position: 'absolute',
         top: '5px',
         zIndex: 1, // for firefox
-
-        '&.Mui-error': {
-          paddingLeft: '0',
-          width: '100%',
-          textAlign: 'center',
-        },
       },
     },
     MuiInput: {


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react/issues/3374

## How this PR fixes it
1. Restyles the forms input error label when introducing negative values
2. Shows a placeholder with the default value when `maxPrioFee` is left empty

## How to test it
1. Create a transaction
2. Edit the tx parameters
3. Set a negative value in one of the inputs and check the error label is not blocking the input anymore
4. Delete the "maxPrioFee" value and you shall see the 2.5 GWEI placeholder

## Screenshots
![Screen Shot 2022-02-01 at 13 36 37](https://user-images.githubusercontent.com/32431609/151969508-603114e8-f434-48be-8489-d0c54b6097ff.png)

