### PR TITLE
fix: reverse the "Execute" and "Reject" buttons order

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsedActions.tsx
@@ -48,15 +48,6 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
 
   return (
     <>
-      {canCancel && (
-        <Tooltip title="Reject" placement="top">
-          <span>
-            <IconButton size="small" type="button" onClick={handleCancelButtonClick} disabled={isPending}>
-              <Icon type="circleCross" color="error" size="sm" />
-            </IconButton>
-          </span>
-        </Tooltip>
-      )}
       <Tooltip title={getTitle()} placement="top">
         <span>
           <IconButton
@@ -71,6 +62,15 @@ export const TxCollapsedActions = ({ transaction }: TxCollapsedActionsProps): Re
           </IconButton>
         </span>
       </Tooltip>
+      {canCancel && (
+        <Tooltip title="Reject" placement="top">
+          <span>
+            <IconButton size="small" type="button" onClick={handleCancelButtonClick} disabled={isPending}>
+              <Icon type="circleCross" color="error" size="sm" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
     </>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxExpandedActions.tsx
@@ -45,11 +45,6 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
   // https://github.com/facebook/react/issues/4492
   return (
     <>
-      {canCancel && (
-        <Button size="md" color="error" onClick={handleCancelButtonClick} className="error" disabled={isPending}>
-          Reject
-        </Button>
-      )}
       <Tooltip title={getConfirmTooltipTitle()} placement="top">
         <span>
           <Button
@@ -65,6 +60,15 @@ export const TxExpandedActions = ({ transaction }: TxExpandedActionsProps): Reac
           </Button>
         </span>
       </Tooltip>
+      {canCancel && (
+        <Tooltip title="Reject" placement="top">
+          <span>
+            <Button size="md" color="error" onClick={handleCancelButtonClick} className="error" disabled={isPending}>
+              Reject
+            </Button>
+          </span>
+        </Tooltip>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## What it solves
Reverts the order of the  "Execute" and "Reject" buttons in the Collapsed Transaction as well as in the Expanded Transaction

## How this PR fixes it
Reverts the order of the buttons

## How to test it
1. Create a transaction that lands in the Queue.
2. Verify the buttons order

## Screenshots
<img width="1123" alt="Screen Shot 2022-02-01 at 12 06 36" src="https://user-images.githubusercontent.com/32431609/151957645-9d3a7d73-d3ba-40ae-ba73-c8e71ee7a083.png">

