### PR TITLE
feat: track pending transactions by `txId`

### DIFF
--- a/src/logic/safe/store/actions/processTransaction.ts
+++ b/src/logic/safe/store/actions/processTransaction.ts
@@ -50,6 +50,9 @@ export const processTransaction = (props: ProcessTransactionArgs): ProcessTransa
 
     const { tx, approveAndExecute } = props
 
+    // Set specific transaction being finalised
+    sender.txId = tx.id
+
     const txProps = {
       navigateToTransactionsTab: false,
       notifiedTransaction: props.notifiedTransaction,

--- a/src/logic/safe/store/middleware/gatewayTransactionsMiddleware.ts
+++ b/src/logic/safe/store/middleware/gatewayTransactionsMiddleware.ts
@@ -5,7 +5,7 @@ import { ADD_HISTORY_TRANSACTIONS } from 'src/logic/safe/store/actions/transacti
 import { isTransactionSummary } from 'src/logic/safe/store/models/types/gateway.d'
 import { removePendingTransaction } from 'src/logic/safe/store/actions/pendingTransactions'
 import { Dispatch } from 'src/logic/safe/store/actions/types'
-import { getSafeTxHashFromId, isTxPending } from 'src/logic/safe/store/selectors/pendingTransactions'
+import { isTxPending } from 'src/logic/safe/store/selectors/pendingTransactions'
 import { HistoryPayload } from 'src/logic/safe/store/reducer/gatewayTransactions'
 
 export const gatewayTransactionsMiddleware =
@@ -22,10 +22,10 @@ export const gatewayTransactionsMiddleware =
             continue
           }
 
-          const safeTxHash = getSafeTxHashFromId(value.transaction.id)
+          const { id } = value.transaction
 
-          if (isTxPending(store.getState(), safeTxHash)) {
-            store.dispatch(removePendingTransaction({ safeTxHash }))
+          if (isTxPending(store.getState(), id)) {
+            store.dispatch(removePendingTransaction({ id }))
           }
         }
 

--- a/src/logic/safe/store/middleware/notificationsMiddleware.ts
+++ b/src/logic/safe/store/middleware/notificationsMiddleware.ts
@@ -23,7 +23,7 @@ import { store as reduxStore } from 'src/store/index'
 import { HistoryPayload } from 'src/logic/safe/store/reducer/gatewayTransactions'
 import { history, extractSafeAddress, generateSafeRoute, ADDRESSED_ROUTE, SAFE_ROUTES } from 'src/routes/routes'
 import { getShortName } from 'src/config'
-import { getSafeTxHashFromId, isTxPending } from 'src/logic/safe/store/selectors/pendingTransactions'
+import { isTxPending } from 'src/logic/safe/store/selectors/pendingTransactions'
 
 const watchedActions = [ADD_OR_UPDATE_SAFE, ADD_QUEUED_TRANSACTIONS, ADD_HISTORY_TRANSACTIONS]
 
@@ -106,10 +106,7 @@ const notificationsMiddleware =
           const safesMap = safesAsMap(state)
           const currentSafe = safesMap.get(safeAddress)
 
-          const hasPendingTx = transactions.some((tx) => {
-            const safeTxHash = getSafeTxHashFromId(tx.id)
-            return isTxPending(state, safeTxHash)
-          })
+          const hasPendingTx = transactions.some(({ id }) => isTxPending(state, id))
 
           if (
             hasPendingTx ||

--- a/src/logic/safe/store/reducer/pendingTransactions.ts
+++ b/src/logic/safe/store/reducer/pendingTransactions.ts
@@ -7,13 +7,12 @@ import { _getChainId } from 'src/config'
 
 export const PENDING_TRANSACTIONS_ID = 'pendingTransactions'
 
-type SafeTxHash = string
-export type PendingTransactionsState = Record<ChainId, Record<SafeTxHash, boolean>>
+export type PendingTransactionsState = Record<ChainId, Record<string, boolean>>
 
 const initialPendingTxsState = session.getItem<PendingTransactionsState>(PENDING_TRANSACTIONS_ID) || {}
 
 export type PendingTransactionPayload = {
-  safeTxHash: string
+  id: string
   isBroadcast?: boolean
 }
 
@@ -24,11 +23,11 @@ export const pendingTransactionsReducer = handleActions<PendingTransactionsState
       action: Action<PendingTransactionPayload>,
     ) => {
       const chainId = _getChainId()
-      const { safeTxHash } = action.payload
+      const { id } = action.payload
 
       return {
         ...state,
-        [chainId]: { ...state[chainId], [safeTxHash]: true },
+        [chainId]: { ...state[chainId], [id]: true },
       }
     },
     [PENDING_TRANSACTIONS_ACTIONS.REMOVE]: (
@@ -36,10 +35,10 @@ export const pendingTransactionsReducer = handleActions<PendingTransactionsState
       action: Action<PendingTransactionPayload>,
     ) => {
       const chainId = _getChainId()
-      const { safeTxHash } = action.payload
+      const { id } = action.payload
 
-      // Omit safeTxHash from the pending transactions on current chain
-      const { [safeTxHash]: _, ...newChainState } = state[chainId] || {}
+      // Omit id from the pending transactions on current chain
+      const { [id]: _, ...newChainState } = state[chainId] || {}
 
       return {
         ...state,

--- a/src/logic/safe/store/selectors/pendingTransactions.ts
+++ b/src/logic/safe/store/selectors/pendingTransactions.ts
@@ -2,11 +2,7 @@ import { TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
 import { createSelector } from 'reselect'
 
 import { AppReduxState } from 'src/store'
-import {
-  isMultiSigExecutionDetails,
-  LocalTransactionStatus,
-  Transaction,
-} from 'src/logic/safe/store/models/types/gateway.d'
+import { LocalTransactionStatus, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { PendingTransactionsState, PENDING_TRANSACTIONS_ID } from 'src/logic/safe/store/reducer/pendingTransactions'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { ChainId } from 'src/config/chain'
@@ -25,29 +21,16 @@ const pendingTxsByChain = createSelector(
 
 export const isTxPending = createSelector(
   pendingTxsByChain,
-  (_: AppReduxState, safeTxHash: string) => safeTxHash,
-  (pendingTxs: PendingTransactionsState[ChainId], safeTxHash: string): boolean => {
-    return pendingTxs ? !!pendingTxs?.[safeTxHash] : false
+  (_: AppReduxState, id: string) => id,
+  (pendingTxs: PendingTransactionsState[ChainId], id: string): boolean => {
+    return pendingTxs ? !!pendingTxs?.[id] : false
   },
 )
-
-// @FIXME: this is a dirty hack.
-// Ask backend to add safeTxHash in tx list items.
-export const getSafeTxHashFromId = (id: string): string => {
-  return id.split('_').pop() || ''
-}
 
 export const selectTxStatus = createSelector(
   pendingTxsByChain,
   (_: AppReduxState, tx: Transaction) => tx,
   (pendingTxs: PendingTransactionsState[ChainId], tx: Transaction): TransactionStatus => {
-    const { detailedExecutionInfo } = tx.txDetails || {}
-
-    const safeTxHash =
-      detailedExecutionInfo && isMultiSigExecutionDetails(detailedExecutionInfo)
-        ? detailedExecutionInfo.safeTxHash
-        : getSafeTxHashFromId(tx.id)
-
-    return !!pendingTxs?.[safeTxHash] ? LocalTransactionStatus.PENDING : tx.txStatus
+    return !!pendingTxs?.[tx.id] ? LocalTransactionStatus.PENDING : tx.txStatus
   },
 )


### PR DESCRIPTION
## What it solves
Resolves #3391

## How this PR fixes it
The `pendingTransactions` store now stores a hashmap for pending transactions as follows:

```ts
{
  [chainId]: {
    [txId]: true
  }
}
```

All associated selectors and middlewares are updated to reflect this change, as well as an added pending status setter in `createTransaction` for immediately executed transactions on a 1/? Safe.

## How to test it

There should be no UI-noticeable changes.

All pending statuses should broadcast between tabs/windows, as well as reset (to awaiting) when a signing is rejected or (to successful) transaction succeeds.

- Create and immediately execute a transaction on a 1/? Safe. Observe that the transaction is pending.
- Queue a transaction on a X/? Safe. Upon executing, the execute/reject buttons should disappear in favour of the pending status.
    - Rejecting this should return the transaction to the state it was in before clicking 'Execute'.
    - Executing it should function as before.