### PR TITLE
fix: load GTM from cookie banner

### DIFF
--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -10,7 +10,6 @@ import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBann
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
 import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
-import { loadGoogleAnalytics, removeCookies } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
 import AlertRedIcon from './assets/alert-red.svg'
 import IntercomIcon from './assets/intercom.png'
@@ -114,10 +113,6 @@ const CookiesBanner = (): ReactElement => {
   const isSafeAppView = newAppUrl !== null
 
   useEffect(() => {
-    loadGoogleTagManager()
-  }, [])
-
-  useEffect(() => {
     if (showIntercom && !isSafeAppView) {
       loadIntercom()
     }
@@ -156,7 +151,7 @@ const CookiesBanner = (): ReactElement => {
         setLocalNecessary(acceptedNecessary)
 
         if (acceptedAnalytics && !isDesktop) {
-          loadGoogleAnalytics()
+          loadGoogleTagManager()
         }
       }
     }
@@ -190,10 +185,6 @@ const CookiesBanner = (): ReactElement => {
     await saveCookie(COOKIES_KEY, newState, cookieConfig)
     setShowAnalytics(localAnalytics)
     setShowIntercom(localIntercom)
-
-    if (!localAnalytics) {
-      removeCookies()
-    }
 
     if (!localIntercom && isIntercomLoaded()) {
       closeIntercom()

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,7 +8,6 @@ export const DEFAULT_CHAIN_ID =
 export const PUBLIC_URL = process.env.PUBLIC_URL
 export const TX_SERVICE_VERSION = '1'
 export const INTERCOM_ID = IS_PRODUCTION ? process.env.REACT_APP_INTERCOM_ID : 'plssl1fl'
-export const GOOGLE_ANALYTICS_ID = process.env.REACT_APP_GOOGLE_ANALYTICS || ''
 export const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN || ''
 export const PORTIS_ID = process.env.REACT_APP_PORTIS_ID ?? '852b763d-f28b-4463-80cb-846d7ec5806b'
 export const FORTMATIC_KEY = process.env.REACT_APP_FORTMATIC_KEY ?? 'pk_test_CAD437AA29BE0A40'
@@ -25,8 +24,9 @@ export const SPENDING_LIMIT_MODULE_ADDRESS =
   process.env.REACT_APP_SPENDING_LIMIT_MODULE_ADDRESS || '0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134'
 
 // Google Tag Manager
-export const GTM_AUTH_LIVE = process.env.REACT_APP_GTM_LIVE_AUTH || ''
-export const GTM_AUTH_LATEST = process.env.REACT_APP_GTM_LATEST_AUTH || ''
+export const GOOGLE_TAG_MANAGER_ID = process.env.REACT_APP_GOOGLE_TAG_MANAGER_ID || ''
+export const GOOGLE_TAG_MANAGER_AUTH_LIVE = process.env.REACT_APP_GOOGLE_TAG_MANAGER_LIVE_AUTH || ''
+export const GOOGLE_TAG_MANAGER_AUTH_LATEST = process.env.REACT_APP_GOOGLE_TAG_MANAGER_LATEST_AUTH || ''
 
 // localStorage-related constants
 export const LS_NAMESPACE = 'SAFE'

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import ReactGA, { EventArgs } from 'react-ga'
 import { useSelector } from 'react-redux'
-import { getChainInfo, _getChainId } from 'src/config'
+import { getChainInfo } from 'src/config'
 
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { COOKIES_KEY } from 'src/logic/cookies/model/cookie'
-import { loadFromCookie, removeCookie } from 'src/logic/cookies/utils'
-import { GOOGLE_ANALYTICS_ID, IS_PRODUCTION } from './constants'
+import { loadFromCookie } from 'src/logic/cookies/utils'
+import { IS_PRODUCTION } from './constants'
 import { capitalize } from './css'
 
 const USER_EVENT = 'User'
@@ -98,40 +98,7 @@ const trackAnalyticsPage: typeof ReactGA.pageview = (...args) => {
   return shouldUseGoogleAnalytics ? ReactGA.pageview(...args) : console.info('[GA] - Page:', ...args)
 }
 
-let analyticsLoaded = false
-export const loadGoogleAnalytics = (): void => {
-  if (analyticsLoaded) {
-    return
-  }
-
-  console.info(
-    shouldUseGoogleAnalytics
-      ? 'Loading Google Analytics...'
-      : 'Google Analytics will not load in the development environment, but instead log.',
-  )
-
-  const customDimensions: ReactGA.FieldsObject = {
-    anonymizeIp: true,
-    appName: `Gnosis Safe Web`,
-    appVersion: process.env.REACT_APP_APP_VERSION,
-    dimension1: _getChainId(),
-  }
-
-  const gaTrackingId = GOOGLE_ANALYTICS_ID
-
-  if (shouldUseGoogleAnalytics) {
-    if (!gaTrackingId) {
-      console.error('In order to use Google Analytics you need to add a tracking ID.')
-    } else {
-      ReactGA.initialize(gaTrackingId)
-      ReactGA.set(customDimensions)
-    }
-  } else {
-    console.info('[GA] - Custom dimensions:', customDimensions)
-  }
-
-  analyticsLoaded = true
-}
+const analyticsLoaded = false
 
 type UseAnalyticsResponse = {
   trackPage: (path: string) => void
@@ -178,11 +145,4 @@ export const useAnalytics = (): UseAnalyticsResponse => {
   )
 
   return { trackPage, trackEvent }
-}
-
-// we remove GA cookies manually as react-ga does not provides a utility for it.
-export const removeCookies = (): void => {
-  // Extracts the main domain, e.g. gnosis-safe.io
-  const subDomain = location.host.split('.').slice(-2).join('.')
-  COOKIES_LIST.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${subDomain}`))
 }

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -1,18 +1,22 @@
 import TagManager, { TagManagerArgs } from 'react-gtm-module'
 
-import { GTM_AUTH_LIVE, GTM_AUTH_LATEST, IS_PRODUCTION } from 'src/utils/constants'
+import {
+  GOOGLE_TAG_MANAGER_ID,
+  GOOGLE_TAG_MANAGER_AUTH_LIVE,
+  GOOGLE_TAG_MANAGER_AUTH_LATEST,
+  IS_PRODUCTION,
+} from 'src/utils/constants'
 
 type GTMEnvironment = 'LIVE' | 'LATEST' | 'DEVELOPMENT'
 type GTMEnvironmentArgs = Required<Pick<TagManagerArgs, 'auth' | 'preview'>>
 
-const GTM_ID: TagManagerArgs['gtmId'] = 'GTM-TSZSBRK'
 const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
   LIVE: {
-    auth: GTM_AUTH_LIVE,
+    auth: GOOGLE_TAG_MANAGER_AUTH_LIVE,
     preview: 'env-1',
   },
   LATEST: {
-    auth: GTM_AUTH_LATEST,
+    auth: GOOGLE_TAG_MANAGER_AUTH_LATEST,
     preview: 'env-2',
   },
   DEVELOPMENT: {
@@ -24,13 +28,13 @@ const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
 export const loadGoogleTagManager = (): void => {
   const GTM_ENVIRONMENT = IS_PRODUCTION ? GTM_ENV_AUTH.LIVE : GTM_ENV_AUTH.DEVELOPMENT
 
-  if (!GTM_ENVIRONMENT.auth) {
-    console.warn('Unable to initialise GTM. No `gtm_auth` found.')
+  if (!GOOGLE_TAG_MANAGER_ID || GTM_ENVIRONMENT.auth) {
+    console.warn('Unable to initialise Google Tag Manager. `id` or `gtm_auth` missing.')
     return
   }
 
   TagManager.initialize({
-    gtmId: GTM_ID,
+    gtmId: GOOGLE_TAG_MANAGER_ID,
     ...GTM_ENVIRONMENT,
   })
 }

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -28,7 +28,7 @@ const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
 export const loadGoogleTagManager = (): void => {
   const GTM_ENVIRONMENT = IS_PRODUCTION ? GTM_ENV_AUTH.LIVE : GTM_ENV_AUTH.DEVELOPMENT
 
-  if (!GOOGLE_TAG_MANAGER_ID || GTM_ENVIRONMENT.auth) {
+  if (!GOOGLE_TAG_MANAGER_ID || !GTM_ENVIRONMENT.auth) {
     console.warn('Unable to initialise Google Tag Manager. `id` or `gtm_auth` missing.')
     return
   }


### PR DESCRIPTION
## What it solves
Part of #3408 - cookie banner

## How this PR fixes it
The cookie banner now loads GTM instead of GA when the user accepts. GTM doesn't use cookies so no removal is required.
