### PR TITLE
Fix: approve&execute conditions for non-owners

### DIFF
--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -37,11 +37,9 @@ export const checkIfTxIsApproveAndExecution = (
   txType?: string,
   preApprovingOwner?: string,
 ): boolean => {
-  if (preApprovingOwner) {
-    return txConfirmations + 1 === threshold || isSpendingLimit(txType)
-  }
-
-  return threshold === 1
+  if (txConfirmations === threshold) return false
+  if (!preApprovingOwner) return false
+  return txConfirmations + 1 === threshold || isSpendingLimit(txType)
 }
 
 export const checkIfTxIsCreation = (txConfirmations: number, txType?: string): boolean =>


### PR DESCRIPTION
## What it solves
Resolves #3412

It was a regression introduced in the [ApporveTxModal refactoring](https://github.com/gnosis/safe-react/pull/3369).

When estimating gas, it was always adding the current wallet address to the signatures list, even if full quorum had been reached.

It wasn't breaking anything for actual owners, but when a non-owner estimates a tx like this, it gets reverted with `GS026: Invalid owner provided`.

Strangely, such transactions would still execute fine.

## How this PR fixes it
Fixes a condition in `checkIfTxIsApproveAndExecution`.

## How to test it
* Create and fully sign a tx
* Try to execute with a non-owner

<img width="1036" alt="Screenshot 2022-02-02 at 21 10 03" src="https://user-images.githubusercontent.com/381895/152229576-e54030e7-8458-4819-a46d-edf642def12c.png">

## Comment
@francovenica we probably want to include a non-owner test in our read-only suite.
This bug had nothing to do with Trezor, btw.