### PR TITLE
fix: Redirect user to next available safe after removing current safe

### DIFF
--- a/src/logic/safe/hooks/useLocalSafes.tsx
+++ b/src/logic/safe/hooks/useLocalSafes.tsx
@@ -7,7 +7,7 @@ import { ChainId } from 'src/config/chain.d'
 import { SafeRecordProps } from '../store/models/safe'
 import { getLocalNetworkSafesById } from '../utils'
 
-type LocalSafes = Record<ChainId, SafeRecordProps[]>
+export type LocalSafes = Record<ChainId, SafeRecordProps[]>
 
 const getEmptyLocalSafes = (): LocalSafes => {
   return getChains().reduce((safes, { chainId }) => ({ ...safes, [chainId]: [] }), {} as LocalSafes)

--- a/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
@@ -26,7 +26,6 @@ type RemoveSafeModalProps = {
 
 function getNextAvailableSafe(currentChainId: string, currentSafeAddress: string, localSafes: LocalSafes) {
   const availableSafes = Object.values(localSafes)
-    .filter((safes) => safes.length !== 0)
     .flat()
     .filter((safe) => safe.address !== currentSafeAddress)
   const sameNetworkSafes = availableSafes.filter((safe) => safe.chainId === currentChainId)

--- a/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
@@ -31,10 +31,10 @@ function getNextAvailableSafe(currentChainId: string, currentSafeAddress: string
   const sameNetworkSafes = availableSafes.filter((safe) => safe.chainId === currentChainId)
 
   if (sameNetworkSafes.length > 0) {
-    return sameNetworkSafes.pop()
+    return sameNetworkSafes[0]
   }
 
-  return availableSafes.pop()
+  return availableSafes[0]
 }
 
 function getDestinationRoute(nextAvailableSafe: SafeRecordProps | undefined) {

--- a/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
@@ -11,24 +11,60 @@ import Row from 'src/components/layout/Row'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import removeSafe from 'src/logic/safe/store/actions/removeSafe'
-import { getExplorerInfo } from 'src/config'
+import { getChainById, getExplorerInfo } from 'src/config'
 import Col from 'src/components/layout/Col'
-import { WELCOME_ROUTE, history } from 'src/routes/routes'
+import { WELCOME_ROUTE, history, SafeRouteParams, generateSafeRoute, SAFE_ROUTES } from 'src/routes/routes'
+import useLocalSafes, { LocalSafes } from 'src/logic/safe/hooks/useLocalSafes'
+import { currentChainId } from 'src/logic/config/store/selectors'
+import { useMemo } from 'react'
+import { SafeRecordProps } from 'src/logic/safe/store/models/safe'
 
 type RemoveSafeModalProps = {
   isOpen: boolean
   onClose: () => void
 }
 
+function getNextAvailableSafe(currentChainId: string, currentSafeAddress: string, localSafes: LocalSafes) {
+  const availableSafes = Object.values(localSafes)
+    .filter((safes) => safes.length !== 0)
+    .flat()
+    .filter((safe) => safe.address !== currentSafeAddress)
+  const sameNetworkSafes = availableSafes.filter((safe) => safe.chainId === currentChainId)
+
+  if (sameNetworkSafes.length > 0) {
+    return sameNetworkSafes.pop()
+  }
+
+  return availableSafes.pop()
+}
+
+function getDestinationRoute(nextAvailableSafe: SafeRecordProps | undefined) {
+  if (!nextAvailableSafe || !nextAvailableSafe.chainId) return WELCOME_ROUTE
+
+  const { shortName } = getChainById(nextAvailableSafe.chainId)
+  const routesSlug: SafeRouteParams = {
+    shortName,
+    safeAddress: nextAvailableSafe.address,
+  }
+  return generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, routesSlug)
+}
+
 const RemoveSafeModal = ({ isOpen, onClose }: RemoveSafeModalProps): React.ReactElement => {
   const classes = useStyles()
   const { address: safeAddress, name: safeName } = useSelector(currentSafeWithNames)
+  const curChainId = useSelector(currentChainId)
+  const localSafes = useLocalSafes()
+  const nextAvailableSafe = useMemo(
+    () => getNextAvailableSafe(curChainId, safeAddress, localSafes),
+    [curChainId, safeAddress, localSafes],
+  )
   const dispatch = useDispatch()
 
   const onRemoveSafeHandler = async () => {
+    const destination = getDestinationRoute(nextAvailableSafe)
     dispatch(removeSafe(safeAddress))
     onClose()
-    history.push(WELCOME_ROUTE)
+    history.push(destination)
   }
 
   return (

--- a/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
@@ -33,8 +33,6 @@ function getNextAvailableSafe(currentChainId: string, currentSafeAddress: string
   if (sameNetworkSafes.length > 0) {
     return sameNetworkSafes[0]
   }
-
-  return availableSafes[0]
 }
 
 function getDestinationRoute(nextAvailableSafe: SafeRecordProps | undefined) {


### PR DESCRIPTION
## What it solves
Resolves #3031 

## How this PR fixes it
Similar to how its handled on mobile, when deleting the current safe the user gets redirected to:

- The next available safe on the same network OR
- The next available safe on another network OR
- The welcome page

## Open Questions
Could opening another safe automatically impact UX in a negative way? cc @liliiaorlenko 

## How to test it

1. Open the Safe App
2. Go to Settings > Safe Details
3. Click Remove Safe
4. Observe redirection for different cases in the order described above
