### PR TITLE
fix: migrate anonymous page tracking to GTM

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,31 +1,26 @@
 import React from 'react'
 import { Loader } from '@gnosis.pm/safe-react-components'
-import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { matchPath, Redirect, Route, Switch, useLocation } from 'react-router-dom'
+import { Redirect, Route, Switch, useLocation } from 'react-router-dom'
 
 import { LoadingContainer } from 'src/components/LoaderContainer'
-import { useAnalytics } from 'src/utils/googleAnalytics'
 import { lastViewedSafe } from 'src/logic/currentSession/store/selectors'
 import {
   generateSafeRoute,
-  getPrefixedSafeAddressSlug,
   LOAD_SPECIFIC_SAFE_ROUTE,
   OPEN_SAFE_ROUTE,
   ADDRESSED_ROUTE,
   SAFE_ROUTES,
   WELCOME_ROUTE,
-  hasPrefixedSafeAddressInUrl,
   ROOT_ROUTE,
   LOAD_SAFE_ROUTE,
   getNetworkRootRoutes,
-  TRANSACTION_ID_SLUG,
 } from './routes'
 import { getShortName } from 'src/config'
 import { setChainId } from 'src/logic/config/utils'
-import { isDeeplinkedTx } from './safe/components/Transactions/TxList/utils'
 import { useAddressedRouteKey } from './safe/container/hooks/useAddressedRouteKey'
 import { setChainIdFromUrl } from 'src/utils/history'
+import { useGTMPageTracking } from 'src/utils/googleTagManager'
 
 const Welcome = React.lazy(() => import('./welcome/Welcome'))
 const CreateSafePage = React.lazy(() => import('./CreateSafePage/CreateSafePage'))
@@ -34,33 +29,13 @@ const SafeContainer = React.lazy(() => import('./safe/container'))
 
 const Routes = (): React.ReactElement => {
   const location = useLocation()
-  const { pathname, search } = location
   const defaultSafe = useSelector(lastViewedSafe)
-  const { trackPage } = useAnalytics()
 
   // Component key that changes when addressed route slug changes
   const { key } = useAddressedRouteKey()
 
-  // Google Analytics
-  useEffect(() => {
-    let trackedPath = pathname
-
-    // Anonymize safe address
-    if (hasPrefixedSafeAddressInUrl()) {
-      trackedPath = trackedPath.replace(getPrefixedSafeAddressSlug(), 'SAFE_ADDRESS')
-    }
-
-    // Anonymize deeplinked transaction
-    if (isDeeplinkedTx()) {
-      const match = matchPath(pathname, {
-        path: SAFE_ROUTES.TRANSACTIONS_SINGULAR,
-      })
-
-      trackedPath = trackedPath.replace(match?.params[TRANSACTION_ID_SLUG], 'TRANSACTION_ID')
-    }
-
-    trackPage(trackedPath + search)
-  }, [pathname, search, trackPage])
+  // Google Tag Manager page tracking
+  useGTMPageTracking()
 
   return (
     <Switch>
@@ -131,7 +106,7 @@ const Routes = (): React.ReactElement => {
         path={ADDRESSED_ROUTE}
         render={() => {
           // Routes with a shortName prefix
-          const validShortName = setChainIdFromUrl(pathname)
+          const validShortName = setChainIdFromUrl(location.pathname)
           return validShortName ? <SafeContainer key={key} /> : <Redirect to={WELCOME_ROUTE} />
         }}
       />

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -1,4 +1,9 @@
+import { useEffect } from 'react'
 import TagManager, { TagManagerArgs } from 'react-gtm-module'
+import { matchPath } from 'react-router-dom'
+import { Location } from 'history'
+
+import { ADDRESSED_ROUTE, history, SAFE_ADDRESS_SLUG, SAFE_ROUTES, TRANSACTION_ID_SLUG } from 'src/routes/routes'
 
 import {
   GOOGLE_TAG_MANAGER_ID,
@@ -26,6 +31,10 @@ const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
   },
 }
 
+const GTM_EVENTS = {
+  pageview: 'Page View',
+}
+
 export const loadGoogleTagManager = (): void => {
   const GTM_ENVIRONMENT = IS_PRODUCTION ? GTM_ENV_AUTH.LIVE : GTM_ENV_AUTH.DEVELOPMENT
 
@@ -37,5 +46,39 @@ export const loadGoogleTagManager = (): void => {
   TagManager.initialize({
     gtmId: GOOGLE_TAG_MANAGER_ID,
     ...GTM_ENVIRONMENT,
+    ...GTM_EVENTS,
   })
+}
+
+const getAnonymizedLocation = ({ pathname, search, hash }: Location): string => {
+  const ANON_SAFE_ADDRESS = 'SAFE_ADDRESS'
+  const ANON_TX_ID = 'TRANSACTION_ID'
+
+  let anonPathname = pathname
+
+  // Anonymize safe address
+  const safeAddressMatch = matchPath(pathname, { path: ADDRESSED_ROUTE })
+  if (safeAddressMatch) {
+    anonPathname = anonPathname.replace(safeAddressMatch.params[SAFE_ADDRESS_SLUG], ANON_SAFE_ADDRESS)
+  }
+
+  // Anonymise transaction id
+  const txIdMatch = matchPath(pathname, { path: SAFE_ROUTES.TRANSACTIONS_SINGULAR })
+  if (txIdMatch) {
+    anonPathname = anonPathname.replace(txIdMatch.params[TRANSACTION_ID_SLUG], ANON_TX_ID)
+  }
+
+  return anonPathname + search + hash
+}
+
+export const useGTMPageTracking = (): void => {
+  useEffect(() => {
+    const unsubscribe = history.listen((location) => {
+      TagManager.dataLayer({ dataLayer: { event: 'pageview', page: getAnonymizedLocation(location) } })
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
 }


### PR DESCRIPTION
## What it solves
Part of https://github.com/gnosis/safe-react/issues/3408 - anonymous tracking

## How this PR fixes it
As with GA was, the URL is now anonymised for GTM. It is possible to implement RegEx replacement on the GTM-side, but a history listener is used instead so that no safe addresses or transaction ids are even sent to GTM in the first place

- Safe addresses are replaced with `"SAFE_ADDRESS"`
- Transaction ids are replaced with `"TRANSACTION_ID"`

## How to test it
Open GTM preview and observe that, when navigating between pages, the safe address and any deeplinked transaction ids are replaced.