### PR TITLE
fix: Hide estimated fee dropdown when creating tx rejection

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -1,6 +1,6 @@
 import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useStyles } from './style'
 import Modal, { ButtonStatus, Modal as GenericModal } from 'src/components/Modal'
 import { ReviewInfoText } from 'src/components/ReviewInfoText'
@@ -23,6 +23,8 @@ import { extractSafeAddress } from 'src/routes/routes'
 import useCanTxExecute from 'src/logic/hooks/useCanTxExecute'
 import { TxEstimatedFeesDetail } from 'src/routes/safe/components/Transactions/helpers/TxEstimatedFeesDetail'
 import { getNativeCurrency } from 'src/config'
+import { grantedSelector } from 'src/routes/safe/container/selector'
+import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 
 type Props = {
   isOpen: boolean
@@ -35,6 +37,9 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
   const safeAddress = extractSafeAddress()
   const classes = useStyles()
   const nativeCurrency = getNativeCurrency()
+  const isOwner = useSelector(grantedSelector)
+  const userAddress = useSelector(userAccountSelector)
+  const preApprovingOwner = isOwner ? userAddress : undefined
 
   const {
     txEstimationExecutionStatus,
@@ -47,7 +52,7 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
     txData: EMPTY_DATA,
     txRecipient: safeAddress,
   })
-  const canTxExecute = useCanTxExecute()
+  const canTxExecute = useCanTxExecute(preApprovingOwner)
 
   const origin = gwTransaction.safeAppInfo
     ? JSON.stringify({ name: gwTransaction.safeAppInfo.name, url: gwTransaction.safeAppInfo.url })

--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -112,7 +112,7 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
                   </Paragraph>
                 </Row>
 
-                {txEstimationExecutionStatus !== EstimationStatus.LOADING && (
+                {txEstimationExecutionStatus !== EstimationStatus.LOADING && canTxExecute && (
                   <TxEstimatedFeesDetail
                     txParameters={txParameters}
                     gasCost={gasCost}


### PR DESCRIPTION
## What it solves
Resolves #3423

## How this PR fixes it
The estimated fee dropdown is hidden when creating a Tx rejection by additionally checking `canTxExecute`. This change aligns with how `TxEstimatedFeesDetail` is handled for other transaction modals.

## How to test it

1. Open Safe App
2. Queue a Transaction
3. Reject the Transaction
4. Observe that the Estimated Fees dropdown is not displayed

## Open Issues

~In single owner safes when the rejection is immediately executed `canTxExecute` is still false although it should be true.~
This is fixed in this PR, now passing `preApprovingOwner` to `canTxExecute` which then returns true in a single owner safe

## Screenshots
![Screenshot 2022-02-03 at 17 28 21](https://user-images.githubusercontent.com/5880855/152385025-4df75ed6-0116-408f-bea7-e5394de76317.png)

