### PR TITLE
fix: show stepper for immediate executions

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -95,10 +95,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
   const isPending = txStatus === LocalTransactionStatus.PENDING
   const currentUser = useSelector(userAccountSelector)
   const isMultiSend = data && isMultiSendTxInfo(data.txInfo)
-  const noTxOwners =
-    !data?.detailedExecutionInfo ||
-    (isMultiSigExecutionDetails(data.detailedExecutionInfo) && !data.detailedExecutionInfo.confirmations.length) ||
-    isModuleExecutionInfo(data.detailedExecutionInfo)
+  const shouldShowStepper = data?.detailedExecutionInfo && isMultiSigExecutionDetails(data.detailedExecutionInfo)
 
   // To avoid prop drilling into TxDataGroup, module details are positioned here accordingly
   const getModuleDetails = () => {
@@ -171,8 +168,8 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
 
   return (
     <TxDetailsContainer>
-      <div className={cn('tx-data', { 'no-owners': noTxOwners, 'no-data': noTxDataBlock })}>{txData()}</div>
-      {!noTxOwners && (
+      <div className={cn('tx-data', { 'no-owners': !shouldShowStepper, 'no-data': noTxDataBlock })}>{txData()}</div>
+      {shouldShowStepper && (
         <div>
           <div
             className={cn('tx-owners', {


### PR DESCRIPTION
## What it solves
Resolves #3427

## How this PR fixes it
`TxOwners` is now always shown for `'MULTISIG'` transaction types and not dependant on confirmations.

## How to test it
- Create and immediately execute a transaction on a 1/? Safe.
- Observe the stepper now appearing

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/152407081-845fa53d-2e7c-41d2-9ab1-55c13ec4c84d.png)