### PR TITLE
fix: Make params editable when executing a reject transaction

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -42,12 +42,14 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
   const preApprovingOwner = isOwner ? userAddress : undefined
 
   const {
-    txEstimationExecutionStatus,
-    isOffChainSignature,
-    isCreation,
-    gasLimit,
-    gasPriceFormatted,
     gasCostFormatted,
+    gasPriceFormatted,
+    gasMaxPrioFeeFormatted,
+    gasLimit,
+    gasEstimation,
+    txEstimationExecutionStatus,
+    isCreation,
+    isOffChainSignature,
   } = useEstimateTransactionGas({
     txData: EMPTY_DATA,
     txRecipient: safeAddress,
@@ -95,7 +97,8 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
         isExecution={canTxExecute}
         ethGasLimit={gasLimit}
         ethGasPrice={gasPriceFormatted}
-        safeTxGas={'0'}
+        ethMaxPrioFee={gasMaxPrioFeeFormatted}
+        safeTxGas={gasEstimation}
         safeNonce={nonce.toString()}
         parametersStatus={getParametersStatus()}
       >

--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -196,7 +196,7 @@ export const EditTxParametersForm = ({
                       text="Gas limit"
                       type="number"
                       component={TextField}
-                      disabled={parametersStatus === 'CANCEL_TRANSACTION'}
+                      disabled={!areEthereumParamsVisible(parametersStatus)}
                     />
                     {((gasPriceText) => (
                       <Field

--- a/src/routes/safe/components/Transactions/helpers/utils.tsx
+++ b/src/routes/safe/components/Transactions/helpers/utils.tsx
@@ -4,9 +4,7 @@ import { sameString } from 'src/utils/strings'
 export type ParametersStatus = 'ENABLED' | 'DISABLED' | 'SAFE_DISABLED' | 'ETH_HIDDEN' | 'CANCEL_TRANSACTION'
 
 export const areEthereumParamsVisible = (parametersStatus: ParametersStatus): boolean => {
-  return (
-    parametersStatus === 'ENABLED' || (parametersStatus !== 'ETH_HIDDEN' && parametersStatus !== 'CANCEL_TRANSACTION')
-  )
+  return parametersStatus === 'ENABLED' || parametersStatus !== 'ETH_HIDDEN'
 }
 
 export const areSafeParamsEnabled = (parametersStatus: ParametersStatus): boolean => {

--- a/src/routes/safe/container/hooks/useTransactionParameters.ts
+++ b/src/routes/safe/container/hooks/useTransactionParameters.ts
@@ -6,7 +6,6 @@ import { getUserNonce } from 'src/logic/wallets/ethTransactions'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { currentSafeCurrentVersion } from 'src/logic/safe/store/selectors'
 import { ParametersStatus } from 'src/routes/safe/components/Transactions/helpers/utils'
-import { sameString } from 'src/utils/strings'
 import { extractSafeAddress } from 'src/routes/routes'
 import { AppReduxState } from 'src/store'
 import { getRecommendedNonce } from 'src/logic/safe/api/fetchSafeTxGasEstimation'
@@ -43,7 +42,6 @@ type Props = {
  * It needs to be initialized calling setGasEstimation.
  */
 export const useTransactionParameters = (props?: Props): TxParameters => {
-  const isCancelTransaction = sameString(props?.parametersStatus || 'ENABLED', 'CANCEL_TRANSACTION')
   const connectedWalletAddress = useSelector(userAccountSelector)
   const safeAddress = extractSafeAddress()
   const safeVersion = useSelector(currentSafeCurrentVersion) as string
@@ -81,7 +79,7 @@ export const useTransactionParameters = (props?: Props): TxParameters => {
       return
     }
     setEthGasPriceInGWei(toWei(ethGasPrice, 'Gwei'))
-  }, [ethGasPrice, isCancelTransaction])
+  }, [ethGasPrice])
 
   // Get max prio fee
   useEffect(() => {
@@ -90,7 +88,7 @@ export const useTransactionParameters = (props?: Props): TxParameters => {
       return
     }
     setEthMaxPrioFeeInGWei(toWei(ethMaxPrioFee, 'Gwei'))
-  }, [ethMaxPrioFee, isCancelTransaction])
+  }, [ethMaxPrioFee])
 
   // Calc safe nonce
   useEffect(() => {

--- a/src/routes/safe/container/hooks/useTransactionParameters.ts
+++ b/src/routes/safe/container/hooks/useTransactionParameters.ts
@@ -52,7 +52,7 @@ export const useTransactionParameters = (props?: Props): TxParameters => {
   // Safe Params
   const [safeNonce, setSafeNonce] = useState<string | undefined>(props?.initialSafeNonce)
   // SafeTxGas: for a new Tx call requiredTxGas, for an existing tx get it from the backend.
-  const [safeTxGas, setSafeTxGas] = useState<string | undefined>(isCancelTransaction ? '0' : props?.initialSafeTxGas)
+  const [safeTxGas, setSafeTxGas] = useState<string | undefined>(props?.initialSafeTxGas)
 
   // ETH Params
   const [ethNonce, setEthNonce] = useState<string | undefined>() // we delegate it to the wallet
@@ -80,10 +80,6 @@ export const useTransactionParameters = (props?: Props): TxParameters => {
       setEthGasPriceInGWei(undefined)
       return
     }
-    if (isCancelTransaction) {
-      setEthGasPrice('0')
-      return
-    }
     setEthGasPriceInGWei(toWei(ethGasPrice, 'Gwei'))
   }, [ethGasPrice, isCancelTransaction])
 
@@ -91,10 +87,6 @@ export const useTransactionParameters = (props?: Props): TxParameters => {
   useEffect(() => {
     if (!ethMaxPrioFee) {
       setEthMaxPrioFee(undefined)
-      return
-    }
-    if (isCancelTransaction) {
-      setEthMaxPrioFee('0')
       return
     }
     setEthMaxPrioFeeInGWei(toWei(ethMaxPrioFee, 'Gwei'))


### PR DESCRIPTION
## What it solves
Resolves #3429 

## How this PR fixes it
Makes tx parameters editable for reject transactions and passes estimated values to the edit form instead of using 0 value fallback

## How to test it

1. Open a safe
2. Queue a transaction
3. Reject transaction
4. Observe that all parameters except the safe nonce are editable
5. Associated transactions/rejections should process without errors.

## Screenshots
![c](https://user-images.githubusercontent.com/5880855/152522744-6356fa41-9775-4d16-b708-81ccb084dd31.png)

