### PR TITLE
refactor: Use TxModalWrapper for RejectTxModal

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/ActionModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/ActionModal.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux'
 
 import { ExpandedTxDetails, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { getTransactionByAttribute } from 'src/logic/safe/store/selectors/gatewayTransactions'
-import { useTransactionParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { AppReduxState } from 'src/store'
 import { ApproveTxModal } from './modals/ApproveTxModal'
 import { RejectTxModal } from './modals/RejectTxModal'
@@ -12,7 +11,6 @@ import { Overwrite } from 'src/types/helpers'
 
 export const ActionModal = (): ReactElement | null => {
   const { selectedAction, selectAction } = useContext(TransactionActionStateContext)
-  const txParameters = useTransactionParameters()
 
   const transaction = useSelector((state: AppReduxState) =>
     getTransactionByAttribute(state, {
@@ -29,7 +27,13 @@ export const ActionModal = (): ReactElement | null => {
 
   switch (selectedAction.actionSelected) {
     case 'cancel':
-      return <RejectTxModal isOpen onClose={onClose} gwTransaction={transaction} />
+      return (
+        <RejectTxModal
+          isOpen
+          onClose={onClose}
+          transaction={transaction as Overwrite<Transaction, { txDetails: ExpandedTxDetails }>}
+        />
+      )
 
     case 'confirm':
     case 'execute':
@@ -38,7 +42,6 @@ export const ActionModal = (): ReactElement | null => {
           isOpen
           onClose={onClose}
           transaction={transaction as Overwrite<Transaction, { txDetails: ExpandedTxDetails }>}
-          txParameters={txParameters}
         />
       )
 

--- a/src/routes/safe/components/Transactions/TxList/ActionModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/ActionModal.tsx
@@ -21,31 +21,17 @@ export const ActionModal = (): ReactElement | null => {
 
   const onClose = () => selectAction({ actionSelected: 'none', transactionId: '' })
 
-  if (!transaction?.txDetails) {
+  if (!transaction?.txDetails || selectedAction.actionSelected === 'none') {
     return null
   }
 
-  switch (selectedAction.actionSelected) {
-    case 'cancel':
-      return (
-        <RejectTxModal
-          isOpen
-          onClose={onClose}
-          transaction={transaction as Overwrite<Transaction, { txDetails: ExpandedTxDetails }>}
-        />
-      )
+  const Modal = selectedAction.actionSelected === 'cancel' ? RejectTxModal : ApproveTxModal
 
-    case 'confirm':
-    case 'execute':
-      return (
-        <ApproveTxModal
-          isOpen
-          onClose={onClose}
-          transaction={transaction as Overwrite<Transaction, { txDetails: ExpandedTxDetails }>}
-        />
-      )
-
-    case 'none':
-      return null
-  }
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      transaction={transaction as Overwrite<Transaction, { txDetails: ExpandedTxDetails }>}
+    />
+  )
 }

--- a/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/ApproveTxModal.tsx
@@ -33,17 +33,10 @@ import { TxModalWrapper } from '../../helpers/TxModalWrapper'
 
 export const REJECT_TX_MODAL_SUBMIT_BTN_TEST_ID = 'reject-tx-modal-submit-btn'
 
-const getModalTitleAndDescription = (
-  thresholdReached: boolean,
-  isCancelTx: boolean,
-): { title: string; description: string } => {
+const getModalTitleAndDescription = (thresholdReached: boolean): { title: string; description: string } => {
   const modalInfo = {
     title: 'Execute transaction rejection',
     description: 'This action will execute this transaction.',
-  }
-
-  if (isCancelTx) {
-    return modalInfo
   }
 
   if (thresholdReached) {
@@ -190,20 +183,18 @@ const useTxInfo = (transaction: Props['transaction']) => {
 
 type Props = {
   onClose: () => void
-  isCancelTx?: boolean
   isOpen: boolean
   transaction: Overwrite<Transaction, { txDetails: ExpandedTxDetails }>
-  txParameters: TxParameters
 }
 
-export const ApproveTxModal = ({ onClose, isCancelTx = false, isOpen, transaction }: Props): React.ReactElement => {
+export const ApproveTxModal = ({ onClose, isOpen, transaction }: Props): React.ReactElement => {
   const dispatch = useDispatch()
   const userAddress = useSelector(userAccountSelector)
   const classes = useStyles()
   const safeAddress = extractSafeAddress()
   const executionInfo = transaction.executionInfo as MultisigExecutionInfo
   const thresholdReached = !!(executionInfo && isThresholdReached(executionInfo))
-  const { description, title } = getModalTitleAndDescription(thresholdReached, isCancelTx)
+  const { description, title } = getModalTitleAndDescription(thresholdReached)
 
   const txInfo = useTxInfo(transaction)
   const { confirmations } = txInfo

--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -1,66 +1,40 @@
 import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { useStyles } from './style'
-import Modal, { ButtonStatus, Modal as GenericModal } from 'src/components/Modal'
-import { ReviewInfoText } from 'src/components/ReviewInfoText'
+import Modal from 'src/components/Modal'
 import Block from 'src/components/layout/Block'
 import Bold from 'src/components/layout/Bold'
 import Hairline from 'src/components/layout/Hairline'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
-import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
-import { Transaction } from 'src/logic/safe/store/models/types/gateway.d'
-import { EstimationStatus, useEstimateTransactionGas } from 'src/logic/hooks/useEstimateTransactionGas'
-import { TxParametersDetail } from 'src/routes/safe/components/Transactions/helpers/TxParametersDetail'
-import { EditableTxParameters } from 'src/routes/safe/components/Transactions/helpers/EditableTxParameters'
+import { ExpandedTxDetails, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
-import { ParametersStatus } from 'src/routes/safe/components/Transactions/helpers/utils'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import { extractSafeAddress } from 'src/routes/routes'
-import useCanTxExecute from 'src/logic/hooks/useCanTxExecute'
-import { TxEstimatedFeesDetail } from 'src/routes/safe/components/Transactions/helpers/TxEstimatedFeesDetail'
-import { getNativeCurrency } from 'src/config'
-import { grantedSelector } from 'src/routes/safe/container/selector'
-import { userAccountSelector } from 'src/logic/wallets/store/selectors'
+import { Overwrite } from 'src/types/helpers'
+import { TxModalWrapper } from '../../helpers/TxModalWrapper'
+import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 
 type Props = {
   isOpen: boolean
   onClose: () => void
-  gwTransaction: Transaction
+  transaction: Overwrite<Transaction, { txDetails: ExpandedTxDetails }>
 }
 
-export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.ReactElement => {
+export const RejectTxModal = ({ isOpen, onClose, transaction }: Props): React.ReactElement => {
   const dispatch = useDispatch()
   const safeAddress = extractSafeAddress()
   const classes = useStyles()
-  const nativeCurrency = getNativeCurrency()
-  const isOwner = useSelector(grantedSelector)
-  const userAddress = useSelector(userAccountSelector)
-  const preApprovingOwner = isOwner ? userAddress : undefined
+  const executionInfo = transaction.executionInfo as MultisigExecutionInfo
 
-  const {
-    gasCostFormatted,
-    gasPriceFormatted,
-    gasMaxPrioFeeFormatted,
-    gasLimit,
-    gasEstimation,
-    txEstimationExecutionStatus,
-    isCreation,
-    isOffChainSignature,
-  } = useEstimateTransactionGas({
-    txData: EMPTY_DATA,
-    txRecipient: safeAddress,
-  })
-  const canTxExecute = useCanTxExecute(preApprovingOwner)
-
-  const origin = gwTransaction.safeAppInfo
-    ? JSON.stringify({ name: gwTransaction.safeAppInfo.name, url: gwTransaction.safeAppInfo.url })
+  const origin = transaction.safeAppInfo
+    ? JSON.stringify({ name: transaction.safeAppInfo.name, url: transaction.safeAppInfo.url })
     : ''
 
-  const nonce = (gwTransaction.executionInfo as MultisigExecutionInfo)?.nonce ?? 0
+  const nonce = (transaction.executionInfo as MultisigExecutionInfo)?.nonce ?? 0
 
   const sendReplacementTransaction = (txParameters: TxParameters) => {
     dispatch(
@@ -78,93 +52,32 @@ export const RejectTxModal = ({ isOpen, onClose, gwTransaction }: Props): React.
     onClose()
   }
 
-  const getParametersStatus = (): ParametersStatus => {
-    return 'CANCEL_TRANSACTION'
-  }
-
-  let confirmButtonStatus: ButtonStatus = ButtonStatus.READY
-  let confirmButtonText = 'Reject transaction'
-  if (txEstimationExecutionStatus === EstimationStatus.LOADING) {
-    confirmButtonStatus = ButtonStatus.LOADING
-    confirmButtonText = 'Estimating'
-  }
-
-  const gasCost = `${gasCostFormatted} ${nativeCurrency.symbol}`
-
   return (
     <Modal description="Reject transaction" handleClose={onClose} open={isOpen} title="Reject Transaction">
-      <EditableTxParameters
-        isExecution={canTxExecute}
-        ethGasLimit={gasLimit}
-        ethGasPrice={gasPriceFormatted}
-        ethMaxPrioFee={gasMaxPrioFeeFormatted}
-        safeTxGas={gasEstimation}
-        safeNonce={nonce.toString()}
-        parametersStatus={getParametersStatus()}
+      <TxModalWrapper
+        txNonce={nonce.toString()}
+        txThreshold={executionInfo.confirmationsRequired}
+        txData={EMPTY_DATA}
+        onSubmit={sendReplacementTransaction}
+        onClose={onClose}
+        isRejectTx
       >
-        {(txParameters, toggleEditMode) => {
-          return (
-            <>
-              <ModalHeader onClose={onClose} title="Reject transaction" />
-              <Hairline />
-              <Block className={classes.container}>
-                <Row>
-                  <Paragraph>
-                    This action will reject this transaction. A separate transaction will be performed to submit the
-                    rejection.
-                  </Paragraph>
-                  <Paragraph color="medium" size="sm">
-                    Transaction nonce:
-                    <br />
-                    <Bold className={classes.nonceNumber}>{nonce}</Bold>
-                  </Paragraph>
-                </Row>
-
-                {txEstimationExecutionStatus !== EstimationStatus.LOADING && canTxExecute && (
-                  <TxEstimatedFeesDetail
-                    txParameters={txParameters}
-                    gasCost={gasCost}
-                    onEdit={toggleEditMode}
-                    isTransactionCreation={isCreation}
-                    isTransactionExecution={canTxExecute}
-                    isOffChainSignature={isOffChainSignature}
-                  />
-                )}
-
-                {/* Tx Parameters */}
-                <TxParametersDetail
-                  onEdit={toggleEditMode}
-                  txParameters={txParameters}
-                  parametersStatus={getParametersStatus()}
-                  isTransactionCreation={isCreation}
-                  isOffChainSignature={isOffChainSignature}
-                />
-              </Block>
-
-              {txEstimationExecutionStatus !== EstimationStatus.LOADING && (
-                <ReviewInfoText
-                  isCreation={isCreation}
-                  isExecution={canTxExecute}
-                  safeNonce={txParameters.safeNonce}
-                  txEstimationExecutionStatus={txEstimationExecutionStatus}
-                />
-              )}
-              <GenericModal.Footer withoutBorder={confirmButtonStatus !== ButtonStatus.LOADING}>
-                <GenericModal.Footer.Buttons
-                  cancelButtonProps={{ onClick: onClose, text: 'Close' }}
-                  confirmButtonProps={{
-                    onClick: () => sendReplacementTransaction(txParameters),
-                    color: 'error',
-                    type: 'submit',
-                    status: confirmButtonStatus,
-                    text: confirmButtonText,
-                  }}
-                />
-              </GenericModal.Footer>
-            </>
-          )
-        }}
-      </EditableTxParameters>
+        <ModalHeader onClose={onClose} title="Reject transaction" />
+        <Hairline />
+        <Block className={classes.container}>
+          <Row>
+            <Paragraph>
+              This action will reject this transaction. A separate transaction will be performed to submit the
+              rejection.
+            </Paragraph>
+            <Paragraph color="medium" size="sm">
+              Transaction nonce:
+              <br />
+              <Bold className={classes.nonceNumber}>{nonce}</Bold>
+            </Paragraph>
+          </Row>
+        </Block>
+      </TxModalWrapper>
     </Modal>
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
+++ b/src/routes/safe/components/Transactions/TxList/modals/RejectTxModal.tsx
@@ -1,5 +1,3 @@
-import { MultisigExecutionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-
 import { useDispatch } from 'react-redux'
 import { useStyles } from './style'
 import Modal from 'src/components/Modal'
@@ -10,7 +8,7 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
-import { ExpandedTxDetails, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
+import { ExpandedTxDetails, isMultisigExecutionInfo, Transaction } from 'src/logic/safe/store/models/types/gateway.d'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import { extractSafeAddress } from 'src/routes/routes'
@@ -28,13 +26,13 @@ export const RejectTxModal = ({ isOpen, onClose, transaction }: Props): React.Re
   const dispatch = useDispatch()
   const safeAddress = extractSafeAddress()
   const classes = useStyles()
-  const executionInfo = transaction.executionInfo as MultisigExecutionInfo
+  const executionInfo = isMultisigExecutionInfo(transaction.executionInfo) ? transaction.executionInfo : undefined
 
   const origin = transaction.safeAppInfo
     ? JSON.stringify({ name: transaction.safeAppInfo.name, url: transaction.safeAppInfo.url })
     : ''
 
-  const nonce = (transaction.executionInfo as MultisigExecutionInfo)?.nonce ?? 0
+  const nonce = isMultisigExecutionInfo(transaction.executionInfo) ? transaction.executionInfo.nonce : 0
 
   const sendReplacementTransaction = (txParameters: TxParameters) => {
     dispatch(
@@ -56,7 +54,7 @@ export const RejectTxModal = ({ isOpen, onClose, transaction }: Props): React.Re
     <Modal description="Reject transaction" handleClose={onClose} open={isOpen} title="Reject Transaction">
       <TxModalWrapper
         txNonce={nonce.toString()}
-        txThreshold={executionInfo.confirmationsRequired}
+        txThreshold={executionInfo?.confirmationsRequired}
         txData={EMPTY_DATA}
         onSubmit={sendReplacementTransaction}
         onClose={onClose}

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -39,6 +39,7 @@ type Props = {
   onBack?: (...rest: any) => void
   submitText?: string
   isSubmitDisabled?: boolean
+  isRejectTx?: boolean
 }
 
 const Container = styled.div`
@@ -48,8 +49,8 @@ const Container = styled.div`
 /**
  * Determines which fields are displayed in the TxEditableParameters
  */
-const getParametersStatus = (isCreation: boolean, doExecute: boolean): ParametersStatus => {
-  return isCreation
+const getParametersStatus = (isCreation: boolean, doExecute: boolean, isRejectTx = false): ParametersStatus => {
+  return isCreation && !isRejectTx
     ? doExecute
       ? 'ENABLED'
       : 'ETH_HIDDEN' // allow editing nonce when creating
@@ -74,6 +75,7 @@ export const TxModalWrapper = ({
   onClose,
   submitText,
   isSubmitDisabled,
+  isRejectTx,
 }: Props): React.ReactElement => {
   const [manualSafeTxGas, setManualSafeTxGas] = useState('0')
   const [manualGasPrice, setManualGasPrice] = useState<string | undefined>()
@@ -163,7 +165,7 @@ export const TxModalWrapper = ({
     onSubmit(txParameters, !doExecute)
   }
 
-  const parametersStatus = getParametersStatus(isCreation, doExecute)
+  const parametersStatus = getParametersStatus(isCreation, doExecute, isRejectTx)
 
   const gasCost = `${gasCostFormatted} ${nativeCurrency.symbol}`
 


### PR DESCRIPTION
## What it solves
Resolves #3429 

## How this PR fixes it
The previous PR #3434 didn't fully cover all cases when a reject tx modal should be editable. This PR refactors the `RejectTxModal` component to use `TxModalWrapper`. It slightly changes the existing UI when creating a reject tx in a 2+/x safe (see screenshot).

## How to test it

1. Open a safe
2. Queue a transaction
3. Reject the transaction
4. In case it can be immediately executed, observe that all parameters except the safe nonce are editable
5. In case it can't be immediately executed, observe that no paramters are visible

## Screenshots
left: prod, right: current
![c](https://user-images.githubusercontent.com/5880855/152567449-0924b23e-90ec-44e5-818a-2daced9e5f56.png)

