### PR TITLE
fix: check that calculated gas price is a number

### DIFF
--- a/src/logic/wallets/ethTransactions.ts
+++ b/src/logic/wallets/ethTransactions.ts
@@ -12,7 +12,12 @@ const fetchGasPrice = async (gasPriceOracle: GasPriceOracle): Promise<string> =>
   const { uri, gasParameter, gweiFactor } = gasPriceOracle
   const { data: response } = await axios.get(uri)
   const data = response.data || response.result || response // Sometimes the data comes with a data parameter
-  return new BigNumber(data[gasParameter]).multipliedBy(gweiFactor).toString()
+
+  const gasPrice = new BigNumber(data[gasParameter]).multipliedBy(gweiFactor)
+  if (gasPrice.isNaN()) {
+    throw new Error('Fetched gas price is NaN')
+  }
+  return gasPrice.multipliedBy(gweiFactor).toString()
 }
 
 export const calculateGasPrice = async (): Promise<string> => {

--- a/src/logic/wallets/ethTransactions.ts
+++ b/src/logic/wallets/ethTransactions.ts
@@ -17,7 +17,7 @@ const fetchGasPrice = async (gasPriceOracle: GasPriceOracle): Promise<string> =>
   if (gasPrice.isNaN()) {
     throw new Error('Fetched gas price is NaN')
   }
-  return gasPrice.multipliedBy(gweiFactor).toString()
+  return gasPrice.toString()
 }
 
 export const calculateGasPrice = async (): Promise<string> => {


### PR DESCRIPTION
## What it solves
Resolves down oracles

## How this PR fixes it
Gas price oracles that are down, namely Rinkeby (atm), do not throw when there is an issue but return a string. This was not breaking out of the oracle estimation loop we use.

The fetced gas price is first checked (`!isNaN()`), throwing if so, before returning it.

## How to test it
This is very hard to test because manually switching to another oracle in Django will likely throw. You would likely have to mock the response of an oracle, returning a string (that is not a number).

This is the error returned:

![image](https://user-images.githubusercontent.com/20442784/152758334-1fbb34e9-448d-4118-95ec-07189bd289a1.png)

Hopefully this PR is reviewed whilst there is an Etherscan issue.