### PR TITLE
style: remove inconsistent on-chain rejection label

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
@@ -24,7 +24,7 @@ import { TokenTransferAmount } from './TokenTransferAmount'
 import { TxsInfiniteScrollContext } from './TxsInfiniteScroll'
 import { TxLocationContext } from './TxLocationProvider'
 import { CalculatedVotes } from './TxQueueCollapsed'
-import { getTxTo, isAwaitingExecution, isCancelTxDetails } from './utils'
+import { getTxTo, isAwaitingExecution } from './utils'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { useKnownAddress } from './hooks/useKnownAddress'
 import useTxStatus from 'src/logic/hooks/useTxStatus'
@@ -123,9 +123,6 @@ export const TxCollapsed = ({
   const isPending = txStatus === LocalTransactionStatus.PENDING
   const willBeReplaced = txStatus === LocalTransactionStatus.WILL_BE_REPLACED ? ' will-be-replaced' : ''
 
-  const onChainRejection =
-    isCancelTxDetails(transaction.txInfo) && txLocation !== 'history' ? ' on-chain-rejection' : ''
-
   const txCollapsedNonce = (
     <div className={'tx-nonce' + willBeReplaced}>
       <Text size="xl">{nonce}</Text>
@@ -133,7 +130,7 @@ export const TxCollapsed = ({
   )
 
   const txCollapsedType = (
-    <div className={'tx-type' + willBeReplaced + onChainRejection}>
+    <div className={'tx-type' + willBeReplaced}>
       <CustomIconText
         address={toAddress?.value || '0x'}
         iconUrl={type.icon || toInfo?.logoUri || undefined}

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -170,32 +170,6 @@ const failedTransaction = css`
   }
 `
 
-const onChainRejection = css`
-  &.on-chain-rejection {
-    background-color: ${({ theme }) => theme.colors.errorTooltip};
-    border-left: 4px solid ${({ theme }) => theme.colors.error};
-    border-radius: 4px;
-    padding-left: 7px;
-    height: 22px;
-    max-width: 165px;
-
-    > div {
-      height: 17px;
-      align-items: center;
-      padding-top: 3px;
-    }
-
-    p {
-      font-size: 11px;
-      line-height: 16px;
-      letter-spacing: 1px;
-      font-weight: bold;
-      text-transform: uppercase;
-      margin-left: -2px;
-    }
-  }
-`
-
 export const StyledTransaction = styled.div`
   ${willBeReplaced};
   ${failedTransaction};
@@ -206,10 +180,6 @@ export const StyledTransaction = styled.div`
 
   & > div {
     align-self: center;
-  }
-
-  .tx-type {
-    ${onChainRejection};
   }
 
   .tx-votes {


### PR DESCRIPTION
## What it solves
Resolves #3443

## How this PR fixes it
The old on-chain rejection label styling was removed to keep it consistent across tthe app.

## How to test it
1. Create a transaction and corresponding on-chain rejection.
2. Observe that the on-chain rejection in the group has the usual transaction label style.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/152850863-fd7ed70e-2987-4e4f-a239-a9a55e0562e0.png)