### PR TITLE
fix: don't pass theming props to DOM

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/ModalHeader/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ModalHeader/index.tsx
@@ -14,11 +14,11 @@ import { smallFontSize, xs, sm, border, primary } from 'src/theme/variables'
 
 const useStyles = makeStyles(styles)
 
-const ChainIndicatorWrapper = styled(Row)<{ chainTheme: Theme }>`
+const ChainIndicatorWrapper = styled(Row)<{ $chainTheme: Theme }>`
   font-size: ${smallFontSize};
   padding: ${xs} ${sm};
-  background-color: ${(props) => props.chainTheme.backgroundColor ?? border};
-  color: ${(props) => props.chainTheme.textColor ?? primary};
+  background-color: ${({ $chainTheme }) => $chainTheme.backgroundColor ?? border};
+  color: ${({ $chainTheme }) => $chainTheme.textColor ?? primary};
   border-radius: 4px;
   align-items: center;
   white-space: nowrap;
@@ -47,7 +47,7 @@ export const ModalHeader = ({ onClose, subTitle, title, iconUrl }: HeaderProps):
       <Paragraph className={classes.annotation} size="sm">
         {subTitle}
       </Paragraph>
-      <ChainIndicatorWrapper chainTheme={theme}>
+      <ChainIndicatorWrapper $chainTheme={theme}>
         {connectedNetwork.chainId && <ChainIndicator chainId={connectedNetwork.chainId} hideCircle />}
       </ChainIndicatorWrapper>
       <IconButton disableRipple onClick={onClose}>

--- a/src/routes/safe/components/Transactions/TxList/TxOwners.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxOwners.tsx
@@ -77,12 +77,12 @@ const getStepColor = (state: StepState): string => {
 }
 
 type StyledStepProps = {
-  bold?: boolean
+  $bold?: boolean
   state: StepState
 }
 const StyledStep = styled(Step)<StyledStepProps>`
   .MuiStepLabel-label {
-    font-weight: ${({ bold = false }) => (bold ? 'bold' : 'normal')};
+    font-weight: ${({ $bold = false }) => ($bold ? 'bold' : 'normal')};
     font-size: 16px;
     color: ${({ state }) => getStepColor(state)};
   }
@@ -123,7 +123,7 @@ const getConfirmationStep = (
   { value, name, logoUri }: AddressEx,
   key: string | undefined = undefined,
 ): ReactElement => (
-  <StyledStep key={key} bold state="confirmed">
+  <StyledStep key={key} $bold state="confirmed">
     <StepLabel icon={<DotIcon />}>
       <AddressInfo address={value} name={name || undefined} avatarUrl={logoUri || undefined} shortenHash={4} />
     </StepLabel>
@@ -163,15 +163,15 @@ export const TxOwners = ({
   return (
     <StyledStepper orientation="vertical" nonLinear connector={<StyledStepConnector />}>
       {isCancelTxDetails(txInfo) ? (
-        <StyledStep bold state="error">
+        <StyledStep $bold state="error">
           <StepLabel icon={<TxRejectionIcon />}>On-chain rejection created</StepLabel>
         </StyledStep>
       ) : (
-        <StyledStep bold state="confirmed">
+        <StyledStep $bold state="confirmed">
           <StepLabel icon={<TxCreationIcon />}>Created</StepLabel>
         </StyledStep>
       )}
-      <StyledStep bold state={isConfirmed ? 'confirmed' : 'active'}>
+      <StyledStep $bold state={isConfirmed ? 'confirmed' : 'active'}>
         <StepLabel icon={isConfirmed ? <CheckIcon /> : <CircleIcon />}>
           Confirmations{' '}
           <span style={confirmationsStyle}>
@@ -190,7 +190,7 @@ export const TxOwners = ({
           </StepLabel>
         </StyledStep>
       )}
-      <StyledStep expanded bold state={isExecuted ? 'confirmed' : 'disabled'}>
+      <StyledStep expanded $bold state={isExecuted ? 'confirmed' : 'disabled'}>
         <StepLabel icon={isExecuted ? <CheckIcon /> : <CircleIcon />}>
           {isExecuted ? 'Executed' : isPending ? 'Executing' : 'Execution'}
         </StepLabel>


### PR DESCRIPTION
## What it solves
Console errors related to Stepper and chain theming

## How this PR fixes it
Theme-related props are appended with `$`, preventing them from being passed to the DOM.

## How to test it
Interface with the Stepper and observe no errors in the console.