### PR TITLE
fix: only show safe sidebar on open Safes

### DIFF
--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -9,6 +9,7 @@ import {
   CopyToClipboardBtn,
   ExplorerButton,
 } from '@gnosis.pm/safe-react-components'
+import { useRouteMatch } from 'react-router-dom'
 
 import ButtonHelper from 'src/components/ButtonHelper'
 import FlexSpacer from 'src/components/FlexSpacer'
@@ -17,7 +18,7 @@ import { border, fontColor } from 'src/theme/variables'
 import { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { copyShortNameSelector } from 'src/logic/appearance/selectors'
-import { extractShortChainName } from 'src/routes/routes'
+import { ADDRESSED_ROUTE, extractShortChainName } from 'src/routes/routes'
 
 export const TOGGLE_SIDEBAR_BTN_TESTID = 'TOGGLE_SIDEBAR_BTN'
 
@@ -129,7 +130,9 @@ const SafeHeader = ({
   const copyChainPrefix = useSelector(copyShortNameSelector)
   const shortName = extractShortChainName()
 
-  if (!address) {
+  const hasSafeOpen = useRouteMatch(ADDRESSED_ROUTE)
+
+  if (!address || !hasSafeOpen) {
     return (
       <Container>
         <IdenticonContainer>


### PR DESCRIPTION
## What it solves
Resolves #3458

## How this PR fixes it
The Safe-specific sidebar is only shown when a Safe address exists in the URL. (The 'loaded' Safe remains in the store so it is necessary to use the URL as a flag as well).

## How to test it
1. Open a Safe.
2. Click the Safe logo.
3. Observe that the Safe-specific sidebar is no longer visible.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/153033150-4d67eb30-e2cb-4df8-8eb8-f099f18f20a9.png)