### PR TITLE
fix: lookup ENS domains when intialising form

### DIFF
--- a/src/components/forms/validator.ts
+++ b/src/components/forms/validator.ts
@@ -135,7 +135,7 @@ export const minMaxDecimalsLength =
     return minMaxLengthErrMsg ? `Should be ${minLen} to ${maxLen} decimals` : undefined
   }
 
-export const ADDRESS_REPEATED_ERROR = 'Address already introduced'
+export const ADDRESS_REPEATED_ERROR = 'Address already added'
 export const OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR = 'Cannot use Safe itself as owner.'
 export const THRESHOLD_ERROR = 'You cannot set more confirmations than owners'
 

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -115,7 +115,7 @@ export const reverseENSLookup = async (address: string): Promise<string> => {
     return ''
   }
 
-  return verifiedAddress === checksumAddress(address) ? name : ''
+  return checksumAddress(verifiedAddress) === checksumAddress(address) ? name : ''
 }
 
 export const getContentFromENS = (name: string): Promise<ContentHash> => web3.eth.ens.getContenthash(name)

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -14,6 +14,7 @@ import { CHAIN_ID, ChainId } from 'src/config/chain.d'
 import { isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { getAddressFromUnstoppableDomain } from './utils/unstoppableDomains'
 import { hasFeature } from 'src/logic/safe/utils/safeVersion'
+import { checksumAddress } from 'src/utils/checksumAddress'
 
 // This providers have direct relation with name assigned in bnc-onboard configuration
 export enum WALLET_PROVIDER {
@@ -114,7 +115,7 @@ export const reverseENSLookup = async (address: string): Promise<string> => {
     return ''
   }
 
-  return verifiedAddress === address ? name : ''
+  return verifiedAddress === checksumAddress(address) ? name : ''
 }
 
 export const getContentFromENS = (name: string): Promise<ContentHash> => web3.eth.ens.getContenthash(name)

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -15,6 +15,7 @@ import { isValidCryptoDomainName } from 'src/logic/wallets/ethAddresses'
 import { getAddressFromUnstoppableDomain } from './utils/unstoppableDomains'
 import { hasFeature } from 'src/logic/safe/utils/safeVersion'
 import { checksumAddress } from 'src/utils/checksumAddress'
+import { isValidAddress } from 'src/utils/isValidAddress'
 
 // This providers have direct relation with name assigned in bnc-onboard configuration
 export enum WALLET_PROVIDER {
@@ -91,7 +92,7 @@ export const getAddressFromDomain = (name: string): Promise<string> => {
 }
 
 export const reverseENSLookup = async (address: string): Promise<string> => {
-  if (!hasFeature(FEATURES.DOMAIN_LOOKUP)) {
+  if (!hasFeature(FEATURES.DOMAIN_LOOKUP) || !isValidAddress(address)) {
     return ''
   }
 

--- a/src/routes/CreateSafePage/CreateSafePage.test.tsx
+++ b/src/routes/CreateSafePage/CreateSafePage.test.tsx
@@ -519,7 +519,7 @@ describe('<CreateSafePage>', () => {
       const defaultOwnerInput = screen.getByTestId('owner-address-1')
       fireEvent.change(defaultOwnerInput, { target: { value: '0x680cde08860141F9D223cE4E620B10Cd6741037E' } })
 
-      const errorText = 'Address already introduced'
+      const errorText = 'Address already added'
 
       expect(screen.getByText(errorText)).toBeInTheDocument()
     })

--- a/src/routes/CreateSafePage/steps/NameNewSafeStep.tsx
+++ b/src/routes/CreateSafePage/steps/NameNewSafeStep.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useForm } from 'react-final-form'
 import styled from 'styled-components'
@@ -10,20 +10,13 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Field from 'src/components/forms/Field'
 import TextField from 'src/components/forms/TextField'
 import { providerNameSelector } from 'src/logic/wallets/store/selectors'
-import {
-  FIELD_CREATE_CUSTOM_SAFE_NAME,
-  FIELD_CREATE_SUGGESTED_SAFE_NAME,
-  FIELD_SAFE_OWNER_ENS_LIST,
-  FIELD_SAFE_OWNERS_LIST,
-} from '../fields/createSafeFields'
+import { FIELD_CREATE_CUSTOM_SAFE_NAME, FIELD_CREATE_SUGGESTED_SAFE_NAME } from '../fields/createSafeFields'
 import { useStepper } from 'src/components/Stepper/stepperContext'
 import NetworkLabel from 'src/components/NetworkLabel/NetworkLabel'
-import { reverseENSLookup } from 'src/logic/wallets/getWeb3'
 
 export const nameNewSafeStepLabel = 'Name'
 
 function NameNewSafeStep(): ReactElement {
-  const [ownersWithENSName, setOwnersWithENSName] = useState<Record<string, string>>({})
   const provider = useSelector(providerNameSelector)
 
   const { setCurrentStep } = useStepper()
@@ -36,39 +29,6 @@ function NameNewSafeStep(): ReactElement {
 
   const createNewSafeForm = useForm()
   const formValues = createNewSafeForm.getState().values
-
-  useEffect(() => {
-    const getInitialOwnerENSNames = async () => {
-      const formValues = createNewSafeForm.getState().values
-      const owners = formValues[FIELD_SAFE_OWNERS_LIST]
-      const ownersWithENSName = await Promise.all(
-        owners.map(async ({ addressFieldName }) => {
-          const address = formValues[addressFieldName]
-          const ensName = await reverseENSLookup(address)
-          return {
-            address,
-            name: ensName,
-          }
-        }),
-      )
-
-      const ownersWithENSNameRecord = ownersWithENSName.reduce<Record<string, string>>((acc, { address, name }) => {
-        return {
-          ...acc,
-          [address]: name,
-        }
-      }, {})
-
-      setOwnersWithENSName(ownersWithENSNameRecord)
-    }
-    getInitialOwnerENSNames()
-  }, [createNewSafeForm])
-
-  useEffect(() => {
-    if (ownersWithENSName) {
-      createNewSafeForm.change(FIELD_SAFE_OWNER_ENS_LIST, ownersWithENSName)
-    }
-  }, [ownersWithENSName, createNewSafeForm])
 
   return (
     <BlockWithPadding data-testid={'create-safe-name-step'}>


### PR DESCRIPTION
## What it solves
Resolves #3459

## How this PR fixes it
The address being looked up is now checksummed before being compared to the verified (checksummed) address, allowing it to pass validation.

Note: the error message regarding repeated multiple of the same owner was adjusted.

## How to test it
1. Open Safe creation whilst connected to an EOA with an ENS domain
2. Progress to the owner step and observe that the ENS name has been resolved

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/153042051-f73244fa-a874-4f1a-abaf-6e7518ce565c.png)
