### PR TITLE
style: increase SpendingLimitDetails title font size

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
@@ -93,7 +93,7 @@ export const DeleteSpendingLimitDetails = ({ txData, txInfo }: SpendingLimitProp
 
   return (
     <StyledTxInfoDetails>
-      <StyledDetailsTitle size="sm" strong>
+      <StyledDetailsTitle size="xl" strong>
         Delete spending limit:
       </StyledDetailsTitle>
       <StyledInfoBlock>


### PR DESCRIPTION
## What it solves
Resolves #3456

## How this PR fixes it
Aligns the font size with the other SpendingLimitDetail title size

## How to test it
Open a DeleteAllowance transaction in the TxList and assert that the font size is as per designs https://www.figma.com/file/47wkjxMZkyEeCRbCrLJBJa/safe%232995-Tx-details?node-id=387%3A21816

## Screenshots
![Screen Shot 2022-02-08 at 17 24 40](https://user-images.githubusercontent.com/32431609/153041714-02edf4d7-261f-4506-b5fa-6a6ffe8834c0.png)

