### PR TITLE
fix: Disable tx execution for out of order nonce txs

### DIFF
--- a/src/logic/hooks/useCanTxExecute.tsx
+++ b/src/logic/hooks/useCanTxExecute.tsx
@@ -5,10 +5,20 @@ type UseCanTxExecuteType = (
   preApprovingOwner?: string,
   txConfirmations?: number,
   existingTxThreshold?: number,
+  txNonce?: string,
 ) => boolean
 
-const useCanTxExecute: UseCanTxExecuteType = (preApprovingOwner = '', txConfirmations = 0, existingTxThreshold) => {
+const useCanTxExecute: UseCanTxExecuteType = (
+  preApprovingOwner = '',
+  txConfirmations = 0,
+  existingTxThreshold,
+  txNonce,
+) => {
   const safeInfo = useSelector(currentSafe)
+
+  if (txNonce && parseInt(txNonce, 10) !== safeInfo.nonce) {
+    return false
+  }
 
   // A tx might have been created with a threshold that is different than the current policy
   // If an existing tx threshold isn't passed, take the current safe threshold

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -89,7 +89,7 @@ export const TxModalWrapper = ({
   const isSpendingLimitTx = isSpendingLimit(txType)
   const preApprovingOwner = isOwner ? userAddress : undefined
   const confirmationsLen = Array.from(txConfirmations || []).length
-  const canTxExecute = useCanTxExecute(preApprovingOwner, confirmationsLen, txThreshold)
+  const canTxExecute = useCanTxExecute(preApprovingOwner, confirmationsLen, txThreshold, txNonce)
   const doExecute = executionApproved && canTxExecute
   const nativeCurrency = getNativeCurrency()
 


### PR DESCRIPTION
## What it solves
Resolves #3457 

## How this PR fixes it
Changes `useCanTxExecute` to return `false` if current transaction nonce is out of order

## How to test it

1. Open a 2+/n safe
2. Queue a transaction
3. Queue a second transaction
4. Switch wallet
5. Try to Confirm the second transaction
6. Observe that it can not be executed

## Screenshots
![Screenshot 2022-02-08 at 18 36 32](https://user-images.githubusercontent.com/5880855/153043808-4e07253b-0523-45d1-84dd-2b1db26f5811.png)

