### PR TITLE
fix: deal with nested arrays param values

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils/index.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils/index.ts
@@ -66,7 +66,6 @@ export const isInt = (type: string): boolean => type.indexOf('int') === 0
 export const isByte = (type: string): boolean => type.indexOf('byte') === 0
 
 export const isArrayParameter = (parameter: string): boolean => /(\[\d*])+$/.test(parameter)
-export const isNestedArrayParameter = (parameter: string): boolean => /(\[\d*]\[\d*])+$/.test(parameter)
 export const getParsedJSONOrArrayFromString = (parameter: string): (string | number)[] | null => {
   try {
     const arrayResult = JSON.parse(parameter)

--- a/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils/index.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils/index.ts
@@ -66,6 +66,7 @@ export const isInt = (type: string): boolean => type.indexOf('int') === 0
 export const isByte = (type: string): boolean => type.indexOf('byte') === 0
 
 export const isArrayParameter = (parameter: string): boolean => /(\[\d*])+$/.test(parameter)
+export const isNestedArrayParameter = (parameter: string): boolean => /(\[\d*]\[\d*])+$/.test(parameter)
 export const getParsedJSONOrArrayFromString = (parameter: string): (string | number)[] | null => {
   try {
     const arrayResult = JSON.parse(parameter)

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -50,6 +50,8 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
 }
 
 const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
+  const getKey = (key = '0', index) => `${key}-${index}`
+
   if (isArrayParameter(type) && isAddress(type)) {
     return (
       <>
@@ -57,7 +59,12 @@ const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
         <NestedWrapper>
           {(props.value as string[]).map((address, index) => {
             if (Array.isArray(address)) {
-              const newProps = { type, ...props, value: address, key: `${props.method}-value-${index}` }
+              const newProps = {
+                type,
+                ...props,
+                value: address,
+                key: `${props.method}-${getKey(props.key, index)}`,
+              }
               return <Value {...newProps} />
             }
             const explorerUrl = getExplorerInfo(address)

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -50,27 +50,26 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
 }
 
 const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
-  const getKey = (key = '0', index) => `${key}-${index}`
-
   if (isArrayParameter(type) && isAddress(type)) {
     return (
       <>
         [
         <NestedWrapper>
           {(props.value as string[]).map((address, index) => {
+            const key = `${props.key || props.method}-${index}`
             if (Array.isArray(address)) {
               const newProps = {
                 type,
                 ...props,
                 value: address,
-                key: `${props.method}-${getKey(props.key, index)}`,
+                key,
               }
               return <Value {...newProps} />
             }
             const explorerUrl = getExplorerInfo(address)
             return (
               <PrefixedEthHashInfo
-                key={`${address}_${index}`}
+                key={`${address}_${key}`}
                 textSize="xl"
                 hash={address}
                 showCopyBtn

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import {
   isAddress,
   isArrayParameter,
-  isNestedArrayParameter,
 } from 'src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils'
 import { HexEncodedData } from './HexEncodedData'
 import { getExplorerInfo } from 'src/config'
@@ -18,6 +17,7 @@ interface RenderValueProps {
   method: string
   type: string
   value: string | string[]
+  key?: string
 }
 
 const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactElement => {
@@ -50,39 +50,16 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
 }
 
 const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
-  if (isNestedArrayParameter(type)) {
-    return (
-      <>
-        [
-        <NestedWrapper>
-          [
-          <NestedWrapper>
-            {(props.value as string[]).flat().map((address, index) => {
-              const explorerUrl = getExplorerInfo(address)
-              return (
-                <PrefixedEthHashInfo
-                  key={`${address}_${index}`}
-                  textSize="xl"
-                  hash={address}
-                  showCopyBtn
-                  explorerUrl={explorerUrl}
-                />
-              )
-            })}
-          </NestedWrapper>
-          ]
-        </NestedWrapper>
-        ]
-      </>
-    )
-  }
-
   if (isArrayParameter(type) && isAddress(type)) {
     return (
       <>
         [
         <NestedWrapper>
           {(props.value as string[]).map((address, index) => {
+            if (Array.isArray(address)) {
+              const newProps = { type, ...props, value: address, key: `${props.method}-value-${index}` }
+              return <Value {...newProps} />
+            }
             const explorerUrl = getExplorerInfo(address)
             return (
               <PrefixedEthHashInfo

--- a/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
+++ b/src/routes/safe/components/Transactions/TxList/MethodValue.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import {
   isAddress,
   isArrayParameter,
+  isNestedArrayParameter,
 } from 'src/routes/safe/components/Balances/SendModal/screens/ContractInteraction/utils'
 import { HexEncodedData } from './HexEncodedData'
 import { getExplorerInfo } from 'src/config'
@@ -49,6 +50,33 @@ const GenericValue = ({ method, type, value }: RenderValueProps): React.ReactEle
 }
 
 const Value = ({ type, ...props }: RenderValueProps): React.ReactElement => {
+  if (isNestedArrayParameter(type)) {
+    return (
+      <>
+        [
+        <NestedWrapper>
+          [
+          <NestedWrapper>
+            {(props.value as string[]).flat().map((address, index) => {
+              const explorerUrl = getExplorerInfo(address)
+              return (
+                <PrefixedEthHashInfo
+                  key={`${address}_${index}`}
+                  textSize="xl"
+                  hash={address}
+                  showCopyBtn
+                  explorerUrl={explorerUrl}
+                />
+              )
+            })}
+          </NestedWrapper>
+          ]
+        </NestedWrapper>
+        ]
+      </>
+    )
+  }
+
   if (isArrayParameter(type) && isAddress(type)) {
     return (
       <>


### PR DESCRIPTION
## What it solves
Resolves #3468

## How this PR fixes it
Handles multidimensional method param values

## How to test it
Open app/avax:0x2ABC32Fcf8584Aba161b33133af55cD3f94Ba288/transactions/0xb249327fea1885798f2ffca88aa31bd4e9a4d35f66aa57e58bf3cf25af4c239c and you shall see all the values well represented without the application crashing

## Screenshots
<img width="505" alt="Screen Shot 2022-02-09 at 11 58 33" src="https://user-images.githubusercontent.com/32431609/153211575-a5770632-0e4d-4331-9214-575ee6eed014.png">

