### PR TITLE
fix: use field-level owner validation

### DIFF
--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -67,6 +67,7 @@ const AddressInput = ({
 
       // A crypto domain name
       if (isValidEnsName(address) || isValidCryptoDomainName(address)) {
+        setResolutions((prev) => ({ ...prev, [rawVal]: '' }))
         getAddressFromDomain(address)
           .then((resolverAddr) => {
             const formattedAddress = checksumAddress(resolverAddr)

--- a/src/components/forms/AddressInput/index.tsx
+++ b/src/components/forms/AddressInput/index.tsx
@@ -67,8 +67,6 @@ const AddressInput = ({
 
       // A crypto domain name
       if (isValidEnsName(address) || isValidCryptoDomainName(address)) {
-        setResolutions((prev) => ({ ...prev, [rawVal]: '' }))
-
         getAddressFromDomain(address)
           .then((resolverAddr) => {
             const formattedAddress = checksumAddress(resolverAddr)

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -16,6 +16,7 @@ import updateProviderNetwork from 'src/logic/wallets/store/actions/updateProvide
 import updateProviderEns from 'src/logic/wallets/store/actions/updateProviderEns'
 import closeSnackbar from '../notifications/store/actions/closeSnackbar'
 import { getChains } from 'src/config/cache/chains'
+import { checksumAddress } from 'src/utils/checksumAddress'
 
 const LAST_USED_PROVIDER_KEY = 'LAST_USED_PROVIDER'
 
@@ -63,14 +64,16 @@ const getOnboard = (chainId: ChainId): API => {
         )
       },
       address: (address) => {
-        store.dispatch(updateProviderAccount(address))
+        const checksummedAddress = checksumAddress(address)
 
-        if (address) {
-          prevAddress = address
+        store.dispatch(updateProviderAccount(checksummedAddress))
+
+        if (checksummedAddress) {
+          prevAddress = checksummedAddress
         }
 
         // Wallet disconnected
-        if (!address && prevAddress) {
+        if (!checksummedAddress && prevAddress) {
           resetWeb3()
           removeFromStorage(LAST_USED_PROVIDER_KEY)
         }

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -16,7 +16,6 @@ import updateProviderNetwork from 'src/logic/wallets/store/actions/updateProvide
 import updateProviderEns from 'src/logic/wallets/store/actions/updateProviderEns'
 import closeSnackbar from '../notifications/store/actions/closeSnackbar'
 import { getChains } from 'src/config/cache/chains'
-import { checksumAddress } from 'src/utils/checksumAddress'
 
 const LAST_USED_PROVIDER_KEY = 'LAST_USED_PROVIDER'
 
@@ -63,17 +62,16 @@ const getOnboard = (chainId: ChainId): API => {
           }),
         )
       },
+      // Non-checksummed address
       address: (address) => {
-        const checksummedAddress = checksumAddress(address)
+        store.dispatch(updateProviderAccount(address))
 
-        store.dispatch(updateProviderAccount(checksummedAddress))
-
-        if (checksummedAddress) {
-          prevAddress = checksummedAddress
+        if (address) {
+          prevAddress = address
         }
 
         // Wallet disconnected
-        if (!checksummedAddress && prevAddress) {
+        if (!address && prevAddress) {
           resetWeb3()
           removeFromStorage(LAST_USED_PROVIDER_KEY)
         }

--- a/src/logic/wallets/store/reducer/index.ts
+++ b/src/logic/wallets/store/reducer/index.ts
@@ -2,6 +2,7 @@ import { Action, handleActions } from 'redux-actions'
 
 import { ChainId } from 'src/config/chain.d'
 import { PROVIDER_ACTIONS } from 'src/logic/wallets/store/actions'
+import { checksumAddress } from 'src/utils/checksumAddress'
 
 export type ProvidersState = {
   name: string
@@ -51,7 +52,7 @@ const providerReducer = handleActions<ProvidersState, ProviderPayloads>(
     [PROVIDER_ACTIONS.NETWORK]: (state: ProvidersState, { payload }: Action<ProviderNetworkPayload>) =>
       providerFactory({ ...state, network: payload }),
     [PROVIDER_ACTIONS.ACCOUNT]: (state: ProvidersState, { payload }: Action<ProviderAccountPayload>) =>
-      providerFactory({ ...state, account: payload, available: !!payload }),
+      providerFactory({ ...state, account: checksumAddress(payload), available: !!payload }),
     [PROVIDER_ACTIONS.ENS]: (state: ProvidersState, { payload }: Action<ProviderEnsPayload>) =>
       providerFactory({ ...state, ensDomain: payload }),
   },

--- a/src/routes/CreateSafePage/CreateSafePage.tsx
+++ b/src/routes/CreateSafePage/CreateSafePage.tsx
@@ -30,7 +30,6 @@ import { useMnemonicSafeName } from 'src/logic/hooks/useMnemonicName'
 import { providerNameSelector, shouldSwitchWalletChain, userAccountSelector } from 'src/logic/wallets/store/selectors'
 import OwnersAndConfirmationsNewSafeStep, {
   ownersAndConfirmationsNewSafeStepLabel,
-  ownersAndConfirmationsNewSafeStepValidations,
 } from './steps/OwnersAndConfirmationsNewSafeStep'
 import { currentNetworkAddressBookAsMap } from 'src/logic/addressBook/store/selectors'
 import ReviewNewSafeStep, { reviewNewSafeStepLabel } from './steps/ReviewNewSafeStep'
@@ -124,11 +123,7 @@ function CreateSafePage(): ReactElement {
           <StepFormElement label={nameNewSafeStepLabel} nextButtonLabel="Continue">
             <NameNewSafeStep />
           </StepFormElement>
-          <StepFormElement
-            label={ownersAndConfirmationsNewSafeStepLabel}
-            nextButtonLabel="Continue"
-            validate={ownersAndConfirmationsNewSafeStepValidations}
-          >
+          <StepFormElement label={ownersAndConfirmationsNewSafeStepLabel} nextButtonLabel="Continue">
             <OwnersAndConfirmationsNewSafeStep />
           </StepFormElement>
           <StepFormElement label={reviewNewSafeStepLabel} nextButtonLabel="Create">

--- a/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
+++ b/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
@@ -140,7 +140,7 @@ function OwnersAndConfirmationsNewSafeStep(): ReactElement {
             const ownerName = ownersWithENSName[ownerAddress] || 'Owner Name'
 
             const isRepeated = (value: string) => {
-              const prevOwners = owners.slice(0, i)
+              const prevOwners = owners.filter((_: typeof owners[number], index: number) => index !== i)
               const repeated = prevOwners.some((owner: typeof owners[number]) => {
                 return sameString(createSafeFormValues[owner.addressFieldName], value)
               })

--- a/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
+++ b/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
@@ -39,6 +39,7 @@ import { ScanQRWrapper } from 'src/components/ScanQRModal/ScanQRWrapper'
 import { currentNetworkAddressBookAsMap } from 'src/logic/addressBook/store/selectors'
 import NetworkLabel from 'src/components/NetworkLabel/NetworkLabel'
 import { reverseENSLookup } from 'src/logic/wallets/getWeb3'
+import { sameString } from 'src/utils/strings'
 
 export const ownersAndConfirmationsNewSafeStepLabel = 'Owners and Confirmations'
 
@@ -132,11 +133,19 @@ function OwnersAndConfirmationsNewSafeStep(): ReactElement {
       <Hairline />
       <Block margin="md" padding="md">
         <RowHeader>
-          {owners.map(({ nameFieldName, addressFieldName }) => {
+          {owners.map(({ nameFieldName, addressFieldName }, i: number) => {
             const hasOwnerAddressError = formErrors[addressFieldName]
             const ownerAddress = createSafeFormValues[addressFieldName]
             const showDeleteIcon = addressFieldName !== 'owner-address-0' // we hide de delete icon for the first owner
             const ownerName = ownersWithENSName[ownerAddress] || 'Owner Name'
+
+            const isRepeated = (value: string) => {
+              const prevOwners = owners.slice(0, i)
+              const repeated = prevOwners.some((owner: typeof owners[number]) => {
+                return sameString(createSafeFormValues[owner.addressFieldName], value)
+              })
+              return repeated ? ADDRESS_REPEATED_ERROR : undefined
+            }
 
             return (
               <Fragment key={addressFieldName}>
@@ -175,6 +184,7 @@ function OwnersAndConfirmationsNewSafeStep(): ReactElement {
                     placeholder="Owner Address*"
                     text="Owner Address"
                     testId={addressFieldName}
+                    validators={[isRepeated]}
                   />
                 </Col>
                 <OwnersIconsContainer xs={1} center="xs" middle="xs">
@@ -214,7 +224,12 @@ function OwnersAndConfirmationsNewSafeStep(): ReactElement {
                 component={SelectField}
                 data-testid="threshold-selector-input"
                 name={FIELD_NEW_SAFE_THRESHOLD}
-                validate={composeValidators(required, minValue(1))}
+                validate={(val) => {
+                  const isValidThreshold = () => {
+                    return !!threshold && threshold <= owners.length ? undefined : THRESHOLD_ERROR
+                  }
+                  return composeValidators(required, minValue(1), isValidThreshold)(val)
+                }}
               >
                 {owners.map((_, option) => (
                   <MenuItem
@@ -238,34 +253,6 @@ function OwnersAndConfirmationsNewSafeStep(): ReactElement {
 }
 
 export default OwnersAndConfirmationsNewSafeStep
-
-export const ownersAndConfirmationsNewSafeStepValidations = (values: {
-  [FIELD_SAFE_OWNERS_LIST]: Array<Record<string, string>>
-  [FIELD_NEW_SAFE_THRESHOLD]: number
-}): Record<string, string> => {
-  const errors = {}
-
-  const owners = values[FIELD_SAFE_OWNERS_LIST]
-  const threshold = values[FIELD_NEW_SAFE_THRESHOLD]
-  const addresses = owners.map(({ addressFieldName }) => values[addressFieldName])
-
-  // we check repeated addresses
-  owners.forEach(({ addressFieldName }, index) => {
-    const address = values[addressFieldName]
-    const previousOwners = addresses.slice(0, index)
-    const isRepeated = previousOwners.includes(address)
-    if (isRepeated) {
-      errors[addressFieldName] = ADDRESS_REPEATED_ERROR
-    }
-  })
-
-  const isValidThreshold = !!threshold && threshold <= owners.length
-  if (!isValidThreshold) {
-    errors[FIELD_NEW_SAFE_THRESHOLD] = THRESHOLD_ERROR
-  }
-
-  return errors
-}
 
 const BlockWithPadding = styled(Block)`
   padding: ${lg};


### PR DESCRIPTION
## What it solves
Resolves #3460

## How this PR fixes it
The 'Owners and Confirmations' step validation was being overwritten by field-level `onChange` validation. Field-specific validation is now added on a per-field basis, appending it to the `composeValidators`.

## How to test it
1. Open Safe creation.
2. Progress to 'Owners and Confirmations' step.
3. Attempt to add the same owner (with/without EIP-3770 prefix) and observe the duplicate owner error.