### PR TITLE
fix: `getCode` via readonly web3 object

### DIFF
--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -79,13 +79,13 @@ export const getChainIdFrom = (web3Provider: Web3): Promise<number> => {
 const isHardwareWallet = (walletName: string) =>
   sameAddress(WALLET_PROVIDER.LEDGER, walletName) || sameAddress(WALLET_PROVIDER.TREZOR, walletName)
 
-export const isSmartContractWallet = async (web3Provider: Web3, account: string): Promise<boolean> => {
+export const isSmartContractWallet = async (account: string): Promise<boolean> => {
   if (!account) {
     return false
   }
   let contractCode = ''
   try {
-    contractCode = await web3Provider.eth.getCode(account)
+    contractCode = await getWeb3ReadOnly().eth.getCode(account)
   } catch (e) {
     // ignore
   }
@@ -96,7 +96,7 @@ export const getProviderInfo = async (web3Instance: Web3, providerName = 'Wallet
   const account = (await getAccountFrom(web3Instance)) || ''
   const ensDomain = account ? await reverseENSLookup(account) : ''
   const network = await getChainIdFrom(web3Instance)
-  const smartContractWallet = await isSmartContractWallet(web3Instance, account)
+  const smartContractWallet = await isSmartContractWallet(account)
   const hardwareWallet = isHardwareWallet(providerName)
   const available = Boolean(account)
 


### PR DESCRIPTION
## What it solves
Resolves #3435

## How this PR fixes it
`isSmartContractWallet` now checks via the readonly `web3` object instead of that from the provider. Using the standard `getWeb3()` object, returned from the provider, was causing `web3` interaction in the case of `,eth.getCode()` to hang when using the `https://rpc.xdaichain.com/oe-only/` RPC.

This fix facilitates switching back to the OE RPC for Gnosis Chain instead. This fixes the gas estimation issue. The `isSmartContractWallet()` tweak fixes the WalletConnect issue which made us migrate RPC in the first place.

## How to test it
- Use the temporary Gnosis Chain on the staging CGW (it has a different RPC than on prod.)
- Test that estimations do not fail on < 1.3.0 Safes on Gnosis Chain
- Test that Safe-Safe WC works, setting the `smartContractWallet` flag correctly in the `providers` store

## Before release
- Change the Gnosis Chain RPC back to `https://rpc.xdaichain.com/oe-only/`