### PR TITLE
fix: show user as confirmer for immediately executed transactions

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxOwners.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxOwners.tsx
@@ -20,6 +20,7 @@ import { black300, gray500, primary400, red400, orange500 } from 'src/theme/vari
 import { currentSafe } from 'src/logic/safe/store/selectors'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { addressBookName } from 'src/logic/addressBook/store/selectors'
+import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 
 // Icons
 
@@ -141,9 +142,10 @@ export const TxOwners = ({
 
   const [hideConfirmations, setHideConfirmations] = useState<boolean>(shouldHideConfirmations(detailedExecutionInfo))
 
-  const { threshold, address } = useSelector(currentSafe)
+  const { threshold } = useSelector(currentSafe)
+  const account = useSelector(userAccountSelector)
   const chainId = useSelector(currentChainId)
-  const safeName = useSelector((state) => addressBookName(state, { address, chainId }))
+  const name = useSelector((state) => addressBookName(state, { address: account, chainId }))
 
   const toggleHide = () => {
     setHideConfirmations((prev) => !prev)
@@ -181,7 +183,7 @@ export const TxOwners = ({
       </StyledStep>
       {!hideConfirmations &&
         (isImmediateExecution
-          ? getConfirmationStep({ value: address, name: safeName, logoUri: null })
+          ? getConfirmationStep({ value: account, name, logoUri: null })
           : detailedExecutionInfo.confirmations.map(({ signer }) => getConfirmationStep(signer, signer.value)))}
       {detailedExecutionInfo.confirmations.length > 0 && (
         <StyledStep state="confirmed">


### PR DESCRIPTION
## What it solves
Incorrect confirmation details on immediately executed transactions

## How this PR fixes it
The user account details are not shown at the confirmer on transactions that are created and executed immediately.

We do not receive details of the confirmations/executor from backend when immediate execution occurs. This instance renders a 'mimicked' Stepper and the Safe name was being shown as the confirmer, not the current user.

## How to test it
- Create and immediately execute a transaction on a 1/? Safe
- Observe that the confirmations (1) is that of the current user w/ name, not the Safe

![image](https://user-images.githubusercontent.com/20442784/153433618-a3811ba3-c63c-414e-8761-f2622e20d1b2.png)