### PR TITLE
fix: Add form validation for max priority fee

### DIFF
--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -12,7 +12,7 @@ import Row from 'src/components/layout/Row'
 import { styles } from './style'
 import GnoForm from 'src/components/forms/GnoForm'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
-import { minValue } from 'src/components/forms/validator'
+import { composeValidators, maxValue, minValue } from 'src/components/forms/validator'
 import { Modal } from 'src/components/Modal'
 import {
   ParametersStatus,
@@ -75,7 +75,7 @@ const formValidation = (values: Record<keyof TxParameters, string>): Record<stri
 
   const ethGasPriceValidation = minValue(0, true)(ethGasPrice)
 
-  const ethMaxPrioFeeValidation = minValue(0, true)(ethMaxPrioFee)
+  const ethMaxPrioFeeValidation = composeValidators(minValue(0, true), maxValue(ethGasPrice))(ethMaxPrioFee)
 
   const ethNonceValidation = minValue(0, true)(ethNonce)
 


### PR DESCRIPTION
## What it solves
Resolves #3464 

## How this PR fixes it
Extends the form validation to compare `ethMaxPrioFee` against `ethGasPrice`.

## How to test it

1. Open the safe
2. Create a pre EIP-1559 transaction
3. Change `Max fee per gas` and observe that the form can be saved
4. Create a post EIP-1559 transaction
5. Change `Max priority fee per gas` to be higher than `Max fee per gas`
6. Observe that there is a validation error

## Screenshots
<img width="525" alt="Screenshot 2022-02-11 at 09 10 19" src="https://user-images.githubusercontent.com/5880855/153557171-958d92ed-70bc-4a8e-9b99-42d8cf89ca17.png">

