### PR TITLE
Feature: desktop localstorage migration

### DIFF
--- a/.github/workflows/release-mainnet-desktop.yml
+++ b/.github/workflows/release-mainnet-desktop.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       max-parallel: 15
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
+        os: [macos-10.15, windows-latest, ubuntu-18.04]
 
     steps:
       - name: Check out Git repository
@@ -70,18 +70,18 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Desktop OSX
-          path: ./dist/Safe[ ]Multisig*.dmg
+          path: ./dist/Safe*.dmg
 
       - name: 'Upload Artifacts Linux'
         if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v2
         with:
           name: Desktop Linux
-          path: ./dist/Safe[ ]Multisig*.AppImage
+          path: ./dist/Safe*.AppImage
 
       - name: 'Upload Artifacts Windows'
         if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v2
         with:
           name: Desktop Windows
-          path: ./dist/Safe[ ]Multisig*.exe
+          path: ./dist/Safe*.exe

--- a/.github/workflows/release-mainnet-desktop.yml
+++ b/.github/workflows/release-mainnet-desktop.yml
@@ -17,11 +17,16 @@ jobs:
       fail-fast: false
       max-parallel: 15
       matrix:
-        os: [macos-10.15, windows-latest, ubuntu-18.04]
+        os: [macos-10.15, windows-2019, ubuntu-18.04]
 
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
 
       # Linux build patches
       - name: Install linux dependencies
@@ -33,11 +38,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
 
       - name: Run yarn install
         run: yarn install --frozen-lockfile --network-timeout 1000000

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@gnosis.pm/safe-core-sdk": "^1.1.1",
     "@gnosis.pm/safe-deployments": "^1.5.0",
     "@gnosis.pm/safe-react-components": "^0.9.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "2.7.5",
+    "@gnosis.pm/safe-react-gateway-sdk": "2.8.1",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.20.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "@gnosis.pm/safe-apps-sdk": "6.1.0",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^1.1.1",
-    "@gnosis.pm/safe-deployments": "^1.5.0",
+    "@gnosis.pm/safe-deployments": "^1.8.0",
     "@gnosis.pm/safe-react-components": "^0.9.0",
     "@gnosis.pm/safe-react-gateway-sdk": "2.8.1",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.20.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "cross-env REACT_APP_APP_VERSION=$npm_package_version rescripts --max-old-space-size=8192 build",
     "compile-electron": "tsc --project tsconfig.electron.json",
     "eject": "rescripts eject",
-    "electron-build": "yarn compile-electron && electron-builder --windows",
+    "electron-build": "yarn compile-electron && electron-builder --mac",
     "electron-dev": "yarn compile-electron && concurrently \"cross-env BROWSER=none REACT_APP_BUILD_FOR_DESKTOP=true yarn start\" \"wait-on http://localhost:3000 && electron .\"",
     "format:staged": "lint-staged",
     "generate-types": "yarn generate-types:spendingLimit && yarn generate-types:safeDeployments && yarn generate-types:erc20 && yarn generate-types:erc721",
@@ -72,7 +72,7 @@
       "!src/**/assets/**"
     ]
   },
-  "productName": "Safe",
+  "productName": "Safe Multisig",
   "build": {
     "appId": "io.gnosis.safe",
     "afterSign": "scripts/notarize.js",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,7 +8,6 @@ import {
 } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import {
-  GATEWAY_URL,
   DEFAULT_CHAIN_ID,
   ETHERSCAN_API_KEY,
   INFURA_TOKEN,

--- a/src/logic/safe/api/fetchSafeApps.ts
+++ b/src/logic/safe/api/fetchSafeApps.ts
@@ -4,5 +4,7 @@ import { _getChainId } from 'src/config'
 import { GATEWAY_URL } from 'src/utils/constants'
 
 export const fetchSafeAppsList = async (): Promise<SafeAppData[]> => {
-  return getSafeApps(GATEWAY_URL, _getChainId())
+  return getSafeApps(GATEWAY_URL, _getChainId(), {
+    client_url: window.location.origin,
+  })
 }

--- a/src/logic/wallets/utils/walletList.ts
+++ b/src/logic/wallets/utils/walletList.ts
@@ -74,7 +74,8 @@ const wallets = (): Wallet[] => {
 export const getSupportedWallets = (): WalletInitOptions[] => {
   if (window.isDesktop) {
     return wallets()
-      .filter((wallet) => wallet.desktop)
+      .filter(({ desktop }) => desktop)
+      .filter(({ walletName }) => !getDisabledWallets().includes(walletName))
       .map(({ desktop, ...rest }) => rest)
   }
 

--- a/src/routes/safe/components/Apps/components/AppCard/index.stories.tsx
+++ b/src/routes/safe/components/Apps/components/AppCard/index.stories.tsx
@@ -1,3 +1,4 @@
+import { SafeAppAccessPolicyTypes } from '@gnosis.pm/safe-react-gateway-sdk'
 import { FETCH_STATUS } from 'src/utils/requests'
 import { getEmptySafeApp } from '../../utils'
 import { AppCard, AddCustomAppCard } from './index'
@@ -22,6 +23,9 @@ export const LoadedApp = (): React.ReactElement => (
       description: 'Gnosis safe app',
       fetchStatus: FETCH_STATUS.SUCCESS,
       chainIds: ['4'],
+      accessControl: {
+        type: SafeAppAccessPolicyTypes.NoRestrictions,
+      },
     }}
   />
 )

--- a/src/routes/safe/components/Apps/components/AppsList.test.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.test.tsx
@@ -1,10 +1,12 @@
-import AppsList, { PINNED_APPS_LIST_TEST_ID, ALL_APPS_LIST_TEST_ID } from './AppsList'
-import { render, screen, fireEvent, within, act, waitFor } from 'src/utils/test-utils'
+import { SafeAppAccessPolicyTypes } from '@gnosis.pm/safe-react-gateway-sdk'
 
+import { render, screen, fireEvent, within, act, waitFor } from 'src/utils/test-utils'
 import * as appUtils from 'src/routes/safe/components/Apps/utils'
 import { FETCH_STATUS } from 'src/utils/requests'
 import { loadFromStorage, saveToStorage } from 'src/utils/storage'
 import * as googleAnalytics from 'src/utils/googleAnalytics'
+
+import AppsList, { PINNED_APPS_LIST_TEST_ID, ALL_APPS_LIST_TEST_ID } from './AppsList'
 
 jest.mock('src/routes/routes', () => {
   const original = jest.requireActual('src/routes/routes')
@@ -30,6 +32,9 @@ jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
         fetchStatus: 'SUCCESS',
         chainIds: ['1', '4'],
         provider: null,
+        accessControl: {
+          type: 'NO_RESTRICTIONS',
+        },
       },
       {
         id: 3,
@@ -41,6 +46,10 @@ jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
         fetchStatus: 'SUCCESS',
         chainIds: ['1', '4'],
         provider: null,
+        accessControl: {
+          type: 'DOMAIN_ALLOWLIST',
+          value: ['https://gnosis-safe.io'],
+        },
       },
       {
         id: 14,
@@ -51,6 +60,9 @@ jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
         fetchStatus: 'SUCCESS',
         chainIds: ['1', '4'],
         provider: null,
+        accessControl: {
+          type: 'NO_RESTRICTIONS',
+        },
       },
       {
         id: 24,
@@ -61,6 +73,10 @@ jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
         fetchStatus: 'SUCCESS',
         chainIds: ['1', '4', '56', '100', '137', '246', '73799'],
         provider: null,
+        accessControl: {
+          type: 'DOMAIN_ALLOWLIST',
+          value: ['https://gnosis-safe.io'],
+        },
       },
     ]),
 }))
@@ -92,6 +108,9 @@ beforeEach(() => {
       chainIds: ['4'],
       provider: undefined,
       fetchStatus: FETCH_STATUS.SUCCESS,
+      accessControl: {
+        type: SafeAppAccessPolicyTypes.NoRestrictions,
+      },
     }),
   )
 })

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -4,6 +4,7 @@ import memoize from 'lodash/memoize'
 import { getContentFromENS } from 'src/logic/wallets/getWeb3'
 import appsIconSvg from 'src/assets/icons/apps.svg'
 import { FETCH_STATUS } from 'src/utils/requests'
+import { SafeAppAccessPolicyTypes } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { SafeApp } from './types'
 
@@ -47,6 +48,9 @@ export const getEmptySafeApp = (url = ''): SafeApp => {
     description: '',
     fetchStatus: FETCH_STATUS.LOADING,
     chainIds: [],
+    accessControl: {
+      type: SafeAppAccessPolicyTypes.NoRestrictions,
+    },
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,10 +2163,10 @@
     react-media "^1.10.0"
     web3-utils "^1.6.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@2.7.5":
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.7.5.tgz#5640fc8c3972397ea1135f1e552d0c3333acb8fa"
-  integrity sha512-kY2aOLqfm9fxZbeMa8JkyKr7S3RYdxL/B0n2rU2fRAoPULleq+a6wZ2Y+zHC+XrHpjsNi6QIA183apP+XcRYIQ==
+"@gnosis.pm/safe-react-gateway-sdk@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.1.tgz#3ed166fb49fa19837c9ce8d9ba4f29a14755e9c4"
+  integrity sha512-J6gJT6sbXvEPqhrWepEEgwYseo4UVUU3wNS9GNIpGMuh0zi7ZU0Gld+yXqSAoZWtS3hCntg7lyuM8W31AEjQLQ==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,10 +2150,15 @@
     "@gnosis.pm/safe-deployments" "^1.4.0"
     ethereumjs-util "^7.1.3"
 
-"@gnosis.pm/safe-deployments@^1.4.0", "@gnosis.pm/safe-deployments@^1.5.0":
+"@gnosis.pm/safe-deployments@^1.4.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.5.0.tgz#5e01ccc2e2d78bf91ecb4453a64d1cac3a5ba2d6"
   integrity sha512-IDU7I+IQr1zUU94/uD8shDVI+/nUA1unQUg8jtbTG0YGcmm49Lu8G01rqtWt2mhLxZWzFsgbLWGnU+/BzUqk7g==
+
+"@gnosis.pm/safe-deployments@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.8.0.tgz#856c15517274f924539ea4df40fffe6f009249a7"
+  integrity sha512-xK2ZZXxCEGOw+6UZAeUmvqE/4C/XTpYmv1a8KzKUgSOxcGkHsIDqcjdKjqif7gOdnwHl4+XXJUtDQEuSLT4Scg==
 
 "@gnosis.pm/safe-react-components@^0.9.0":
   version "0.9.0"


### PR DESCRIPTION
## What it solves
Resolves #3379 
Cherry-picks #2672 

## How this PR fixes it
It turned out that we don't need a migration script, but we had to change `productName` in package.json to match the old name, so it uses the same cache folder

## How to test it
1. Download app 3.8.4 from https://gnosis-safe.io
2. Load safes, add things to address book, etc
3. Build a new app from this PR:
```
yarn build-desktop && yarn electron-build
```
4. Install it from `dist` folder and check that all the content from an old app is there

# ⚠️ Question ⚠️ 
Do I merge it to the `electron` branch or we should create a new one for the release? 