### PR TITLE
Fix: undefined address in reverse ENS lookup

### DIFF
--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -120,7 +120,7 @@ export const getAddressFromDomain = (name: string): Promise<string> => {
 }
 
 export const reverseENSLookup = async (address: string): Promise<string> => {
-  if (!hasFeature(FEATURES.DOMAIN_LOOKUP)) {
+  if (!address || !hasFeature(FEATURES.DOMAIN_LOOKUP)) {
     return ''
   }
 

--- a/src/routes/CreateSafePage/steps/NameNewSafeStep.tsx
+++ b/src/routes/CreateSafePage/steps/NameNewSafeStep.tsx
@@ -42,14 +42,16 @@ function NameNewSafeStep(): ReactElement {
       const formValues = createNewSafeForm.getState().values
       const owners = formValues[FIELD_SAFE_OWNERS_LIST]
       const ownersWithENSName = await Promise.all(
-        owners.map(async ({ addressFieldName }) => {
-          const address = formValues[addressFieldName]
-          const ensName = await reverseENSLookup(address)
-          return {
-            address,
-            name: ensName,
-          }
-        }),
+        owners
+          .filter(({ addressFieldName }) => !!formValues[addressFieldName])
+          .map(async ({ addressFieldName }) => {
+            const address = formValues[addressFieldName]
+            const ensName = await reverseENSLookup(address)
+            return {
+              address,
+              name: ensName,
+            }
+          }),
       )
 
       const ownersWithENSNameRecord = ownersWithENSName.reduce<Record<string, string>>((acc, { address, name }) => {


### PR DESCRIPTION
## What it solves
Resolves #3507

## How this PR fixes it
Just a quick fix that checks that the address isn't undefined.

I couldn't reproduce the error from Sentry. We actually don't allow empty addresses.
But this should fix it.

## How to test it
Try creating a Safe with several owners, some of which are ENS owners.