### PR TITLE
style: remove row-gap overwritting style in MuiAccordion

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -96,12 +96,6 @@ export const StyledTransactions = styled.div`
     &:last-child {
       border-bottom: none;
     }
-
-    &:last-of-type {
-      div {
-        row-gap: 0;
-      }
-    }
   }
 `
 


### PR DESCRIPTION
## What it solves
Resolves #3509

## How this PR fixes it
Removes style that was suppressing row-gap in the last MUI accordion for no apparent reason

## How to test it
Open a transaction deeplink view and the layout shall not be cramped anymore.

## Screenshots
![Screen Shot 2022-02-15 at 14 55 52](https://user-images.githubusercontent.com/32431609/154088119-64747a27-12d4-4deb-bfc6-f36974fe3834.png)

