### PR TITLE
Fix: suggest upgrading Safe in the estimation error message

### DIFF
--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -6,10 +6,12 @@ import Img from 'src/components/layout/Img'
 import InfoIcon from 'src/assets/icons/info_red.svg'
 
 import { useSelector } from 'react-redux'
-import { currentSafeThreshold } from 'src/logic/safe/store/selectors'
+import { currentSafeCurrentVersion, currentSafeThreshold } from 'src/logic/safe/store/selectors'
 import { shouldSwitchWalletChain } from 'src/logic/wallets/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
+import { hasFeature } from 'src/logic/safe/utils/safeVersion'
+import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 const styles = createStyles({
   executionWarningRow: {
@@ -38,6 +40,7 @@ export const TransactionFailText = ({
   const threshold = useSelector(currentSafeThreshold)
   const isWrongChain = useSelector(shouldSwitchWalletChain)
   const isGranted = useSelector(grantedSelector)
+  const safeVersion = useSelector(currentSafeCurrentVersion)
 
   if (estimationStatus !== EstimationStatus.FAILURE && !(isCreation && !isGranted)) {
     return null
@@ -54,8 +57,14 @@ export const TransactionFailText = ({
   const defaultMsg = `This transaction will most likely fail. ${errorDesc}`
   const notOwnerMsg = `You are currently not an owner of this Safe and won't be able to submit this transaction.`
   const wrongChainMsg = 'Your wallet is connected to the wrong chain.'
+  const updateSafeMessage = `This transaction will most likely fail. Please consider updating your Safe version (Settings → Safe Details → Update Safe).`
 
-  const error = isGranted ? defaultMsg : isWrongChain ? wrongChainMsg : isCreation ? notOwnerMsg : defaultMsg
+  let error = isGranted ? defaultMsg : isWrongChain ? wrongChainMsg : isCreation ? notOwnerMsg : defaultMsg
+
+  // For legacy Safes, esp. on Gnosis Chain
+  if (estimationStatus === EstimationStatus.FAILURE && !hasFeature(FEATURES.SAFE_TX_GAS_OPTIONAL, safeVersion)) {
+    error = updateSafeMessage
+  }
 
   return (
     <Row align="center">


### PR DESCRIPTION
## What it solves
Resolves #3510

## How this PR fixes it
The toot cause is a too-low gas estimation with the public xDai RPC on 1.1.1 Safes.
This PR doesn't fix the root cause, but it urges users to upgrade their pre-1.3.0 Safes when gas estimation fails.

## How to test it
Make a tx on a 1.1.1 xDai Safe. It will likely fail due to a wrong gas estimation.

## Screenshots
<img width="479" alt="Screenshot 2022-02-15 at 16 00 53" src="https://user-images.githubusercontent.com/381895/154089229-6abe1d32-2877-4d92-b342-ee2d77d1e452.png">

