### PR TITLE
feat: Cookies and privacy policy

### DIFF
--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -88,7 +88,7 @@ const Sidebar = ({
       dispatch(openCookieBanner({ cookieBannerOpen: true }))
       return
     }
-    if (!cookiesState.acceptedAnalytics) {
+    if (!cookiesState.acceptedSupportAndUpdates) {
       dispatch(
         openCookieBanner({
           cookieBannerOpen: true,
@@ -129,7 +129,7 @@ const Sidebar = ({
         <HelpList>
           <StyledListItem id="whats-new-button" button onClick={handleClick}>
             <ListIcon type="gift" />
-            <StyledListItemText>Whats new</StyledListItemText>
+            <StyledListItemText>What&apos;s new</StyledListItemText>
           </StyledListItem>
 
           <HelpCenterLink href="https://help.gnosis-safe.io/en/" target="_blank" title="Help Center of Gnosis Safe">

--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -88,8 +88,13 @@ const Sidebar = ({
       dispatch(openCookieBanner({ cookieBannerOpen: true }))
       return
     }
-    if (!cookiesState.acceptedIntercom) {
-      dispatch(openCookieBanner({ cookieBannerOpen: true, intercomAlertDisplayed: true }))
+    if (!cookiesState.acceptedAnalytics) {
+      dispatch(
+        openCookieBanner({
+          cookieBannerOpen: true,
+          cookiesAlertMessageProps: { clickedLabel: "What's New", cookieType: 'analytics cookies' },
+        }),
+      )
     }
   }
 

--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -10,7 +10,7 @@ import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import ListIcon from 'src/components/List/ListIcon'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { loadFromCookie } from 'src/logic/cookies/utils'
-import { COOKIES_KEY, BannerCookiesType, warningProps } from 'src/logic/cookies/model/cookie'
+import { COOKIES_KEY, BannerCookiesType, COOKIE_IDS } from 'src/logic/cookies/model/cookie'
 
 const StyledDivider = styled(Divider)`
   margin: 16px -8px 0;
@@ -92,7 +92,7 @@ const Sidebar = ({
       dispatch(
         openCookieBanner({
           cookieBannerOpen: true,
-          cookiesAlertMessageProps: warningProps.whatsNew,
+          key: COOKIE_IDS.BEAMER,
         }),
       )
     }

--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -10,7 +10,7 @@ import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import ListIcon from 'src/components/List/ListIcon'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { loadFromCookie } from 'src/logic/cookies/utils'
-import { COOKIES_KEY, BannerCookiesType } from 'src/logic/cookies/model/cookie'
+import { COOKIES_KEY, BannerCookiesType, warningProps } from 'src/logic/cookies/model/cookie'
 
 const StyledDivider = styled(Divider)`
   margin: 16px -8px 0;
@@ -92,7 +92,7 @@ const Sidebar = ({
       dispatch(
         openCookieBanner({
           cookieBannerOpen: true,
-          cookiesAlertMessageProps: { clickedLabel: "What's New", cookieType: 'analytics cookies' },
+          cookiesAlertMessageProps: warningProps.whatsNew,
         }),
       )
     }

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -5,7 +5,7 @@ import { ReactElement, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import Button from 'src/components/layout/Button'
 import Link from 'src/components/layout/Link'
-import { COOKIES_KEY, BannerCookiesType } from 'src/logic/cookies/model/cookie'
+import { COOKIES_KEY, BannerCookiesType, warningProps } from 'src/logic/cookies/model/cookie'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { cookieBannerOpen } from 'src/logic/cookies/store/selectors'
 import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
@@ -294,10 +294,7 @@ const CookiesBanner = (): ReactElement => {
             dispatch.current(
               openCookieBanner({
                 cookieBannerOpen: true,
-                cookiesAlertMessageProps: {
-                  clickedLabel: 'customer support chat',
-                  cookieType: 'customer support cookie',
-                },
+                cookiesAlertMessageProps: warningProps.customerSupport,
               }),
             )
           }

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -102,7 +102,7 @@ const CookiesBanner = (): ReactElement => {
   const [showIntercom, setShowIntercom] = useState(false)
   const [localNecessary, setLocalNecessary] = useState(true)
   const [localAnalytics, setLocalAnalytics] = useState(false)
-  const [localIntercom, setLocalIntercom] = useState(false)
+  const [localSupportAndUpdates, setLocalSupportAndUpdates] = useState(false)
   const { getAppUrl } = useSafeAppUrl()
   const beamerScriptRef = useRef<HTMLScriptElement>()
 
@@ -113,6 +113,10 @@ const CookiesBanner = (): ReactElement => {
   useEffect(() => {
     if (showIntercom && !isSafeAppView) {
       loadIntercom()
+
+      // For use in non-webapps (Mobile and Desktop)
+      // https://www.getbeamer.com/help/how-to-install-beamer-using-our-api
+      loadBeamer(beamerScriptRef)
     }
   }, [showIntercom, isSafeAppView])
 
@@ -128,32 +132,28 @@ const CookiesBanner = (): ReactElement => {
       if (!cookiesState) {
         dispatch(openCookieBanner({ cookieBannerOpen: true }))
       } else {
-        const { acceptedIntercom, acceptedAnalytics, acceptedNecessary } = cookiesState
-        if (acceptedIntercom === undefined) {
+        const { acceptedSupportAndUpdates, acceptedAnalytics, acceptedNecessary } = cookiesState
+        if (acceptedSupportAndUpdates === undefined) {
           const newState = {
             acceptedNecessary,
             acceptedAnalytics,
-            acceptedIntercom: acceptedAnalytics,
+            acceptedSupportAndUpdates: acceptedAnalytics,
           }
           const cookieConfig: CookieAttributes = {
             expires: acceptedAnalytics ? 365 : 7,
           }
           await saveCookie<BannerCookiesType>(COOKIES_KEY, newState, cookieConfig)
-          setLocalIntercom(newState.acceptedIntercom)
-          setShowIntercom(newState.acceptedIntercom)
+          setLocalSupportAndUpdates(newState.acceptedSupportAndUpdates)
+          setShowIntercom(newState.acceptedSupportAndUpdates)
         } else {
-          setLocalIntercom(acceptedIntercom)
-          setShowIntercom(acceptedIntercom)
+          setLocalSupportAndUpdates(acceptedSupportAndUpdates)
+          setShowIntercom(acceptedSupportAndUpdates)
         }
         setLocalAnalytics(acceptedAnalytics)
         setLocalNecessary(acceptedNecessary)
 
         if (acceptedAnalytics && !isDesktop) {
           loadGoogleAnalytics()
-
-          // For use in non-webapps (Mobile and Desktop)
-          // https://www.getbeamer.com/help/how-to-install-beamer-using-our-api
-          loadBeamer(beamerScriptRef)
         }
       }
     }
@@ -164,7 +164,7 @@ const CookiesBanner = (): ReactElement => {
     const newState = {
       acceptedNecessary: true,
       acceptedAnalytics: !isDesktop,
-      acceptedIntercom: true,
+      acceptedSupportAndUpdates: true,
     }
     const cookieConfig: CookieAttributes = {
       expires: 365,
@@ -179,22 +179,24 @@ const CookiesBanner = (): ReactElement => {
     const newState = {
       acceptedNecessary: true,
       acceptedAnalytics: localAnalytics,
-      acceptedIntercom: localIntercom,
+      acceptedSupportAndUpdates: localSupportAndUpdates,
     }
     const cookieConfig: CookieAttributes = {
       expires: localAnalytics ? 365 : 7,
     }
     await saveCookie<BannerCookiesType>(COOKIES_KEY, newState, cookieConfig)
     setShowAnalytics(localAnalytics)
-    setShowIntercom(localIntercom)
+    setShowIntercom(localSupportAndUpdates)
 
     if (!localAnalytics) {
       removeCookies()
-      closeBeamer(beamerScriptRef)
     }
 
-    if (!localIntercom && isIntercomLoaded()) {
-      closeIntercom()
+    if (!localSupportAndUpdates) {
+      closeBeamer(beamerScriptRef)
+      if (isIntercomLoaded()) {
+        closeIntercom()
+      }
     }
     dispatch(closeCookieBanner())
   }
@@ -232,11 +234,11 @@ const CookiesBanner = (): ReactElement => {
             </div>
             <div className={classes.formItem}>
               <FormControlLabel
-                control={<Checkbox checked={localIntercom} />}
-                label="Customer support"
-                name="Customer support"
-                onChange={() => setLocalIntercom((prev) => !prev)}
-                value={localIntercom}
+                control={<Checkbox checked={localSupportAndUpdates} />}
+                label="Community support & updates"
+                name="Community support & updates"
+                onChange={() => setLocalSupportAndUpdates((prev) => !prev)}
+                value={localSupportAndUpdates}
               />
             </div>
             <div className={classes.formItem}>

--- a/src/logic/cookies/model/cookie.ts
+++ b/src/logic/cookies/model/cookie.ts
@@ -8,7 +8,7 @@ export enum COOKIE_IDS {
 
 export const COOKIE_ALERTS: Record<COOKIE_IDS, string> = {
   INTERCOM: 'You attempted to open the customer support chat. Please accept the customer support cookie',
-  BEAMER: "You attempted to open the What's New. Please accept the analytics cookies.",
+  BEAMER: "You attempted to open the What's New section. Please accept the analytics cookies.",
 }
 
 export type BannerCookiesType = {

--- a/src/logic/cookies/model/cookie.ts
+++ b/src/logic/cookies/model/cookie.ts
@@ -7,13 +7,13 @@ export enum COOKIE_IDS {
 }
 
 export const COOKIE_ALERTS: Record<COOKIE_IDS, string> = {
-  INTERCOM: 'You attempted to open the customer support chat. Please accept the customer support cookie',
-  BEAMER: "You attempted to open the What's New section. Please accept the analytics cookies.",
+  INTERCOM: 'You attempted to open the customer support chat. Please accept the community support & updates cookies',
+  BEAMER: "You attempted to open the What's New section. Please accept the community support & updates cookies.",
 }
 
 export type BannerCookiesType = {
   acceptedNecessary: boolean
-  acceptedIntercom: boolean
+  acceptedSupportAndUpdates: boolean
   acceptedAnalytics: boolean
 }
 export type IntercomCookieType = {

--- a/src/logic/cookies/model/cookie.ts
+++ b/src/logic/cookies/model/cookie.ts
@@ -1,3 +1,16 @@
+export const COOKIES_KEY = 'COOKIES'
+export const COOKIES_KEY_INTERCOM = `${COOKIES_KEY}_INTERCOM`
+
+export enum COOKIE_IDS {
+  INTERCOM = 'INTERCOM',
+  BEAMER = 'BEAMER',
+}
+
+export const COOKIE_ALERTS: Record<COOKIE_IDS, string> = {
+  INTERCOM: 'You attempted to open the customer support chat. Please accept the customer support cookie',
+  BEAMER: "You attempted to open the What's New. Please accept the analytics cookies.",
+}
+
 export type BannerCookiesType = {
   acceptedNecessary: boolean
   acceptedIntercom: boolean
@@ -5,20 +18,4 @@ export type BannerCookiesType = {
 }
 export type IntercomCookieType = {
   userId: string
-}
-export const COOKIES_KEY = 'COOKIES'
-export const COOKIES_KEY_INTERCOM = `${COOKIES_KEY}_INTERCOM`
-
-type cookiesWarningTypes = 'customerSupport' | 'whatsNew'
-type warningPropsType = {
-  clickedLabel: string
-  cookieType: string
-}
-
-export const warningProps: Record<cookiesWarningTypes, warningPropsType> = {
-  customerSupport: {
-    clickedLabel: 'customer support chat',
-    cookieType: 'customer support cookie',
-  },
-  whatsNew: { clickedLabel: "What's New", cookieType: 'analytics cookies' },
 }

--- a/src/logic/cookies/model/cookie.ts
+++ b/src/logic/cookies/model/cookie.ts
@@ -8,3 +8,17 @@ export type IntercomCookieType = {
 }
 export const COOKIES_KEY = 'COOKIES'
 export const COOKIES_KEY_INTERCOM = `${COOKIES_KEY}_INTERCOM`
+
+type cookiesWarningTypes = 'customerSupport' | 'whatsNew'
+type warningPropsType = {
+  clickedLabel: string
+  cookieType: string
+}
+
+export const warningProps: Record<cookiesWarningTypes, warningPropsType> = {
+  customerSupport: {
+    clickedLabel: 'customer support chat',
+    cookieType: 'customer support cookie',
+  },
+  whatsNew: { clickedLabel: "What's New", cookieType: 'analytics cookies' },
+}

--- a/src/logic/cookies/store/actions/openCookieBanner.ts
+++ b/src/logic/cookies/store/actions/openCookieBanner.ts
@@ -2,6 +2,10 @@ import { createAction } from 'redux-actions'
 
 import { OpenCookieBannerPayload } from 'src/logic/cookies/store/reducer/cookies'
 
-export const OPEN_COOKIE_BANNER = 'OPEN_COOKIE_BANNER'
+export enum COOKIE_ACTIONS {
+  OPEN_BANNER = 'cookies/openCookieBanner',
+  CLOSE_BANNER = 'cookies/closeCookieBanner',
+}
 
-export const openCookieBanner = createAction<OpenCookieBannerPayload>(OPEN_COOKIE_BANNER)
+export const openCookieBanner = createAction<OpenCookieBannerPayload>(COOKIE_ACTIONS.OPEN_BANNER)
+export const closeCookieBanner = createAction(COOKIE_ACTIONS.CLOSE_BANNER)

--- a/src/logic/cookies/store/reducer/cookies.ts
+++ b/src/logic/cookies/store/reducer/cookies.ts
@@ -1,27 +1,32 @@
-import { Map } from 'immutable'
 import { handleActions } from 'redux-actions'
-import { OPEN_COOKIE_BANNER } from 'src/logic/cookies/store/actions/openCookieBanner'
+
+import { COOKIE_IDS } from 'src/logic/cookies/model/cookie'
+import { COOKIE_ACTIONS } from 'src/logic/cookies/store/actions/openCookieBanner'
 
 export const COOKIES_REDUCER_ID = 'cookies'
 
-type CookieState = Map<string, any>
-
-export type OpenCookieBannerPayload = {
+export type CookieState = {
   cookieBannerOpen: boolean
-  cookiesAlertMessageProps?: {
-    clickedLabel: string
-    cookieType: string
-  }
+  key?: COOKIE_IDS
 }
+
+const initialState: CookieState = {
+  cookieBannerOpen: false,
+  key: undefined,
+}
+
+export type OpenCookieBannerPayload = CookieState
 
 const cookiesReducer = handleActions<CookieState, OpenCookieBannerPayload>(
   {
-    [OPEN_COOKIE_BANNER]: (state, action) => {
-      const { cookieBannerOpen, cookiesAlertMessageProps } = action.payload
-      return state.set('cookieBannerOpen', { cookieBannerOpen, cookiesAlertMessageProps })
+    [COOKIE_ACTIONS.OPEN_BANNER]: (_, action) => {
+      return action.payload
+    },
+    [COOKIE_ACTIONS.CLOSE_BANNER]: () => {
+      return initialState
     },
   },
-  Map(),
+  initialState,
 )
 
 export default cookiesReducer

--- a/src/logic/cookies/store/reducer/cookies.ts
+++ b/src/logic/cookies/store/reducer/cookies.ts
@@ -6,13 +6,19 @@ export const COOKIES_REDUCER_ID = 'cookies'
 
 type CookieState = Map<string, any>
 
-export type OpenCookieBannerPayload = { cookieBannerOpen: boolean; intercomAlertDisplayed?: boolean }
+export type OpenCookieBannerPayload = {
+  cookieBannerOpen: boolean
+  cookiesAlertMessageProps?: {
+    clickedLabel: string
+    cookieType: string
+  }
+}
 
 const cookiesReducer = handleActions<CookieState, OpenCookieBannerPayload>(
   {
     [OPEN_COOKIE_BANNER]: (state, action) => {
-      const { intercomAlertDisplayed = false, cookieBannerOpen } = action.payload
-      return state.set('cookieBannerOpen', { intercomAlertDisplayed, cookieBannerOpen })
+      const { cookieBannerOpen, cookiesAlertMessageProps } = action.payload
+      return state.set('cookieBannerOpen', { cookieBannerOpen, cookiesAlertMessageProps })
     },
   },
   Map(),

--- a/src/logic/cookies/store/selectors/index.ts
+++ b/src/logic/cookies/store/selectors/index.ts
@@ -1,3 +1,4 @@
-import { COOKIES_REDUCER_ID } from 'src/logic/cookies/store/reducer/cookies'
+import { CookieState, COOKIES_REDUCER_ID } from 'src/logic/cookies/store/reducer/cookies'
+import { AppReduxState } from 'src/store'
 
-export const cookieBannerOpen = (state) => state[COOKIES_REDUCER_ID].get('cookieBannerOpen')
+export const cookieBannerState = (state: AppReduxState): CookieState => state[COOKIES_REDUCER_ID]

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,7 +10,7 @@ import {
   nftAssetReducer,
   nftTokensReducer,
 } from 'src/logic/collectibles/store/reducer/collectibles'
-import cookiesReducer, { COOKIES_REDUCER_ID } from 'src/logic/cookies/store/reducer/cookies'
+import cookiesReducer, { CookieState, COOKIES_REDUCER_ID } from 'src/logic/cookies/store/reducer/cookies'
 import currentSessionReducer, {
   CurrentSessionState,
   CURRENT_SESSION_REDUCER_ID,
@@ -112,7 +112,7 @@ export type AppReduxState = CombinedState<{
   [PENDING_TRANSACTIONS_ID]: PendingTransactionsState
   [NOTIFICATIONS_REDUCER_ID]: Map<string, Notification>
   [CURRENCY_REDUCER_ID]: CurrencyValuesState
-  [COOKIES_REDUCER_ID]: Map<string, any>
+  [COOKIES_REDUCER_ID]: CookieState
   [ADDRESS_BOOK_REDUCER_ID]: AddressBookState
   [CURRENT_SESSION_REDUCER_ID]: CurrentSessionState
   [CONFIG_REDUCER_ID]: ConfigState


### PR DESCRIPTION
## What it solves
Resolves #3473

## How this PR fixes it
Adds Beamer cookies under the analytics category.
Displays a warning on trying to open the Beamer drawer without the cookies consent.

## How to test it
Open the Cookies preferences in the Welcome Page footer and toggle the "Analytics"
- If "Analytics" cookies accepted, the sidebar "What's New" button will open the Beamer drawer
- If "Analytics" cookies is not accepted, the sidebar "What's New" button will prompt the Cookies Banner

## Analytics changes

## Screenshots
<img width="1243" alt="Screen Shot 2022-02-15 at 19 36 35" src="https://user-images.githubusercontent.com/32431609/154135871-ec1f04f5-9ba4-4b08-84f8-42be9a7a2f5c.png">

