### PR TITLE
Fix: error message on confirmation

### DIFF
--- a/src/components/TransactionFailText/index.test.tsx
+++ b/src/components/TransactionFailText/index.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, act } from 'src/utils/test-utils'
+import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
+import { TransactionFailText, _ErrorMessage } from '.'
+
+jest.mock('src/logic/wallets/store/selectors', () => {
+  const original = jest.requireActual('src/logic/wallets/store/selectors')
+  return {
+    ...original,
+    shouldSwitchWalletChain: () => false,
+  }
+})
+
+jest.mock('src/routes/safe/container/selector', () => {
+  const original = jest.requireActual('src/routes/safe/container/selector')
+  return {
+    ...original,
+    grantedSelector: () => true,
+  }
+})
+
+describe('TransactionFailText', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('shows the create & execute error', async () => {
+    await act(async () => {
+      render(<TransactionFailText isExecution isCreation estimationStatus={EstimationStatus.FAILURE} />)
+    })
+
+    expect(screen.getByAltText('Info Tooltip')).toBeDefined()
+    expect(screen.getByText(`${_ErrorMessage.general} ${_ErrorMessage.creation}`)).toBeDefined()
+  })
+
+  it('shows the execution error when execution an existing tx', async () => {
+    await act(async () => {
+      render(<TransactionFailText isExecution isCreation={false} estimationStatus={EstimationStatus.FAILURE} />)
+    })
+
+    expect(screen.getByAltText('Info Tooltip')).toBeDefined()
+    expect(screen.getByText(`${_ErrorMessage.general} ${_ErrorMessage.execution}`)).toBeDefined()
+  })
+
+  it('shows a wrong chain error', async () => {
+    const sel = require('src/logic/wallets/store/selectors')
+    ;(sel.shouldSwitchWalletChain as jest.Mocked<unknown>) = jest.fn(() => true)
+
+    await act(async () => {
+      render(<TransactionFailText isExecution isCreation={false} estimationStatus={EstimationStatus.FAILURE} />)
+    })
+
+    expect(screen.getByAltText('Info Tooltip')).toBeDefined()
+    expect(screen.getByText(_ErrorMessage.wrongChain)).toBeDefined()
+  })
+
+  it('shows an owner error', async () => {
+    const sel = require('src/routes/safe/container/selector')
+    ;(sel.grantedSelector as jest.Mocked<unknown>) = jest.fn(() => false)
+
+    await act(async () => {
+      render(<TransactionFailText isExecution isCreation estimationStatus={EstimationStatus.FAILURE} />)
+    })
+
+    expect(screen.getByAltText('Info Tooltip')).toBeDefined()
+    expect(screen.getByText(_ErrorMessage.notOwner)).toBeDefined()
+  })
+
+  it('renders null if neither execution nor creation error', async () => {
+    await act(async () => {
+      render(<TransactionFailText isExecution={false} isCreation={false} estimationStatus={EstimationStatus.FAILURE} />)
+    })
+
+    expect(() => screen.getByAltText('Info Tooltip')).toThrow()
+  })
+
+  it('renders null if estimation status is not failure', async () => {
+    await act(async () => {
+      render(<TransactionFailText isExecution isCreation={false} estimationStatus={EstimationStatus.LOADING} />)
+    })
+
+    expect(() => screen.getByAltText('Info Tooltip')).toThrow()
+  })
+})

--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -45,7 +45,8 @@ export const TransactionFailText = ({
   const isWrongChain = useSelector(shouldSwitchWalletChain)
   const isOwner = useSelector(grantedSelector)
 
-  const showError = (isExecution && estimationStatus === EstimationStatus.FAILURE) || (isCreation && !isOwner)
+  const showError =
+    isWrongChain || (isExecution && estimationStatus === EstimationStatus.FAILURE) || (isCreation && !isOwner)
   if (!showError) return null
 
   const errorDesc = isCreation ? ErrorMessage.creation : ErrorMessage.execution

--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -43,16 +43,15 @@ export const TransactionFailText = ({
 }: TransactionFailTextProps): React.ReactElement | null => {
   const classes = useStyles()
   const isWrongChain = useSelector(shouldSwitchWalletChain)
-  const isGranted = useSelector(grantedSelector)
+  const isOwner = useSelector(grantedSelector)
 
-  if ((estimationStatus !== EstimationStatus.FAILURE || !isExecution) && !(isCreation && !isGranted)) {
-    return null
-  }
+  const showError = (isExecution && estimationStatus === EstimationStatus.FAILURE) || (isCreation && !isOwner)
+  if (!showError) return null
 
   const errorDesc = isCreation ? ErrorMessage.creation : ErrorMessage.execution
   const defaultMsg = `${ErrorMessage.general} ${errorDesc}`
 
-  const error = isWrongChain ? ErrorMessage.wrongChain : isCreation && !isGranted ? ErrorMessage.notOwner : defaultMsg
+  const error = isWrongChain ? ErrorMessage.wrongChain : isCreation && !isOwner ? ErrorMessage.notOwner : defaultMsg
 
   return (
     <Row align="center">

--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -10,7 +10,7 @@ import { shouldSwitchWalletChain } from 'src/logic/wallets/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
 
-enum ErroMessage {
+enum ErrorMessage {
   general = 'This transaction will most likely fail.',
   creation = 'To save gas costs, avoid creating the transaction.',
   execution = 'To save gas costs, reject this transaction.',
@@ -49,10 +49,10 @@ export const TransactionFailText = ({
     return null
   }
 
-  const errorDesc = isCreation ? ErroMessage.creation : ErroMessage.execution
-  const defaultMsg = `${ErroMessage.general} ${errorDesc}`
+  const errorDesc = isCreation ? ErrorMessage.creation : ErrorMessage.execution
+  const defaultMsg = `${ErrorMessage.general} ${errorDesc}`
 
-  const error = isWrongChain ? ErroMessage.wrongChain : isCreation && !isGranted ? ErroMessage.notOwner : defaultMsg
+  const error = isWrongChain ? ErrorMessage.wrongChain : isCreation && !isGranted ? ErrorMessage.notOwner : defaultMsg
 
   return (
     <Row align="center">
@@ -65,4 +65,4 @@ export const TransactionFailText = ({
 }
 
 // For tests
-export const _ErrorMessage = ErroMessage
+export const _ErrorMessage = ErrorMessage

--- a/src/components/TransactionFailText/index.tsx
+++ b/src/components/TransactionFailText/index.tsx
@@ -6,10 +6,17 @@ import Img from 'src/components/layout/Img'
 import InfoIcon from 'src/assets/icons/info_red.svg'
 
 import { useSelector } from 'react-redux'
-import { currentSafeThreshold } from 'src/logic/safe/store/selectors'
 import { shouldSwitchWalletChain } from 'src/logic/wallets/store/selectors'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
+
+enum ErroMessage {
+  general = 'This transaction will most likely fail.',
+  creation = 'To save gas costs, avoid creating the transaction.',
+  execution = 'To save gas costs, reject this transaction.',
+  notOwner = `You are currently not an owner of this Safe and won't be able to submit this transaction.`,
+  wrongChain = 'Your wallet is connected to the wrong chain.',
+}
 
 const styles = createStyles({
   executionWarningRow: {
@@ -35,27 +42,17 @@ export const TransactionFailText = ({
   estimationStatus,
 }: TransactionFailTextProps): React.ReactElement | null => {
   const classes = useStyles()
-  const threshold = useSelector(currentSafeThreshold)
   const isWrongChain = useSelector(shouldSwitchWalletChain)
   const isGranted = useSelector(grantedSelector)
 
-  if (estimationStatus !== EstimationStatus.FAILURE && !(isCreation && !isGranted)) {
+  if ((estimationStatus !== EstimationStatus.FAILURE || !isExecution) && !(isCreation && !isGranted)) {
     return null
   }
 
-  let errorDesc = 'To save gas costs, avoid creating the transaction.'
-  if (isExecution) {
-    errorDesc =
-      threshold && threshold > 1
-        ? `To save gas costs, reject this transaction`
-        : `To save gas costs, avoid executing the transaction.`
-  }
+  const errorDesc = isCreation ? ErroMessage.creation : ErroMessage.execution
+  const defaultMsg = `${ErroMessage.general} ${errorDesc}`
 
-  const defaultMsg = `This transaction will most likely fail. ${errorDesc}`
-  const notOwnerMsg = `You are currently not an owner of this Safe and won't be able to submit this transaction.`
-  const wrongChainMsg = 'Your wallet is connected to the wrong chain.'
-
-  const error = isGranted ? defaultMsg : isWrongChain ? wrongChainMsg : isCreation ? notOwnerMsg : defaultMsg
+  const error = isWrongChain ? ErroMessage.wrongChain : isCreation && !isGranted ? ErroMessage.notOwner : defaultMsg
 
   return (
     <Row align="center">
@@ -66,3 +63,6 @@ export const TransactionFailText = ({
     </Row>
   )
 }
+
+// For tests
+export const _ErrorMessage = ErroMessage


### PR DESCRIPTION
## What it solves
Resolves #3519

## How this PR fixes it
Adds a condition to not render the error if neither an execution nor an unauthorized creation.

## How to test it
Follow the steps in the linked issue.
