### PR TITLE
fix: add chain data to tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "prettier './src/**/*.{js,jsx,ts,tsx}'",
     "start": "rescripts start",
     "start:docker": "docker-compose build && docker-compose up",
-    "test": "REACT_APP_ENV=test rescripts test --env=jsdom",
+    "test": "cross-env REACT_APP_ENV=test rescripts test --env=jsdom",
     "test:coverage": "REACT_APP_ENV=test yarn test --coverage --watchAll=false",
     "test:ci": "REACT_APP_ENV=test yarn test --ci --coverage --json --watchAll=false --testLocationInResults --runInBand --outputFile=jest.results.json",
     "update-mocks": "./scripts/update-mocks.sh",

--- a/src/components/Track/__tests__/index.test.tsx
+++ b/src/components/Track/__tests__/index.test.tsx
@@ -25,7 +25,8 @@ describe('Track', () => {
     const child = screen.queryByText('test child2')
 
     expect(child).toHaveAttribute('data-track-id', 'test')
-    expect(child).toHaveAttribute('data-track-payload', '{"chainName":"Rinkeby","chainId":"4","test":true}')
+    expect(child).toHaveAttribute('data-track-chain', '{"chainName":"Rinkeby","chainId":"4"}')
+    expect(child).toHaveAttribute('data-track-payload', '{"test":true}')
   })
 
   it('does not add the payload if it is undefined', () => {

--- a/src/components/Track/__tests__/index.test.tsx
+++ b/src/components/Track/__tests__/index.test.tsx
@@ -25,7 +25,7 @@ describe('Track', () => {
     const child = screen.queryByText('test child2')
 
     expect(child).toHaveAttribute('data-track-id', 'test')
-    expect(child).toHaveAttribute('data-track-payload', '{"test":true}')
+    expect(child).toHaveAttribute('data-track-payload', '{"chainName":"Rinkeby","chainId":"4","test":true}')
   })
 
   it('does not add the payload if it is undefined', () => {

--- a/src/components/Track/__tests__/index.test.tsx
+++ b/src/components/Track/__tests__/index.test.tsx
@@ -25,7 +25,7 @@ describe('Track', () => {
     const child = screen.queryByText('test child2')
 
     expect(child).toHaveAttribute('data-track-id', 'test')
-    expect(child).toHaveAttribute('data-track-chain', '{"chainName":"Rinkeby","chainId":"4"}')
+    expect(child).toHaveAttribute('data-track-chain', '{"chainId":"4","shortName":"rin"}')
     expect(child).toHaveAttribute('data-track-payload', '{"test":true}')
   })
 

--- a/src/components/Track/index.tsx
+++ b/src/components/Track/index.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, cloneElement, Fragment } from 'react'
+import { getChainInfo } from 'src/config'
 
 type Props = {
   children: ReactElement
@@ -11,10 +12,18 @@ const Track = ({ children, id, payload }: Props): ReactElement => {
     throw new Error('Fragments cannot be tracked.')
   }
 
+  const { chainName, chainId } = getChainInfo()
+
+  const dataTrackPayload = {
+    chainName,
+    chainId,
+    ...(payload !== undefined && payload),
+  }
+
   return cloneElement(children, {
     ...children.props,
     'data-track-id': id,
-    ...(payload !== undefined && { 'data-track-payload': JSON.stringify(payload) }),
+    'data-track-payload': JSON.stringify(dataTrackPayload),
   })
 }
 

--- a/src/components/Track/index.tsx
+++ b/src/components/Track/index.tsx
@@ -14,16 +14,11 @@ const Track = ({ children, id, payload }: Props): ReactElement => {
 
   const { chainName, chainId } = getChainInfo()
 
-  const dataTrackPayload = {
-    chainName,
-    chainId,
-    ...(payload !== undefined && payload),
-  }
-
   return cloneElement(children, {
     ...children.props,
     'data-track-id': id,
-    'data-track-payload': JSON.stringify(dataTrackPayload),
+    'data-track-chain': JSON.stringify({ chainName, chainId }),
+    ...(payload !== undefined && { 'data-track-payload': JSON.stringify(payload) }),
   })
 }
 

--- a/src/components/Track/index.tsx
+++ b/src/components/Track/index.tsx
@@ -12,12 +12,12 @@ const Track = ({ children, id, payload }: Props): ReactElement => {
     throw new Error('Fragments cannot be tracked.')
   }
 
-  const { chainName, chainId } = getChainInfo()
+  const { chainId, shortName } = getChainInfo()
 
   return cloneElement(children, {
     ...children.props,
     'data-track-id': id,
-    'data-track-chain': JSON.stringify({ chainName, chainId }),
+    'data-track-chain': JSON.stringify({ chainId, shortName }),
     ...(payload !== undefined && { 'data-track-payload': JSON.stringify(payload) }),
   })
 }


### PR DESCRIPTION
## What it solves
Missing chain-specific details

## How this PR fixes it
As per @johannesmoormann's request, the `shortName` (more stable than `chainName`) and `chainId` are sent with every track to GTM. I added them in a separate tracking key `data-track-chain` so they can be separated from the track as/when we want, e.g.

#### Tracking event #1
```ts
{
  id: 'Add owner',
  chain: {
    shortName: 'rin',
    chainId: 4,
  },
  payload: {
    total: 4,
    threshold: 2
  }
}
```

#### Tracking event #2
```ts
{
  id: 'Add owner',
  chain: {
    shortName: 'eth',
    chainId: 1,
  },
  payload: {
    total: 4,
    threshold: 2
  }
}
```

With the above we can track the 'Add owner' event and decide whether to track the total events or also by chain, simply by not including the `data-track-chain` payload into the analytics

## How to test it
It is currently covered by unit tests. Testing to occur when the first set of tracking is implemented.

## Analytics changes
`data-track-chain` is now included as a GTM variable:

![image](https://user-images.githubusercontent.com/20442784/154255156-862e483a-600e-4e2f-8ba4-dc5deb55934f.png)