### PR TITLE
fix: Link execute tx checkbox state to parent component

### DIFF
--- a/src/components/ExecuteCheckbox/index.tsx
+++ b/src/components/ExecuteCheckbox/index.tsx
@@ -23,17 +23,18 @@ const StyledFormControlLabel = styled(FormControlLabel)`
 `
 
 interface ExecuteCheckboxProps {
+  checked?: boolean
   onChange: (val: boolean) => unknown
 }
 
-const ExecuteCheckbox = ({ onChange }: ExecuteCheckboxProps): ReactElement => {
+const ExecuteCheckbox = ({ checked, onChange }: ExecuteCheckboxProps): ReactElement => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     onChange(e.target.checked)
   }
   return (
     <StyledRow>
       <StyledFormControlLabel
-        control={<Checkbox defaultChecked color="secondary" onChange={handleChange} />}
+        control={<Checkbox defaultChecked checked={checked} color="secondary" onChange={handleChange} />}
         label="Execute transaction"
         data-testid="execute-checkbox"
       />

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -91,6 +91,7 @@ export const TxModalWrapper = ({
   const confirmationsLen = Array.from(txConfirmations || []).length
   const canTxExecute = useCanTxExecute(preApprovingOwner, confirmationsLen, txThreshold, txNonce)
   const doExecute = executionApproved && canTxExecute
+  const showCheckbox = !isSpendingLimitTx && canTxExecute && (!txThreshold || txThreshold > confirmationsLen)
   const nativeCurrency = getNativeCurrency()
 
   const {
@@ -118,7 +119,6 @@ export const TxModalWrapper = ({
   })
 
   const [submitStatus, setSubmitStatus] = useEstimationStatus(txEstimationExecutionStatus)
-  const showCheckbox = !isSpendingLimitTx && canTxExecute && (!txThreshold || txThreshold > confirmationsLen)
 
   const onEditClose = (txParameters: TxParameters) => {
     const oldGasPrice = gasPriceFormatted
@@ -185,7 +185,7 @@ export const TxModalWrapper = ({
           {children}
 
           <Container>
-            {showCheckbox && <ExecuteCheckbox onChange={setExecutionApproved} />}
+            {showCheckbox && <ExecuteCheckbox checked={executionApproved} onChange={setExecutionApproved} />}
 
             {!isSpendingLimitTx && doExecute && (
               <TxEstimatedFeesDetail


### PR DESCRIPTION
## What it solves
Resolves #3539 

## How this PR fixes it
We now also pass the state itself to the checkbox component instead of just the setter so it stays in sync.

## How to test it
1. Open the Safe
2. Create a Transaction
3. Uncheck the Execute Tx Checkbox
4. Go to the Edit Parameters screen
5. Go back
6. Observe that Advanced Details is still hidden and the checkbox is still unchecked
