### PR TITLE
test: Create tests for TxSender class

### DIFF
--- a/src/logic/safe/store/actions/__tests__/TxSender.test.ts
+++ b/src/logic/safe/store/actions/__tests__/TxSender.test.ts
@@ -1,0 +1,285 @@
+import { TxSender } from 'src/logic/safe/store/actions/createTransaction'
+import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
+import { store } from 'src/store'
+import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
+import * as ConnectButton from 'src/components/ConnectButton'
+import * as utils from 'src/logic/safe/store/actions/utils'
+import * as walletSelectors from 'src/logic/wallets/store/selectors'
+import * as safeSelectors from 'src/logic/safe/store/selectors'
+import * as safeContracts from 'src/logic/contracts/safeContracts'
+import * as notificationBuilder from 'src/logic/notifications/notificationBuilder'
+import * as safeTxSigner from 'src/logic/safe/safeTxSigner'
+import * as offChainSigner from 'src/logic/safe/transactions/offchainSigner'
+import * as txHistory from 'src/logic/safe/transactions/txHistory'
+import * as pendingTransactions from 'src/logic/safe/store/actions/pendingTransactions'
+import * as fetchTransactions from 'src/logic/safe/store/actions/transactions/fetchTransactions'
+import * as aboutToExecuteTx from 'src/logic/safe/utils/aboutToExecuteTx'
+import * as send from 'src/logic/safe/transactions/send'
+import { waitFor } from '@testing-library/react'
+import { addPendingTransaction } from 'src/logic/safe/store/actions/pendingTransactions'
+import { LocalTransactionStatus } from 'src/logic/safe/store/models/types/gateway.d'
+
+jest.mock('src/logic/safe/store/actions/transactions/fetchTransactions', () => {
+  const original = jest.requireActual('src/logic/safe/store/actions/transactions/fetchTransactions')
+  return {
+    __esModule: true,
+    ...original,
+    default: jest.fn(),
+  }
+})
+
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux')
+  return {
+    ...original,
+    useSelector: jest.fn,
+  }
+})
+
+const mockTransactionDetails = {
+  txId: '',
+  executedAt: null,
+  txStatus: LocalTransactionStatus['SUCCESS'],
+  txInfo: {
+    type: 'Transfer',
+    sender: {
+      value: '',
+      name: null,
+      logoUri: null,
+    },
+    recipient: {
+      value: '',
+      name: null,
+      logoUri: null,
+    },
+    direction: 'OUTGOING',
+    transferInfo: {
+      type: 'ERC20',
+      tokenAddress: '',
+      tokenName: null,
+      tokenSymbol: null,
+      logoUri: null,
+      decimals: null,
+      value: '',
+    },
+  },
+  txData: null,
+  detailedExecutionInfo: null,
+  txHash: null,
+  safeAppInfo: null,
+}
+
+const mockTxProps = {
+  from: '',
+  to: '',
+  valueInWei: '',
+  notifiedTransaction: '',
+  safeAddress: '',
+  txData: EMPTY_DATA,
+  operation: 0,
+  navigateToTransactionsTab: false,
+  origin: null,
+  safeTxGas: '',
+  txNonce: '0',
+}
+
+describe('TxSender', () => {
+  let tryOffChainSigningSpy, saveTxToHistorySpy, addPendingTransactionSpy, navigateToTxSpy, fetchTransactionsSpy
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    jest.spyOn(ConnectButton, 'onboardUser').mockImplementation(() => Promise.resolve(true))
+    jest.spyOn(utils, 'getNonce')
+    jest.spyOn(safeSelectors, 'currentSafeCurrentVersion')
+    jest.spyOn(walletSelectors, 'providerSelector')
+    jest.spyOn(safeContracts, 'getGnosisSafeInstanceAt')
+    jest.spyOn(notificationBuilder, 'createTxNotifications')
+    tryOffChainSigningSpy = jest.spyOn(offChainSigner, 'tryOffChainSigning')
+    saveTxToHistorySpy = jest
+      .spyOn(txHistory, 'saveTxToHistory')
+      .mockImplementation(() => Promise.resolve(mockTransactionDetails as any))
+    addPendingTransactionSpy = jest.spyOn(pendingTransactions, 'addPendingTransaction')
+    navigateToTxSpy = jest.spyOn(utils, 'navigateToTx')
+    fetchTransactionsSpy = jest.spyOn(fetchTransactions, 'default')
+  })
+
+  it('handles approving a transaction', async () => {
+    jest.spyOn(safeTxSigner, 'checkIfOffChainSignatureIsPossible').mockImplementation(() => true)
+    const sender = new TxSender()
+
+    await sender.prepare(jest.fn(), store.getState(), mockTxProps)
+
+    sender.isFinalization = false
+    sender.txId = '1'
+    sender.safeTxHash = ''
+    sender.txArgs = {
+      safeInstance: sender.safeInstance,
+      to: mockTxProps.to,
+      valueInWei: mockTxProps.valueInWei,
+      data: mockTxProps.txData,
+      operation: mockTxProps.operation,
+      nonce: Number.parseInt(sender.nonce),
+      safeTxGas: mockTxProps.safeTxGas,
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: ZERO_ADDRESS,
+      refundReceiver: ZERO_ADDRESS,
+      sender: mockTxProps.from,
+      sigs: '',
+    }
+
+    sender.submitTx(store.getState())
+
+    await waitFor(() => {
+      expect(tryOffChainSigningSpy).toHaveBeenCalledTimes(1)
+      expect(saveTxToHistorySpy).toHaveBeenCalledTimes(1)
+      expect(addPendingTransactionSpy).toHaveBeenCalledTimes(0)
+      expect(navigateToTxSpy).toHaveBeenCalledTimes(0)
+      expect(fetchTransactionsSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('handles creating a transaction', async () => {
+    jest.spyOn(safeTxSigner, 'checkIfOffChainSignatureIsPossible').mockImplementation(() => true)
+    const sender = new TxSender()
+
+    mockTxProps.navigateToTransactionsTab = true
+
+    await sender.prepare(jest.fn(), store.getState(), mockTxProps)
+
+    sender.isFinalization = false
+    sender.safeTxHash = ''
+    sender.txArgs = {
+      safeInstance: sender.safeInstance,
+      to: mockTxProps.to,
+      valueInWei: mockTxProps.valueInWei,
+      data: mockTxProps.txData,
+      operation: mockTxProps.operation,
+      nonce: Number.parseInt(sender.nonce),
+      safeTxGas: mockTxProps.safeTxGas,
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: ZERO_ADDRESS,
+      refundReceiver: ZERO_ADDRESS,
+      sender: mockTxProps.from,
+      sigs: '',
+    }
+
+    sender.submitTx(store.getState())
+
+    await waitFor(() => {
+      expect(tryOffChainSigningSpy).toHaveBeenCalledTimes(1)
+      expect(saveTxToHistorySpy).toHaveBeenCalledTimes(1)
+      expect(addPendingTransactionSpy).toHaveBeenCalledTimes(0)
+      expect(navigateToTxSpy).toHaveBeenCalledTimes(1)
+      expect(fetchTransactionsSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('handles immediately executing a transaction', async () => {
+    jest.spyOn(safeTxSigner, 'checkIfOffChainSignatureIsPossible').mockImplementation(() => false)
+    const setNonceSpy = jest.spyOn(aboutToExecuteTx, 'setNonce')
+    const getExecutionTransactionSpy = jest.spyOn(send, 'getExecutionTransaction').mockImplementation(() => ({
+      arguments: [],
+      call: jest.fn(),
+      send: jest.fn(() => ({
+        once: jest.fn((type, handler) => handler()) as any,
+        on: jest.fn(),
+        then: jest.fn(),
+        catch: jest.fn((type, handler) => handler()) as any,
+        finally: jest.fn(),
+        [Symbol.toStringTag]: '',
+      })),
+      estimateGas: jest.fn(),
+      encodeABI: jest.fn(),
+    }))
+
+    const sender = new TxSender()
+
+    mockTxProps.navigateToTransactionsTab = true
+
+    await sender.prepare(jest.fn(), store.getState(), mockTxProps)
+
+    sender.isFinalization = true
+    sender.safeTxHash = ''
+    sender.txArgs = {
+      safeInstance: sender.safeInstance,
+      to: mockTxProps.to,
+      valueInWei: mockTxProps.valueInWei,
+      data: mockTxProps.txData,
+      operation: mockTxProps.operation,
+      nonce: Number.parseInt(sender.nonce),
+      safeTxGas: mockTxProps.safeTxGas,
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: ZERO_ADDRESS,
+      refundReceiver: ZERO_ADDRESS,
+      sender: mockTxProps.from,
+      sigs: '',
+    }
+
+    sender.submitTx(store.getState())
+
+    await waitFor(() => {
+      expect(getExecutionTransactionSpy).toHaveBeenCalledTimes(1)
+      expect(setNonceSpy).toHaveBeenCalledTimes(1)
+      expect(saveTxToHistorySpy).toHaveBeenCalledTimes(1)
+      expect(addPendingTransactionSpy).toHaveBeenCalledTimes(1)
+      expect(navigateToTxSpy).toHaveBeenCalledTimes(1)
+      expect(fetchTransactionsSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('handles executing a transaction', async () => {
+    jest.spyOn(safeTxSigner, 'checkIfOffChainSignatureIsPossible').mockImplementation(() => false)
+    const setNonceSpy = jest.spyOn(aboutToExecuteTx, 'setNonce')
+    const getExecutionTransactionSpy = jest.spyOn(send, 'getExecutionTransaction').mockImplementation(() => ({
+      arguments: [],
+      call: jest.fn(),
+      send: jest.fn(() => ({
+        once: jest.fn((type, handler) => handler()) as any,
+        on: jest.fn(),
+        then: jest.fn(),
+        catch: jest.fn((type, handler) => handler()) as any,
+        finally: jest.fn(),
+        [Symbol.toStringTag]: '',
+      })),
+      estimateGas: jest.fn(),
+      encodeABI: jest.fn(),
+    }))
+
+    const sender = new TxSender()
+
+    await sender.prepare(jest.fn(), store.getState(), mockTxProps)
+
+    sender.isFinalization = true
+    sender.txId = 'mockId'
+    sender.safeTxHash = ''
+    sender.txArgs = {
+      safeInstance: sender.safeInstance,
+      to: mockTxProps.to,
+      valueInWei: mockTxProps.valueInWei,
+      data: mockTxProps.txData,
+      operation: mockTxProps.operation,
+      nonce: Number.parseInt(sender.nonce),
+      safeTxGas: mockTxProps.safeTxGas,
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: ZERO_ADDRESS,
+      refundReceiver: ZERO_ADDRESS,
+      sender: mockTxProps.from,
+      sigs: '',
+    }
+
+    sender.submitTx(store.getState())
+
+    await waitFor(() => {
+      expect(getExecutionTransactionSpy).toHaveBeenCalledTimes(1)
+      expect(setNonceSpy).toHaveBeenCalledTimes(1)
+      expect(addPendingTransactionSpy).toHaveBeenCalledTimes(1)
+      expect(saveTxToHistorySpy).toHaveBeenCalledTimes(0)
+      expect(navigateToTxSpy).toHaveBeenCalledTimes(0)
+      expect(fetchTransactionsSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -17,18 +17,14 @@ import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { providerSelector } from 'src/logic/wallets/store/selectors'
 import { generateSafeTxHash } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
-import { getNonce, canExecuteCreatedTx } from 'src/logic/safe/store/actions/utils'
+import { getNonce, canExecuteCreatedTx, navigateToTx } from 'src/logic/safe/store/actions/utils'
 import fetchTransactions from './transactions/fetchTransactions'
 import { AppReduxState } from 'src/store'
 import { Dispatch, DispatchReturn } from './types'
 import { checkIfOffChainSignatureIsPossible, getPreValidatedSignatures } from 'src/logic/safe/safeTxSigner'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
-import { extractShortChainName, history, SAFE_ROUTES } from 'src/routes/routes'
-import { getPrefixedSafeAddressSlug, SAFE_ADDRESS_SLUG, TRANSACTION_ID_SLUG } from 'src/routes/routes'
-import { generatePath } from 'react-router-dom'
 import { fetchOnchainError } from 'src/logic/contracts/safeContractErrors'
-import { isMultiSigExecutionDetails } from '../models/types/gateway.d'
 import { removePendingTransaction, addPendingTransaction } from 'src/logic/safe/store/actions/pendingTransactions'
 import { _getChainId } from 'src/config'
 import { GnosisSafe } from 'src/types/contracts/gnosis_safe.d'
@@ -59,19 +55,6 @@ type ConfirmEventHandler = (safeTxHash: string) => void
 type ErrorEventHandler = () => void
 
 export const METAMASK_REJECT_CONFIRM_TX_ERROR_CODE = 4001
-
-const navigateToTx = (safeAddress: string, txDetails: TransactionDetails) => {
-  if (!isMultiSigExecutionDetails(txDetails.detailedExecutionInfo)) {
-    return
-  }
-  const prefixedSafeAddress = getPrefixedSafeAddressSlug({ shortName: extractShortChainName(), safeAddress })
-  const txRoute = generatePath(SAFE_ROUTES.TRANSACTIONS_SINGULAR, {
-    [SAFE_ADDRESS_SLUG]: prefixedSafeAddress,
-    [TRANSACTION_ID_SLUG]: txDetails.detailedExecutionInfo.safeTxHash,
-  })
-
-  history.push(txRoute)
-}
 
 const getSafeTxGas = async (txProps: RequiredTxProps, safeVersion: string): Promise<string> => {
   const estimationProps: SafeTxGasEstimationProps = {

--- a/src/logic/safe/store/actions/utils.ts
+++ b/src/logic/safe/store/actions/utils.ts
@@ -1,5 +1,7 @@
-import { GnosisSafe } from 'src/types/contracts/gnosis_safe.d'
+import { generatePath } from 'react-router-dom'
+import { SafeInfo, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
 
+import { GnosisSafe } from 'src/types/contracts/gnosis_safe.d'
 import { LATEST_SAFE_VERSION } from 'src/utils/constants'
 import { SafeRecordProps } from 'src/logic/safe/store/models/safe'
 import { getSpendingLimits } from 'src/logic/safe/utils/spendingLimits'
@@ -7,15 +9,24 @@ import { buildModulesLinkedList } from 'src/logic/safe/utils/modules'
 import { enabledFeatures, safeNeedsUpdate } from 'src/logic/safe/utils/safeVersion'
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { ChainId } from 'src/config/chain.d'
-import { SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+
 import {
   Transaction,
   isMultisigExecutionInfo,
   LocalTransactionStatus,
+  isMultiSigExecutionDetails,
 } from 'src/logic/safe/store/models/types/gateway.d'
 import { getGnosisSafeInstanceAt } from 'src/logic/contracts/safeContracts'
 import { logError, Errors } from 'src/logic/exceptions/CodedException'
 import { getRecommendedNonce } from '../../api/fetchSafeTxGasEstimation'
+import {
+  extractShortChainName,
+  getPrefixedSafeAddressSlug,
+  history,
+  SAFE_ADDRESS_SLUG,
+  SAFE_ROUTES,
+  TRANSACTION_ID_SLUG,
+} from 'src/routes/routes'
 
 export const canExecuteCreatedTx = async (
   safeInstance: GnosisSafe,
@@ -119,4 +130,17 @@ export const getNonce = async (safeAddress: string, safeVersion: string): Promis
     nextNonce = await safeInstance.methods.nonce().call()
   }
   return nextNonce
+}
+
+export const navigateToTx = (safeAddress: string, txDetails: TransactionDetails): void => {
+  if (!isMultiSigExecutionDetails(txDetails.detailedExecutionInfo)) {
+    return
+  }
+  const prefixedSafeAddress = getPrefixedSafeAddressSlug({ shortName: extractShortChainName(), safeAddress })
+  const txRoute = generatePath(SAFE_ROUTES.TRANSACTIONS_SINGULAR, {
+    [SAFE_ADDRESS_SLUG]: prefixedSafeAddress,
+    [TRANSACTION_ID_SLUG]: txDetails.detailedExecutionInfo.safeTxHash,
+  })
+
+  history.push(txRoute)
 }


### PR DESCRIPTION
## What it solves
Part of #3494 

## How this PR fixes it
Tests `TxSender` class for each transaction flow: `approve transaction`, `create transaction`, `create and execute transaction`, `execute transaction/approve and execute transaction`. This is an important prerequisite for the upcoming v2 refactor as discussed [here](https://github.com/gnosis/safe-react/pull/3492#issuecomment-1041269479).

## Notes
`navigateToTx` got moved to a different file for mocking purposes.
