### PR TITLE
Fix: throw when WC rejects a created tx + on-chain signing with a Safe signer via WC

### DIFF
--- a/src/logic/safe/store/actions/__tests__/TxSender.test.ts
+++ b/src/logic/safe/store/actions/__tests__/TxSender.test.ts
@@ -94,7 +94,9 @@ describe('TxSender', () => {
     jest.spyOn(walletSelectors, 'providerSelector')
     jest.spyOn(safeContracts, 'getGnosisSafeInstanceAt')
     jest.spyOn(notificationBuilder, 'createTxNotifications')
-    tryOffChainSigningSpy = jest.spyOn(offChainSigner, 'tryOffChainSigning')
+    tryOffChainSigningSpy = jest
+      .spyOn(offChainSigner, 'tryOffChainSigning')
+      .mockImplementation(() => Promise.resolve('mocksignature'))
     saveTxToHistorySpy = jest
       .spyOn(txHistory, 'saveTxToHistory')
       .mockImplementation(() => Promise.resolve(mockTransactionDetails as any))

--- a/src/logic/safe/store/actions/__tests__/TxSender.test.ts
+++ b/src/logic/safe/store/actions/__tests__/TxSender.test.ts
@@ -15,6 +15,7 @@ import * as pendingTransactions from 'src/logic/safe/store/actions/pendingTransa
 import * as fetchTransactions from 'src/logic/safe/store/actions/transactions/fetchTransactions'
 import * as aboutToExecuteTx from 'src/logic/safe/utils/aboutToExecuteTx'
 import * as send from 'src/logic/safe/transactions/send'
+import * as getWeb3 from 'src/logic/wallets/getWeb3'
 import { waitFor } from '@testing-library/react'
 import { addPendingTransaction } from 'src/logic/safe/store/actions/pendingTransactions'
 import { LocalTransactionStatus } from 'src/logic/safe/store/models/types/gateway.d'
@@ -94,6 +95,7 @@ describe('TxSender', () => {
     jest.spyOn(walletSelectors, 'providerSelector')
     jest.spyOn(safeContracts, 'getGnosisSafeInstanceAt')
     jest.spyOn(notificationBuilder, 'createTxNotifications')
+    jest.spyOn(getWeb3, 'isSmartContractWallet')
     tryOffChainSigningSpy = jest
       .spyOn(offChainSigner, 'tryOffChainSigning')
       .mockImplementation(() => Promise.resolve('mocksignature'))

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -3,7 +3,7 @@ import { AnyAction } from 'redux'
 import { ThunkAction } from 'redux-thunk'
 
 import { onboardUser } from 'src/components/ConnectButton'
-import { isSmartContractWallet, WALLET_PROVIDER } from 'src/logic/wallets/getWeb3'
+import { isSmartContractWallet } from 'src/logic/wallets/getWeb3'
 import { getGnosisSafeInstanceAt } from 'src/logic/contracts/safeContracts'
 import { createTxNotifications } from 'src/logic/notifications'
 import {
@@ -192,11 +192,11 @@ export class TxSender {
 
   async canSignOffchain(state: AppReduxState): Promise<boolean> {
     const { isFinalization, safeVersion } = this
-    const { account, name, smartContractWallet } = providerSelector(state)
+    const { account, smartContractWallet } = providerSelector(state)
     let isSmart = smartContractWallet
 
-    // WalletConnect itself isn't a smart contract but the connected account can be
-    if (!isSmart && name.toUpperCase() === WALLET_PROVIDER.WALLETCONNECT) {
+    // WalletConnect/Mobile App aren't smart contracts per se but the connected account can be
+    if (!isSmart) {
       isSmart = await isSmartContractWallet(account) // never throws
     }
 

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -201,10 +201,16 @@ export class TxSender {
     if (!isFinalization && canSignOffChain) {
       try {
         const signature = await this.onlyConfirm(hardwareWallet)
-        this.onComplete(signature, confirmCallback)
+
+        if (signature) {
+          this.onComplete(signature, confirmCallback)
+        } else {
+          throw Error('No signature received')
+        }
       } catch (err) {
         // User likely rejected transaction
         logError(Errors._814, err.message)
+        this.onError(err, errorCallback)
       }
       return
     }


### PR DESCRIPTION
## What it solves
Dima noticed the following bug:
* connect the mobile app via WalletConnect
* initiate a transaction on web (Execute checkbox unchecked)
* reject on mobile
* before the fix: web app redirects to the tx with 0 signatures 🐞

Another bug this PR fixes:
* make a Safe an owner of another Safe
* connect the first Safe to the owned safe via WC and WC Safe App
* create a tx (Execute unchecked)
* before the fix: tx created with 0 signatures 🐞 

After this fix, a tx will be signed correctly in both cases.

## How this PR fixes it
When a created tx is rejected by the wallet, we throw an error and show an error snackbar. The tx is _not_ created and the user is _not_ redirected anywhere.

Also checks if the connected wallet is a smart contract and does an on-chain signature if yes.
