### PR TITLE
fix: Remove defaultChecked attribute from exec tx checkbox

### DIFF
--- a/src/components/ExecuteCheckbox/index.test.tsx
+++ b/src/components/ExecuteCheckbox/index.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { fireEvent, render, screen, waitFor, act } from 'src/utils/test-utils'
 import { history } from 'src/routes/routes'
 import ExecuteCheckbox from '.'
@@ -7,8 +8,20 @@ describe('ExecuteCheckbox', () => {
     const onChange = jest.fn()
     history.push('/rin:0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A/balances')
 
+    const ControlledInputWrapper = () => {
+      const [checked, setChecked] = useState<boolean>(true)
+      return (
+        <ExecuteCheckbox
+          checked={checked}
+          onChange={(value) => {
+            setChecked(value)
+            onChange(value)
+          }}
+        />
+      )
+    }
     await act(async () => {
-      render(<ExecuteCheckbox onChange={onChange} />)
+      render(<ControlledInputWrapper />)
     })
 
     await waitFor(() => {

--- a/src/components/ExecuteCheckbox/index.tsx
+++ b/src/components/ExecuteCheckbox/index.tsx
@@ -23,7 +23,7 @@ const StyledFormControlLabel = styled(FormControlLabel)`
 `
 
 interface ExecuteCheckboxProps {
-  checked?: boolean
+  checked: boolean
   onChange: (val: boolean) => unknown
 }
 
@@ -34,7 +34,7 @@ const ExecuteCheckbox = ({ checked, onChange }: ExecuteCheckboxProps): ReactElem
   return (
     <StyledRow>
       <StyledFormControlLabel
-        control={<Checkbox defaultChecked checked={checked} color="secondary" onChange={handleChange} />}
+        control={<Checkbox checked={checked} color="secondary" onChange={handleChange} />}
         label="Execute transaction"
         data-testid="execute-checkbox"
       />


### PR DESCRIPTION
## What it solves
Relates to #3539 

## How this PR fixes it
Removes the `defaultChecked` attribute as it conflicts with using the Checkbox as a controlled input.

## How to test it
Behaviour is still the same, only the console error is gone now.
