### PR TITLE
fix: Only run createNewSafe if user wallet is connected

### DIFF
--- a/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
+++ b/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
@@ -100,6 +100,8 @@ function SafeCreationProcess(): ReactElement {
       return
     }
 
+    if (!userAddressAccount) return
+
     setSafeCreationTxHash(safeCreationFormValues[FIELD_NEW_SAFE_CREATION_TX_HASH])
 
     setCreationTxPromise(

--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -103,7 +103,7 @@ export const SafeDeployment = ({
     }
   }, [provider])
 
-  // creating safe from from submission
+  // creating safe from form submission
   useEffect(() => {
     if (submittedPromise === undefined) {
       return


### PR DESCRIPTION
## What it solves
Resolves #3498 (partially)

## How this PR fixes it
When calling `createNewSafe` we only proceed with the Tx proposal if the users wallet is connected.

## How to test it
1. Open the Safe App
2. Create a new Safe
3. Reject the Transaction via MetaMask
4. Reload the page
5. Observe that MetaMask opens again
6. Observe that there is no error and the Retry button is not visible

## Screenshots
Before - After
![c](https://user-images.githubusercontent.com/5880855/154989790-fc59d0a1-a45c-4d45-aaf8-4a222fb695c5.png)

