### PR TITLE
fix: stringify parameter value arrays

### DIFF
--- a/src/components/DecodeTxs/index.tsx
+++ b/src/components/DecodeTxs/index.tsx
@@ -113,7 +113,7 @@ export const getParameterElement = (parameter: DecodedDataBasicParameter, index:
     )
   }
 
-  if (parameter.type.startsWith('bytes')) {
+  if (parameter.type === 'bytes') {
     valueElement = (
       <FlexWrapper margin={5}>
         <Text size="lg">{getByteLength(parameter.value)} bytes</Text>


### PR DESCRIPTION
## What it solves
Resolves #3502

## How this PR fixes it
An array parameter value is always stringified when processing a transaction. 

When receiving decoded data from the back-end while creating a transaction, decoded data parameters are of type
`DecodedDataBasicParameter` which types the parameter value as a `string`.

## How to test it
1. Propose a transaction that contains a nested array as a parameter (e.g. claiming a merkle airdrop, such as vCOW)
2. Check that nested array is displayed

## Screenshots
![Screen Shot 2022-02-21 at 19 35 31](https://user-images.githubusercontent.com/32431609/155016821-71e65333-19ee-4845-9751-91ae27ec6ee2.png)

