### PR TITLE
fix: use global `replace` instead of `replaceAll`

### DIFF
--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -67,7 +67,7 @@ export const SAFE_ROUTES = {
 export const getNetworkRootRoutes = (): Array<{ chainId: ChainId; route: string; shortName: string }> =>
   getChains().map(({ chainId, chainName, shortName }) => ({
     chainId,
-    route: `/${chainName.replaceAll(' ', '-').toLowerCase()}`,
+    route: `/${chainName.replace(/\s+/g, '-').toLowerCase()}`,
     shortName,
   }))
 


### PR DESCRIPTION
## What it solves
`replaceAll` errors on Chrome Android.

## How this PR fixes it
`replaceAll` has been exchanged with the legacy global `replace`.

## How to test it
Open an example `chainName` 'root route' on Chrome Android, e.g. `/app/gnosis-chain` and observe that the Safe opens correctly.