### PR TITLE
style: improve conflicting transactions styles

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -123,6 +123,10 @@ export const GroupedTransactionsCard = styled(StyledTransactions)<{ expanded?: b
     }
   }
 
+  .disclaimer-container {
+    background-color: ${({ theme, expanded }) => (expanded ? `${primary200}` : theme.colors.inputField)};
+  }
+
   &:hover {
     background-color: ${primary200};
 

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -132,7 +132,7 @@ export const GroupedTransactionsCard = styled(StyledTransactions)<{ expanded?: b
     }
 
     .disclaimer-container {
-      background-color: ${({ theme }) => theme.colors.inputField};
+      background-color: transparent;
     }
   }
 `
@@ -296,7 +296,7 @@ export const GroupedTransactions = styled(StyledTransaction)`
 `
 
 export const DisclaimerContainer = styled(StyledTransaction)`
-  background-color: ${({ theme }) => theme.colors.inputField} !important;
+  background-color: ${({ theme }) => theme.colors.inputField};
   border-radius: 4px;
   margin: 12px 8px 0 12px;
   padding: 8px 12px;

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -149,8 +149,13 @@ const gridColumns = {
 const willBeReplaced = css`
   .will-be-replaced {
     pointer-events: none;
+  }
+
+  .will-be-replaced.tx-details-actions button,
+  .will-be-replaced img {
     filter: grayscale(1) opacity(0.8) !important;
   }
+
   .will-be-replaced * {
     pointer-events: none;
     color: gray !important;


### PR DESCRIPTION
## What it solves
Resolves #3552

## How this PR fixes it
- Changes the Disclaimer background color on hover
- Removes the grey scale filter in transactions that will be replaced

## How to test it

1. Stack transactions with the same nonce.
2. Get one of the grouped transactions ready to be executed.
3. On hovering the "execute" icon/button, the other transaction will not

## Screenshots
(_on hover_)
![Screen Shot 2022-02-22 at 18 09 54](https://user-images.githubusercontent.com/32431609/155193136-f73f253c-5c9b-4838-9ed4-dab7b34c1ff1.png)


