### PR TITLE
fix: always reset wallet on `disconnect` event

### DIFF
--- a/src/logic/wallets/pairing/module.ts
+++ b/src/logic/wallets/pairing/module.ts
@@ -53,9 +53,7 @@ const getPairingModule = (chainId: ChainId): WalletModule => {
       ;(provider.wc as any)._clientMeta = clientMeta
 
       const onDisconnect = () => {
-        if (provider.connected) {
-          resetWalletState({ disconnected: true, walletName: PAIRING_MODULE_NAME })
-        }
+        resetWalletState({ disconnected: true, walletName: PAIRING_MODULE_NAME })
       }
 
       provider.wc.on('disconnect', onDisconnect)


### PR DESCRIPTION
## What it solves
Resolves outdated pairing QR upon connection rejection.

## How this PR fixes it
`onDisconnect` was only being called when the provider was connected. If the user rejects a pairing request, the provider was `!connected` and would therefore not reset the wallet, invalidating the QR code. The `connected` flag has been removed.

## How to test it
- Scan the pairing QR in the mobile app but reject the pairing request.
- Observe the QR disappear, requesting regeneration.