### PR TITLE
Fix: do not show a nonce warning for rejection txns

### DIFF
--- a/src/components/ReviewInfoText/ReviewInfoText.test.tsx
+++ b/src/components/ReviewInfoText/ReviewInfoText.test.tsx
@@ -12,30 +12,38 @@ describe('<ReviewInfoText>', () => {
     gasCostFormatted: '0',
     isExecution: true,
     isCreation: true,
+    isRejection: false,
     isOffChainSignature: false,
     txEstimationExecutionStatus: EstimationStatus.SUCCESS,
   }
 
-  it('renders ReviewInfoText with safeNonce in order', () => {
+  it('renders only base text with safeNonce in order', () => {
     render(<ReviewInfoText {...initialData} safeNonce="9" />)
 
     expect(screen.getByText(/You're about to create a transaction/)).toBeInTheDocument()
   })
 
-  it('renders ReviewInfoText with safeNonce in order and not a creation', () => {
+  it('renders only base text with safeNonce in order and not a creation', () => {
     render(<ReviewInfoText {...initialData} safeNonce="9" isCreation={false} />)
 
     expect(screen.getByText(/You're about to execute a transaction/)).toBeInTheDocument()
   })
 
-  it('renders ReviewInfoText that is not a creation and nonce in future', () => {
+  it('renders only base text that is not a creation and nonce in future', () => {
     render(<ReviewInfoText {...initialData} safeNonce="100" isCreation={false} />)
 
     expect(screen.getByText(/You're about to execute a transaction/)).toBeInTheDocument()
     expect(screen.queryByText(/will need to be created and executed before this transaction/)).not.toBeInTheDocument()
   })
 
-  it('renders ReviewInfoText with a safeNonce 1 tx in the future', () => {
+  it('renders only base text for a rejection tx with a nonce in the past', () => {
+    render(<ReviewInfoText {...initialData} safeNonce="1" isRejection={true} />)
+
+    expect(screen.getByText(/You're about to create a rejection transaction/)).toBeInTheDocument()
+    expect(screen.queryByText(/will need to be created and executed before this transaction/)).not.toBeInTheDocument()
+  })
+
+  it('renders a warning with a safeNonce +1 tx in the future', () => {
     render(<ReviewInfoText {...initialData} safeNonce="10" />)
 
     expect(screen.getByText(/1/)).toBeInTheDocument()
@@ -44,7 +52,7 @@ describe('<ReviewInfoText>', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders ReviewInfoText with a safeNonce 2 txs the future', () => {
+  it('renders a warning with a safeNonce +2 txs the future', () => {
     render(<ReviewInfoText {...initialData} safeNonce="11" />)
 
     expect(screen.getByText(/2/)).toBeInTheDocument()
@@ -53,7 +61,7 @@ describe('<ReviewInfoText>', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders ReviewInfoText with already used safeNonce', () => {
+  it('renders a warning with an already used safeNonce', () => {
     render(<ReviewInfoText {...initialData} safeNonce="6" />)
 
     expect(screen.getByText(/6/)).toBeInTheDocument()

--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -17,6 +17,7 @@ type ReviewInfoTextProps = {
   txEstimationExecutionStatus: EstimationStatus
   isExecution: boolean
   isCreation: boolean
+  isRejection: boolean
   safeNonce?: string
   testId?: string
 }
@@ -24,6 +25,7 @@ type ReviewInfoTextProps = {
 export const ReviewInfoText = ({
   isCreation,
   isExecution,
+  isRejection,
   safeNonce = '',
   testId,
   txEstimationExecutionStatus,
@@ -40,7 +42,7 @@ export const ReviewInfoText = ({
   }
 
   const getWarning = (): ReactElement | null => {
-    if (!isCreation) return null
+    if (!isCreation || isRejection) return null
     if (!isTxNonceOutOfOrder()) return null
 
     const transactionsToGo = safeTxNonce - recommendedNonce
@@ -70,8 +72,9 @@ export const ReviewInfoText = ({
       {getWarning() || (
         <>
           <Paragraph size="md" align="center" color="disabled" noMargin>
-            You&apos;re about to {isCreation ? 'create' : isExecution ? 'execute' : 'approve'} a transaction and will
-            have to confirm it with your currently connected wallet.
+            You&apos;re about to {isCreation ? 'create' : isExecution ? 'execute' : 'approve'} a{' '}
+            {isRejection ? 'rejection ' : ''}transaction and will have to confirm it with your currently connected
+            wallet.
           </Paragraph>
         </>
       )}

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -91,7 +91,7 @@ export const TxModalWrapper = ({
   onClose,
   submitText,
   isSubmitDisabled,
-  isRejectTx,
+  isRejectTx = false,
 }: Props): React.ReactElement => {
   const [manualSafeTxGas, setManualSafeTxGas] = useState<string>('0')
   const [manualGasPrice, setManualGasPrice] = useState<string>()
@@ -229,6 +229,7 @@ export const TxModalWrapper = ({
             <ReviewInfoText
               isCreation={isCreation}
               isExecution={doExecute}
+              isRejection={isRejectTx}
               safeNonce={txParameters.safeNonce}
               txEstimationExecutionStatus={txEstimationExecutionStatus}
             />


### PR DESCRIPTION
## What it solves
Resolves #3568

## How this PR fixes it
Passes a new prop for rejection txns.

## How to test it
Create a few txns with out-of-order nonces. Reject them.