### PR TITLE
Fix: safe creation monitor - receipt can be undefined

### DIFF
--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -197,9 +197,9 @@ export const SafeDeployment = ({
         const web3 = getWeb3()
         const receipt = await web3.eth.getTransactionReceipt(safeCreationTxHash)
 
-        let safeAddress
+        let safeAddress = ''
 
-        if (receipt.events) {
+        if (receipt?.events) {
           safeAddress = receipt.events.ProxyCreation.returnValues.proxy
         } else {
           // If the node doesn't return the events we try to fetch it from logs


### PR DESCRIPTION
## What it solves
Part of #3569

While testing the creation a Safe on Polygon, I've noticed that an error was thrown in the creation tx monitor.

## How this PR fixes it
Checks for null/undefined.

## How to test it
It's not happening consistently.