### PR TITLE
Fix: show a tx rejection error

### DIFF
--- a/src/logic/notifications/notificationBuilder.tsx
+++ b/src/logic/notifications/notificationBuilder.tsx
@@ -271,6 +271,7 @@ export const createTxNotifications = (
 ): {
   closePending: () => void
   showOnError: (err: Error & { code: number }, contractErrorMessage?: string) => void
+  showOnRejection: (err: Error & { code: number }, contractErrorMessage?: string) => void
 } => {
   // Notifications
   // Each tx gets a slot in the global snackbar queue
@@ -281,6 +282,10 @@ export const createTxNotifications = (
 
   return {
     closePending: () => dispatch(closeSnackbarAction({ key: beforeExecutionKey })),
+
+    showOnRejection: (err: Error & { code?: number }) => {
+      dispatch(enqueueSnackbar({ key: err.code, ...notificationSlot.afterRejection }))
+    },
 
     showOnError: (err: Error & { code: number }, customErrorMessage?: string) => {
       const msg = isTxPendingError(err)

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -128,8 +128,6 @@ export class TxSender {
   async onError(err: Error & { code: number }, errorCallback?: ErrorEventHandler): Promise<void> {
     const { txArgs, isFinalization, from, txProps, dispatch, notifications, safeInstance, txId, txHash } = this
 
-    logError(Errors._803, err.message)
-
     errorCallback?.()
 
     notifications.closePending()
@@ -236,7 +234,6 @@ export class TxSender {
           throw Error('No signature received')
         }
       } catch (err) {
-        // User likely rejected transaction
         logError(Errors._814, err.message)
         this.onError(err, errorCallback)
       }
@@ -247,6 +244,7 @@ export class TxSender {
     try {
       await this.sendTx(confirmCallback)
     } catch (err) {
+      logError(Errors._803, err.message)
       this.onError(err, errorCallback)
     }
 

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -140,7 +140,7 @@ export class TxSender {
       dispatch(removePendingTransaction({ id: txId }))
     }
 
-    // Don't display error when rejecting transaction via MetaMask
+    // Display a notification when user rejects the tx
     if (isWalletRejection(err)) {
       // show snackbar
       notifications.showOnRejection(err)

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -33,6 +33,7 @@ import * as aboutToExecuteTx from 'src/logic/safe/utils/aboutToExecuteTx'
 import { getLastTransaction } from 'src/logic/safe/store/selectors/gatewayTransactions'
 import { TxArgs } from 'src/logic/safe/store/models/types/transaction'
 import { getContractErrorMessage } from 'src/logic/contracts/safeContractErrors'
+import { isWalletRejection } from 'src/logic/wallets/errors'
 
 export interface CreateTransactionArgs {
   navigateToTransactionsTab?: boolean
@@ -55,8 +56,6 @@ type RequiredTxProps = CreateTransactionArgs &
 type CreateTransactionAction = ThunkAction<Promise<void | string>, AppReduxState, DispatchReturn, AnyAction>
 type ConfirmEventHandler = (safeTxHash: string) => void
 type ErrorEventHandler = () => void
-
-export const METAMASK_REJECT_CONFIRM_TX_ERROR_CODE = 4001
 
 const getSafeTxGas = async (txProps: RequiredTxProps, safeVersion: string): Promise<string> => {
   const estimationProps: SafeTxGasEstimationProps = {
@@ -142,7 +141,9 @@ export class TxSender {
     }
 
     // Don't display error when rejecting transaction via MetaMask
-    if (err.code === METAMASK_REJECT_CONFIRM_TX_ERROR_CODE) {
+    if (isWalletRejection(err)) {
+      // show snackbar
+      notifications.showOnRejection(err)
       return
     }
 

--- a/src/logic/safe/transactions/offchainSigner/index.ts
+++ b/src/logic/safe/transactions/offchainSigner/index.ts
@@ -1,7 +1,7 @@
 import semverSatisfies from 'semver/functions/satisfies'
 
-import { METAMASK_REJECT_CONFIRM_TX_ERROR_CODE } from 'src/logic/safe/store/actions/createTransaction'
 import { isPairingModule } from 'src/logic/wallets/pairing/utils'
+import { isWalletRejection } from 'src/logic/wallets/errors'
 import { getEIP712Signer, SigningTxArgs } from './EIP712Signer'
 import { ethSigner, EthSignerArgs } from './ethSigner'
 
@@ -38,14 +38,6 @@ const getSupportedSigners = (isHW: boolean, safeVersion: string): SupportedSigne
   return signers
 }
 
-const isKeystoneError = (err: unknown): boolean => {
-  if (err instanceof Error) {
-    return err.message?.startsWith('#ktek_error')
-  }
-
-  return false
-}
-
 export const tryOffChainSigning = async (
   safeTxHash: string,
   txArgs: Omit<SigningTxArgs & EthSignerArgs, 'safeVersion' | 'safeTxHash'>,
@@ -61,12 +53,11 @@ export const tryOffChainSigning = async (
 
       break
     } catch (err) {
-      if (err.code === METAMASK_REJECT_CONFIRM_TX_ERROR_CODE) {
+      if (isWalletRejection(err)) {
+        // user rejected, exit
         throw err
       }
-      if (isKeystoneError(err)) {
-        throw err
-      }
+      // continue to the next signing method
     }
   }
 

--- a/src/logic/wallets/errors.ts
+++ b/src/logic/wallets/errors.ts
@@ -6,7 +6,7 @@ const isKeystoneError = (err: unknown): boolean => {
 }
 
 const isWCRejection = (err: Error): boolean => {
-  return /User rejected/.test(err.message)
+  return /User rejected/.test(err?.message)
 }
 
 const isMMRejection = (err: Error & { code?: number }): boolean => {

--- a/src/logic/wallets/errors.ts
+++ b/src/logic/wallets/errors.ts
@@ -1,0 +1,20 @@
+const isKeystoneError = (err: unknown): boolean => {
+  if (err instanceof Error) {
+    return err.message?.startsWith('#ktek_error')
+  }
+  return false
+}
+
+const isWCRejection = (err: Error): boolean => {
+  return /User rejected/.test(err.message)
+}
+
+const isMMRejection = (err: Error & { code?: number }): boolean => {
+  const METAMASK_REJECT_CONFIRM_TX_ERROR_CODE = 4001
+
+  return err.code === METAMASK_REJECT_CONFIRM_TX_ERROR_CODE
+}
+
+export const isWalletRejection = (err: Error & { code?: number }): boolean => {
+  return isMMRejection(err) || isWCRejection(err) || isKeystoneError(err)
+}


### PR DESCRIPTION
## What it solves
Resolves #3563

## How this PR fixes it
We were actually never showing any error on rejection, but this PR fixes it.
A snackbar saying "Transaction was rejected" is shown now when rejecting execution/signing in the wallet.
Only works for MM, WC and Keystone (we parse their specific errors).

## How to test it
Create & reject.