### PR TITLE
fix: move Onboard config setting to middleware

### DIFF
--- a/src/logic/config/store/middleware/index.ts
+++ b/src/logic/config/store/middleware/index.ts
@@ -1,4 +1,4 @@
-import { Action } from 'redux'
+import { Action } from 'redux-actions'
 
 import { clearCurrentSession } from 'src/logic/currentSession/store/actions/clearCurrentSession'
 import loadCurrentSessionFromStorage from 'src/logic/currentSession/store/actions/loadCurrentSessionFromStorage'
@@ -7,11 +7,13 @@ import loadSafesFromStorage from 'src/logic/safe/store/actions/loadSafesFromStor
 import { Dispatch } from 'src/logic/safe/store/actions/types'
 import { CONFIG_ACTIONS } from '../actions'
 import { store as reduxStore } from 'src/store'
+import { ChainId } from 'src/config/chain'
+import onboard from 'src/logic/wallets/onboard'
 
 export const configMiddleware =
   ({ dispatch }: typeof reduxStore) =>
   (next: Dispatch) =>
-  async (action: Action<typeof CONFIG_ACTIONS.SET_CHAIN_ID>) => {
+  async (action: Action<ChainId>) => {
     const handledAction = next(action)
 
     switch (action.type) {
@@ -20,6 +22,8 @@ export const configMiddleware =
         dispatch(clearCurrentSession())
         dispatch(loadSafesFromStorage())
         dispatch(loadCurrentSessionFromStorage())
+
+        onboard().config({ networkId: parseInt(action.payload, 10) })
         break
       }
       default:

--- a/src/logic/config/utils/index.ts
+++ b/src/logic/config/utils/index.ts
@@ -2,12 +2,8 @@ import { ChainId } from 'src/config/chain.d'
 import { store } from 'src/store'
 import { setChainIdAction } from 'src/logic/config/store/actions'
 import { _setChainId } from 'src/config'
-import onboard from 'src/logic/wallets/onboard'
 
 export const setChainId = (newChainId: ChainId) => {
   _setChainId(newChainId)
   store.dispatch(setChainIdAction(newChainId))
-
-  // Update Onboard's internal `appNetworkId` (not the provider)
-  onboard().config({ networkId: parseInt(newChainId, 10) })
 }


### PR DESCRIPTION
## What it solves
Updating Onboard's `appNetworkId` on setting the `chainId`.

## How this PR fixes it
Updating the config on Onboard is now done in the middleware as it is a side-effect.

## How to test it
- Pair on a network
- Change to another network via the Web UI
- Execute a transaction successfully