### PR TITLE
fix: Use web3readonly to get the nonce of currently connected wallet

### DIFF
--- a/src/logic/wallets/ethTransactions.ts
+++ b/src/logic/wallets/ethTransactions.ts
@@ -5,7 +5,7 @@ import { BigNumber } from 'bignumber.js'
 import { FeeHistoryResult } from 'web3-eth'
 import { hexToNumber } from 'web3-utils'
 
-import { getSDKWeb3ReadOnly, getWeb3, getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
+import { getSDKWeb3ReadOnly, getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
 import { getFixedGasPrice, getGasPriceOracles } from 'src/config'
 import { CodedException, Errors, logError } from 'src/logic/exceptions/CodedException'
 
@@ -98,7 +98,7 @@ export const calculateGasOf = async (txConfig: EthAdapterTransaction): Promise<n
 }
 
 export const getUserNonce = async (userAddress: string): Promise<number> => {
-  const web3 = getWeb3()
+  const web3 = getWeb3ReadOnly()
   try {
     return await web3.eth.getTransactionCount(userAddress, 'pending')
   } catch (error) {


### PR DESCRIPTION
## What it solves
Resolves #3564 

## How this PR fixes it
Use `web3ReadyOnly` to fetch the current connected wallet nonce instead of using `web3`

## How to test it

1. Open the Safe app on release/3.20.0
2. Connect web and mobile
3. Try to execute Txs on different networks with the same connected key
4. Open estimation details before execution on each network 
5. Observe that the nonce shown is the same as the wallet nonce

## Screenshots
![c](https://user-images.githubusercontent.com/5880855/155517536-30df4811-0da3-4a3d-ad20-0c044041781b.png)

