### PR TITLE
fix: init pairing w/ popper + don't reset on unmount

### DIFF
--- a/src/components/AppLayout/Header/components/Layout.tsx
+++ b/src/components/AppLayout/Header/components/Layout.tsx
@@ -1,5 +1,4 @@
 import ClickAwayListener from '@material-ui/core/ClickAwayListener'
-import Grow from '@material-ui/core/Grow'
 import List from '@material-ui/core/List'
 import Popper from '@material-ui/core/Popper'
 import { withStyles } from '@material-ui/core/styles'
@@ -68,25 +67,22 @@ const styles = () => ({
 })
 
 const WalletPopup = ({ anchorEl, providerDetails, classes, open, onClose }) => {
+  if (!open) {
+    return null
+  }
   return (
     <Popper
       anchorEl={anchorEl}
       className={classes.popper}
-      open={open}
+      open
       placement="bottom"
       popperOptions={{ positionFixed: true }}
     >
-      {({ TransitionProps }) => (
-        <Grow {...TransitionProps}>
-          <>
-            <ClickAwayListener mouseEvent="onClick" onClickAway={onClose} touchEvent={false}>
-              <List className={classes.root} component="div">
-                {providerDetails}
-              </List>
-            </ClickAwayListener>
-          </>
-        </Grow>
-      )}
+      <ClickAwayListener mouseEvent="onClick" onClickAway={onClose} touchEvent={false}>
+        <List className={classes.root} component="div">
+          {providerDetails}
+        </List>
+      </ClickAwayListener>
     </Popper>
   )
 }

--- a/src/logic/wallets/pairing/hooks/usePairing.ts
+++ b/src/logic/wallets/pairing/hooks/usePairing.ts
@@ -1,18 +1,11 @@
 import { useEffect } from 'react'
 
-import onboard from 'src/logic/wallets/onboard'
-import { initPairing, isPairingConnected, isPairingModule } from 'src/logic/wallets/pairing/utils'
+import { initPairing, isPairingConnected } from 'src/logic/wallets/pairing/utils'
 
 const usePairing = (): void => {
   useEffect(() => {
     if (!isPairingConnected()) {
       initPairing()
-    }
-
-    return () => {
-      if (isPairingModule() && !isPairingConnected()) {
-        onboard().walletReset()
-      }
     }
   }, [])
 }


### PR DESCRIPTION
## What it solves
Early pairing initialisation

## How this PR fixes it
The wallet popper only renders when the `open` flag is `true` and the pairing module does not reset the wallet when unmounting.

## How to test it
Load Safe and observe that the 'Mobile Safe' wallet is not immediately saved as a provider.