### PR TITLE
fix: revert cross-chain Onboard persistence

### DIFF
--- a/src/logic/config/store/middleware/index.ts
+++ b/src/logic/config/store/middleware/index.ts
@@ -22,8 +22,6 @@ export const configMiddleware =
         dispatch(clearCurrentSession())
         dispatch(loadSafesFromStorage())
         dispatch(loadCurrentSessionFromStorage())
-
-        onboard().config({ networkId: parseInt(action.payload, 10) })
         break
       }
       default:

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -5,8 +5,8 @@ import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 import { _getChainId, getChainName } from 'src/config'
 import { setWeb3, isSmartContractWallet, resetWeb3 } from 'src/logic/wallets/getWeb3'
 import transactionDataCheck from 'src/logic/wallets/transactionDataCheck'
-import { getSupportedWallets, isSupportedWallet } from 'src/logic/wallets/utils/walletList'
-import { ChainId, CHAIN_ID, WALLETS } from 'src/config/chain.d'
+import { getSupportedWallets } from 'src/logic/wallets/utils/walletList'
+import { ChainId, CHAIN_ID } from 'src/config/chain.d'
 import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 import { loadFromStorageWithExpiry, removeFromStorage, saveToStorageWithExpiry } from 'src/utils/storage'
 import { store } from 'src/store'
@@ -113,12 +113,9 @@ const getOnboard = (chainId: ChainId): API => {
 
 let currentOnboardInstance: API
 const onboard = (): API => {
-  // The `walletName` used in Onboard's `WalletSelectModuleOptions['wallets']` differs from the
-  // wallet name stored in its state
-  const walletName = currentOnboardInstance?.getState()?.wallet?.name?.replace(/-/g, '') as WALLETS
-
-  if (!currentOnboardInstance || (walletName && !isSupportedWallet(walletName))) {
-    currentOnboardInstance = getOnboard(_getChainId())
+  const chainId = _getChainId()
+  if (!currentOnboardInstance || currentOnboardInstance.getState().appNetworkId.toString() !== chainId) {
+    currentOnboardInstance = getOnboard(chainId)
   }
 
   return currentOnboardInstance


### PR DESCRIPTION
## What it solves
Provider with outdated `chainId`

## How this PR fixes it
The cross-chain persistence of Onboard has been reverted to how it was prior to desktop pairing.

Original change here: https://github.com/gnosis/safe-react/pull/3354/commits/2a179d450437550c8acef792e129965b2c194cf4

## How to test it
- Connect a wallet
- Switch network and observe that you will need to reconnect the wallet