### PR TITLE
fix: pairing invalid topic

### DIFF
--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -4,7 +4,6 @@ import { ThunkAction } from 'redux-thunk'
 
 import onboard, { checkWallet } from 'src/logic/wallets/onboard'
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
-import { isSmartContractWallet } from 'src/logic/wallets/getWeb3'
 import { getGnosisSafeInstanceAt } from 'src/logic/contracts/safeContracts'
 import { createTxNotifications } from 'src/logic/notifications'
 import {
@@ -211,15 +210,9 @@ export class TxSender {
 
   async canSignOffchain(state: AppReduxState): Promise<boolean> {
     const { isFinalization, safeVersion } = this
-    const { account, smartContractWallet } = providerSelector(state)
-    let isSmart = smartContractWallet
+    const { smartContractWallet } = providerSelector(state)
 
-    // WalletConnect/Mobile App aren't smart contracts per se but the connected account can be
-    if (!isSmart) {
-      isSmart = await isSmartContractWallet(account) // never throws
-    }
-
-    return checkIfOffChainSignatureIsPossible(isFinalization, isSmart, safeVersion)
+    return checkIfOffChainSignatureIsPossible(isFinalization, smartContractWallet, safeVersion)
   }
 
   async submitTx(

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -75,9 +75,6 @@ export const getChainIdFrom = (web3Provider: Web3): Promise<number> => {
 }
 
 export const isSmartContractWallet = async (account: string): Promise<boolean> => {
-  if (!account) {
-    return false
-  }
   let contractCode = ''
   try {
     contractCode = await getWeb3ReadOnly().eth.getCode(account)

--- a/src/logic/wallets/getWeb3.ts
+++ b/src/logic/wallets/getWeb3.ts
@@ -75,6 +75,9 @@ export const getChainIdFrom = (web3Provider: Web3): Promise<number> => {
 }
 
 export const isSmartContractWallet = async (account: string): Promise<boolean> => {
+  if (!account) {
+    return false
+  }
   let contractCode = ''
   try {
     contractCode = await getWeb3ReadOnly().eth.getCode(account)

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -67,13 +67,17 @@ const getOnboard = (chainId: ChainId): API => {
           updateProviderWallet({
             name: wallet.name || '',
             hardwareWallet: wallet.type === 'hardware',
-            smartContractWallet: await isSmartContractWallet(onboard().getState().address),
           }),
         )
       },
       // Non-checksummed address
-      address: (address) => {
-        store.dispatch(updateProviderAccount(address))
+      address: async (address) => {
+        store.dispatch(
+          updateProviderAccount({
+            account: address || '',
+            smartContractWallet: address ? await isSmartContractWallet(address) : false,
+          }),
+        )
 
         if (address) {
           prevAddress = address

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -3,7 +3,7 @@ import { API, Initialization } from 'bnc-onboard/dist/src/interfaces'
 import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { _getChainId, getChainName } from 'src/config'
-import { setWeb3, isSmartContractWallet, resetWeb3 } from 'src/logic/wallets/getWeb3'
+import { setWeb3, resetWeb3 } from 'src/logic/wallets/getWeb3'
 import transactionDataCheck from 'src/logic/wallets/transactionDataCheck'
 import { getSupportedWallets } from 'src/logic/wallets/utils/walletList'
 import { ChainId, CHAIN_ID } from 'src/config/chain.d'
@@ -71,13 +71,9 @@ const getOnboard = (chainId: ChainId): API => {
         )
       },
       // Non-checksummed address
-      address: async (address) => {
-        store.dispatch(
-          updateProviderAccount({
-            account: address || '',
-            smartContractWallet: address ? await isSmartContractWallet(address) : false,
-          }),
-        )
+      address: (address) => {
+        // isSmartContract is checked when address changes (in middleware)
+        store.dispatch(updateProviderAccount(address || ''))
 
         if (address) {
           prevAddress = address

--- a/src/logic/wallets/store/actions/index.ts
+++ b/src/logic/wallets/store/actions/index.ts
@@ -1,6 +1,7 @@
 export enum PROVIDER_ACTIONS {
   WALLET = 'provider/walletUpdated',
   ACCOUNT = 'provider/accountUpdated',
+  SMART_CONTRACT = 'provider/smartContract',
   NETWORK = 'provider/networkUpdated',
   ENS = 'provider/ensUpdated',
 }

--- a/src/logic/wallets/store/actions/updateProviderSmartContract.ts
+++ b/src/logic/wallets/store/actions/updateProviderSmartContract.ts
@@ -1,0 +1,6 @@
+import { createAction } from 'redux-actions'
+
+import { PROVIDER_ACTIONS } from 'src/logic/wallets/store/actions'
+import { ProviderSmartContractPayload } from 'src/logic/wallets/store/reducer'
+
+export const updateProviderSmartContract = createAction<ProviderSmartContractPayload>(PROVIDER_ACTIONS.SMART_CONTRACT)

--- a/src/logic/wallets/store/middleware/index.ts
+++ b/src/logic/wallets/store/middleware/index.ts
@@ -33,7 +33,7 @@ const providerMiddleware =
       hasAccount = !!payload
 
       // Check if wallet is smart contract
-      const smartContractWallet = payload && typeof payload === 'string' ? await isSmartContractWallet(payload) : false
+      const smartContractWallet = typeof payload === 'string' ? await isSmartContractWallet(payload) : false
       store.dispatch(updateProviderSmartContract(smartContractWallet))
     } else if (type === PROVIDER_ACTIONS.NETWORK) {
       hasNetwork = !!payload

--- a/src/logic/wallets/store/middleware/index.ts
+++ b/src/logic/wallets/store/middleware/index.ts
@@ -9,6 +9,8 @@ import { PROVIDER_ACTIONS } from 'src/logic/wallets/store/actions'
 import { ProviderPayloads } from 'src/logic/wallets/store/reducer'
 import { providerSelector } from '../selectors'
 import { currentChainId } from 'src/logic/config/store/selectors'
+import { isSmartContractWallet } from 'src/logic/wallets/getWeb3'
+import { updateProviderSmartContract } from 'src/logic/wallets/store/actions/updateProviderSmartContract'
 
 let hasWallet = false
 let hasAccount = false
@@ -29,6 +31,10 @@ const providerMiddleware =
       hasWallet = Object.values(payload).some(Boolean)
     } else if (type === PROVIDER_ACTIONS.ACCOUNT) {
       hasAccount = !!payload
+
+      // Check if wallet is smart contract
+      const smartContractWallet = payload && typeof payload === 'string' ? await isSmartContractWallet(payload) : false
+      store.dispatch(updateProviderSmartContract(smartContractWallet))
     } else if (type === PROVIDER_ACTIONS.NETWORK) {
       hasNetwork = !!payload
     } else {

--- a/src/logic/wallets/store/reducer/index.ts
+++ b/src/logic/wallets/store/reducer/index.ts
@@ -17,14 +17,16 @@ export type ProvidersState = {
 
 export type ProviderWalletPayload = Pick<ProvidersState, 'name' | 'hardwareWallet'>
 export type ProviderNetworkPayload = ProvidersState['network']
-export type ProviderAccountPayload = Pick<ProvidersState, 'account' | 'smartContractWallet'>
+export type ProviderAccountPayload = ProvidersState['account']
 export type ProviderEnsPayload = ProvidersState['ensDomain']
+export type ProviderSmartContractPayload = ProvidersState['smartContractWallet']
 
 export type ProviderPayloads =
   | ProviderWalletPayload
   | ProviderAccountPayload
   | ProviderNetworkPayload
   | ProviderEnsPayload
+  | ProviderSmartContractPayload
 
 const initialProviderState: ProvidersState = {
   name: '',
@@ -51,15 +53,14 @@ const providerReducer = handleActions<ProvidersState, ProviderPayloads>(
       providerFactory({ ...state, ...payload }),
     [PROVIDER_ACTIONS.NETWORK]: (state: ProvidersState, { payload }: Action<ProviderNetworkPayload>) =>
       providerFactory({ ...state, network: payload }),
-    [PROVIDER_ACTIONS.ACCOUNT]: (state: ProvidersState, { payload }: Action<ProviderAccountPayload>) => {
-      const { account, smartContractWallet } = payload
-      return providerFactory({
+    [PROVIDER_ACTIONS.ACCOUNT]: (state: ProvidersState, { payload }: Action<ProviderAccountPayload>) =>
+      providerFactory({
         ...state,
-        account: account ? checksumAddress(account) : '',
-        available: !!account,
-        smartContractWallet,
-      })
-    },
+        account: payload ? checksumAddress(payload) : '',
+        available: !!payload,
+      }),
+    [PROVIDER_ACTIONS.SMART_CONTRACT]: (state: ProvidersState, { payload }: Action<ProviderSmartContractPayload>) =>
+      providerFactory({ ...state, smartContractWallet: payload }),
     [PROVIDER_ACTIONS.ENS]: (state: ProvidersState, { payload }: Action<ProviderEnsPayload>) =>
       providerFactory({ ...state, ensDomain: payload }),
   },

--- a/src/logic/wallets/store/reducer/index.ts
+++ b/src/logic/wallets/store/reducer/index.ts
@@ -15,9 +15,9 @@ export type ProvidersState = {
   loaded: boolean
 }
 
-export type ProviderWalletPayload = Pick<ProvidersState, 'name' | 'hardwareWallet' | 'smartContractWallet'>
+export type ProviderWalletPayload = Pick<ProvidersState, 'name' | 'hardwareWallet'>
 export type ProviderNetworkPayload = ProvidersState['network']
-export type ProviderAccountPayload = ProvidersState['account']
+export type ProviderAccountPayload = Pick<ProvidersState, 'account' | 'smartContractWallet'>
 export type ProviderEnsPayload = ProvidersState['ensDomain']
 
 export type ProviderPayloads =
@@ -51,8 +51,15 @@ const providerReducer = handleActions<ProvidersState, ProviderPayloads>(
       providerFactory({ ...state, ...payload }),
     [PROVIDER_ACTIONS.NETWORK]: (state: ProvidersState, { payload }: Action<ProviderNetworkPayload>) =>
       providerFactory({ ...state, network: payload }),
-    [PROVIDER_ACTIONS.ACCOUNT]: (state: ProvidersState, { payload }: Action<ProviderAccountPayload>) =>
-      providerFactory({ ...state, account: checksumAddress(payload), available: !!payload }),
+    [PROVIDER_ACTIONS.ACCOUNT]: (state: ProvidersState, { payload }: Action<ProviderAccountPayload>) => {
+      const { account, smartContractWallet } = payload
+      return providerFactory({
+        ...state,
+        account: account ? checksumAddress(account) : '',
+        available: !!account,
+        smartContractWallet,
+      })
+    },
     [PROVIDER_ACTIONS.ENS]: (state: ProvidersState, { payload }: Action<ProviderEnsPayload>) =>
       providerFactory({ ...state, ensDomain: payload }),
   },

--- a/src/logic/wallets/utils/network.ts
+++ b/src/logic/wallets/utils/network.ts
@@ -20,7 +20,9 @@ const WALLET_ERRORS = {
 const requestSwitch = async (wallet: Wallet, chainId: ChainId): Promise<void> => {
   // Note: This could support WC too
   if (isPairingModule(wallet.name)) {
-    wallet.provider.wc.updateSession({ chainId: parseInt(chainId, 10), accounts: wallet.provider.wc.accounts })
+    if (wallet.provider) {
+      wallet.provider.wc.updateSession({ chainId: parseInt(chainId, 10), accounts: wallet.provider.wc.accounts })
+    }
   } else {
     await wallet.provider.request({
       method: 'wallet_switchEthereumChain',

--- a/src/routes/CreateSafePage/steps/SelectWalletAndNetworkStep.tsx
+++ b/src/routes/CreateSafePage/steps/SelectWalletAndNetworkStep.tsx
@@ -16,7 +16,7 @@ import { setChainId } from 'src/logic/config/utils'
 import { lg } from 'src/theme/variables'
 import NetworkLabel from 'src/components/NetworkLabel/NetworkLabel'
 import Paragraph from 'src/components/layout/Paragraph'
-import { providerNameSelector, shouldSwitchWalletChain } from 'src/logic/wallets/store/selectors'
+import { availableSelector, shouldSwitchWalletChain } from 'src/logic/wallets/store/selectors'
 import ConnectButton from 'src/components/ConnectButton'
 import WalletSwitch from 'src/components/WalletSwitch'
 import { getChains } from 'src/config/cache/chains'
@@ -25,7 +25,7 @@ export const selectWalletAndNetworkStepLabel = 'Connect wallet & select network'
 
 function SelectWalletAndNetworkStep(): ReactElement {
   const [isNetworkSelectorPopupOpen, setIsNetworkSelectorPopupOpen] = useState(false)
-  const isWalletConnected = !!useSelector(providerNameSelector)
+  const isWalletConnected = !!useSelector(availableSelector)
   const isWrongNetwork = useSelector(shouldSwitchWalletChain)
 
   function openNetworkSelectorPopup() {


### PR DESCRIPTION
## What it solves
Resolves #3581 

## How this PR fixes it
Checking whether the connected wallet is a smart contract now occurs in the middleware as a side effect.

Originally, the flag was checked against Onboard's internal state (when the wallet subscription was fired). This was causing it to recurse with the 'old' `chainId` when switching network. It no longer references it's internal state.

- The wallet subscription is often fired first, with an empty address state, meaning that `smartContractWallet` would always be `false`.
- A race condition was occuring because the `isSmartContractWallet` is asynchronous. The payload containing the flag, checked from the address, would be dispatched **after** the reset wallet.

## How to test it
- Pair with the Safe and switch network, observing that no 'invalid topic' error is thrown.
- Connect a normal wallet and observe that `providers.smartContractWallet` is `false` in the store.
- Connect a Safe-Safe via WC and observe that `providers.smartContractWallet` is `true` in the store.