### PR TITLE
fix: verify EIP-1271 signatures

### DIFF
--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -47,7 +47,7 @@ enum ErrorCodes {
   _811 = '811: Error calculating ERC721 transfer data for adding a Safe owner',
   _812 = '812: Error calculating ERC721 transfer data for removing a Safe owner',
   _813 = '813: Error calculating ERC721 transfer data for replacing a Safe owner',
-  _814 = '814: Error performing an off-chain tx signature',
+  _814 = '814: Error performing an tx signature',
   _815 = '815: Error preparing transaction sender',
   _816 = '816: Error saving transaction to history',
   _817 = '817: Unable to decode contract error message',

--- a/src/logic/exceptions/registry.ts
+++ b/src/logic/exceptions/registry.ts
@@ -47,7 +47,7 @@ enum ErrorCodes {
   _811 = '811: Error calculating ERC721 transfer data for adding a Safe owner',
   _812 = '812: Error calculating ERC721 transfer data for removing a Safe owner',
   _813 = '813: Error calculating ERC721 transfer data for replacing a Safe owner',
-  _814 = '814: Error performing an tx signature',
+  _814 = '814: Error signing a transaction',
   _815 = '815: Error preparing transaction sender',
   _816 = '816: Error saving transaction to history',
   _817 = '817: Unable to decode contract error message',

--- a/src/logic/safe/transactions/eip1271Signatures.ts
+++ b/src/logic/safe/transactions/eip1271Signatures.ts
@@ -7,7 +7,11 @@ const { utils } = ethers
 const MAGIC_VALUE = '0x1626ba7e'
 const MAGIC_VALUE_BYTES = '0x20c13b0b'
 
-export const isValid1271Signature = async (signerAddress: string, message: string, signature = EMPTY_DATA) => {
+export const isValid1271Signature = async (
+  signerAddress: string,
+  message: string,
+  signature = EMPTY_DATA,
+): Promise<boolean> => {
   if (!utils.getAddress(signerAddress)) {
     throw new Error('Invalid signer address')
   }
@@ -56,7 +60,12 @@ export const isValid1271Signature = async (signerAddress: string, message: strin
   }
 }
 
-const check1271Signature = async (signerAddress: string, msgBytes: Uint8Array, signature: string, web3: Web3) => {
+const check1271Signature = async (
+  signerAddress: string,
+  msgBytes: Uint8Array,
+  signature: string,
+  web3: Web3,
+): Promise<boolean> => {
   const fragment = ethers.utils.FunctionFragment.from({
     constant: true,
     inputs: [
@@ -131,7 +140,12 @@ const check1271Signature = async (signerAddress: string, msgBytes: Uint8Array, s
   return false
 }
 
-const check1271SignatureBytes = async (signerAddress: string, msgBytes: Uint8Array, signature: string, web3: Web3) => {
+const check1271SignatureBytes = async (
+  signerAddress: string,
+  msgBytes: Uint8Array,
+  signature: string,
+  web3: Web3,
+): Promise<boolean> => {
   const fragment = ethers.utils.FunctionFragment.from({
     constant: true,
     inputs: [

--- a/src/logic/safe/transactions/eip1271Signatures.ts
+++ b/src/logic/safe/transactions/eip1271Signatures.ts
@@ -1,0 +1,172 @@
+import { ethers } from 'ethers'
+import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
+import { getWeb3 } from 'src/logic/wallets/getWeb3'
+import Web3 from 'web3'
+const { utils } = ethers
+
+const MAGIC_VALUE = '0x1626ba7e'
+const MAGIC_VALUE_BYTES = '0x20c13b0b'
+
+export const isValid1271Signature = async (signerAddress: string, message: string, signature = EMPTY_DATA) => {
+  if (!utils.getAddress(signerAddress)) {
+    throw new Error('Invalid signer address')
+  }
+
+  if (!utils.isHexString(signature)) {
+    throw new Error('Signature must be a hex string')
+  }
+
+  const web3 = getWeb3()
+  if (!web3) {
+    throw new Error('Not connected to wallet')
+  }
+
+  let msgBytes: null | Uint8Array = null
+
+  // Set msgBytes as Buffer type
+  if (Buffer.isBuffer(message)) {
+    msgBytes = message
+  } else if (typeof message === 'string') {
+    if (utils.isHexString(message)) {
+      msgBytes = Buffer.from(message.substring(2), 'hex')
+    } else {
+      msgBytes = Buffer.from(message)
+    }
+  } else {
+    throw new Error('Message must be string or Buffer')
+  }
+
+  // Convert Buffer to ethers bytes array
+  msgBytes = ethers.utils.arrayify(msgBytes)
+  const bytecode = await web3.eth.getCode(signerAddress)
+
+  if (!bytecode || bytecode === '0x' || bytecode === '0x0' || bytecode === '0x00') {
+    const sigBytes = ethers.utils.arrayify(signature)
+    const msgSigner = utils.verifyMessage(msgBytes, sigBytes)
+    return msgSigner.toLowerCase() === signerAddress.toLowerCase()
+  } else {
+    if (await check1271Signature(signerAddress, msgBytes, signature, web3)) {
+      return true
+    }
+    if (await check1271SignatureBytes(signerAddress, msgBytes, signature, web3)) {
+      return true
+    }
+
+    return false
+  }
+}
+
+const check1271Signature = async (signerAddress: string, msgBytes: Uint8Array, signature: string, web3: Web3) => {
+  const fragment = ethers.utils.FunctionFragment.from({
+    constant: true,
+    inputs: [
+      {
+        name: 'message',
+        type: 'bytes32',
+      },
+      {
+        name: 'signature',
+        type: 'bytes',
+      },
+    ],
+    name: 'isValidSignature',
+    outputs: [
+      {
+        name: 'magicValue',
+        type: 'bytes4',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  })
+  const ifc = new ethers.utils.Interface([])
+
+  // Convert message to ETH signed message hash and call isValidSignature
+  try {
+    const msgHash = utils.hashMessage(msgBytes)
+    const isValidSignatureData = ifc.encodeFunctionData(fragment, [msgHash, signature])
+    const returnValue = (
+      await web3.eth.call({
+        to: signerAddress,
+        data: isValidSignatureData,
+      })
+    ).slice(0, 10)
+    if (returnValue.toLowerCase() === MAGIC_VALUE) {
+      return true
+    }
+  } catch (err) {}
+
+  // If the message is a 32 bytes, try without any conversion
+  if (msgBytes.length === 32) {
+    try {
+      const isValidSignatureData = ifc.encodeFunctionData(fragment, [msgBytes, signature])
+      const returnValue = (
+        await web3.eth.call({
+          to: signerAddress,
+          data: isValidSignatureData,
+        })
+      ).slice(0, 10)
+      if (returnValue.toLowerCase() === MAGIC_VALUE) {
+        return true
+      }
+    } catch (err) {}
+  }
+
+  // Try taking a regular hash of the message
+  try {
+    const msgHash = utils.keccak256(msgBytes)
+    const isValidSignatureData = ifc.encodeFunctionData(fragment, [msgHash, signature])
+    const returnValue = (
+      await web3.eth.call({
+        to: signerAddress,
+        data: isValidSignatureData,
+      })
+    ).slice(0, 10)
+    if (returnValue.toLowerCase() === MAGIC_VALUE) {
+      return true
+    }
+  } catch (err) {}
+
+  return false
+}
+
+const check1271SignatureBytes = async (signerAddress: string, msgBytes: Uint8Array, signature: string, web3: Web3) => {
+  const fragment = ethers.utils.FunctionFragment.from({
+    constant: true,
+    inputs: [
+      {
+        name: 'message',
+        type: 'bytes',
+      },
+      {
+        name: 'signature',
+        type: 'bytes',
+      },
+    ],
+    name: 'isValidSignature',
+    outputs: [
+      {
+        name: 'magicValue',
+        type: 'bytes4',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  })
+  const ifc = new ethers.utils.Interface([])
+
+  try {
+    const isValidSignatureData = ifc.encodeFunctionData(fragment, [msgBytes, signature])
+    const returnValue = (
+      await web3.eth.call({
+        to: signerAddress,
+        data: isValidSignatureData,
+      })
+    ).slice(0, 10)
+    if (returnValue.toLowerCase() === MAGIC_VALUE_BYTES) return true
+  } catch (err) {}
+
+  return false
+}


### PR DESCRIPTION
## What it solves
WalletConnect signature verification

## How this PR fixes it
When queueing/approving a transaction, if only an on-chain approval is possible (e.g. Safe-Safe) the on-chain hash is validated instead of checking against `'NaN'`.

## References
- Signature validation logic is taken from https://github.com/authereum/is-valid-signature
- Sandbox for signature validation: https://codesandbox.io/s/blissful-dewdney-sc25n?file=/src/is-valid-signature.ts

## How to test it
Create and do not execute/approve and do not execute transactions via WC (Safe-Safe) and observe no different/broken behaviour.