### PR TITLE
fix: Save and update QR Code uri in component state

### DIFF
--- a/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
@@ -9,7 +9,6 @@ import QRCode from 'qrcode.react'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import usePairing from 'src/logic/wallets/pairing/hooks/usePairing'
-import { getOnboardInstance } from 'src/logic/wallets/onboard'
 import { getPairingUri, initPairing, isPairingModule } from 'src/logic/wallets/pairing/utils'
 
 // Hides first wallet in Onboard modal (pairing module)
@@ -28,9 +27,9 @@ const qrRefresh: CSSProperties = {
 }
 
 const PairingDetails = ({ classes }: { classes: Record<string, string> }): ReactElement => {
-  const onboardUri = getOnboardInstance().getState().wallet.provider?.wc?.uri
+  const onboardUri = getPairingUri()
   const isPairingLoaded = isPairingModule()
-  const [uri, setUri] = useState<string>('')
+  const [uri, setUri] = useState<string>()
   usePairing()
 
   useEffect(() => {
@@ -49,7 +48,7 @@ const PairingDetails = ({ classes }: { classes: Record<string, string> }): React
 
       <Row className={classes.justifyCenter}>
         {uri ? (
-          <QRCode value={getPairingUri(uri)} size={QR_DIMENSION} />
+          <QRCode value={uri} size={QR_DIMENSION} />
         ) : isPairingLoaded ? (
           <Skeleton variant="rect" width={QR_DIMENSION} height={QR_DIMENSION} />
         ) : (

--- a/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement } from 'react'
+import { CSSProperties, ReactElement, useEffect, useState } from 'react'
 import Skeleton from '@material-ui/lab/Skeleton'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import IconButton from '@material-ui/core/IconButton'
@@ -9,7 +9,7 @@ import QRCode from 'qrcode.react'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import usePairing from 'src/logic/wallets/pairing/hooks/usePairing'
-import onboard from 'src/logic/wallets/onboard'
+import { getOnboardInstance } from 'src/logic/wallets/onboard'
 import { getPairingUri, initPairing, isPairingModule } from 'src/logic/wallets/pairing/utils'
 
 // Hides first wallet in Onboard modal (pairing module)
@@ -28,10 +28,14 @@ const qrRefresh: CSSProperties = {
 }
 
 const PairingDetails = ({ classes }: { classes: Record<string, string> }): ReactElement => {
+  const onboardUri = getOnboardInstance().getState().wallet.provider?.wc?.uri
+  const isPairingLoaded = isPairingModule()
+  const [uri, setUri] = useState<string>('')
   usePairing()
 
-  const uri = onboard().getState().wallet.provider?.wc?.uri
-  const isPairingLoaded = isPairingModule()
+  useEffect(() => {
+    setUri(onboardUri)
+  }, [onboardUri])
 
   return (
     <>

--- a/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement, useEffect, useState } from 'react'
+import { CSSProperties, ReactElement } from 'react'
 import Skeleton from '@material-ui/lab/Skeleton'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import IconButton from '@material-ui/core/IconButton'
@@ -9,10 +9,11 @@ import QRCode from 'qrcode.react'
 import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import usePairing from 'src/logic/wallets/pairing/hooks/usePairing'
-import { getPairingUri, initPairing, isPairingModule } from 'src/logic/wallets/pairing/utils'
+import { initPairing, isPairingModule } from 'src/logic/wallets/pairing/utils'
 
 // Hides first wallet in Onboard modal (pairing module)
 import 'src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css'
+import { useGetPairingUri } from 'src/logic/wallets/pairing/hooks/useGetPairingUri'
 
 const StyledDivider = styled(Divider)`
   width: calc(100% + 40px);
@@ -27,14 +28,9 @@ const qrRefresh: CSSProperties = {
 }
 
 const PairingDetails = ({ classes }: { classes: Record<string, string> }): ReactElement => {
-  const onboardUri = getPairingUri()
+  const uri = useGetPairingUri()
   const isPairingLoaded = isPairingModule()
-  const [uri, setUri] = useState<string>()
   usePairing()
-
-  useEffect(() => {
-    setUri(onboardUri)
-  }, [onboardUri])
 
   return (
     <>

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -112,6 +112,9 @@ const getOnboard = (chainId: ChainId): API => {
 }
 
 let currentOnboardInstance: API
+export const getOnboardInstance = (): API => {
+  return currentOnboardInstance
+}
 const onboard = (): API => {
   const chainId = _getChainId()
   if (!currentOnboardInstance || currentOnboardInstance.getState().appNetworkId.toString() !== chainId) {

--- a/src/logic/wallets/pairing/hooks/useGetPairingUri.ts
+++ b/src/logic/wallets/pairing/hooks/useGetPairingUri.ts
@@ -1,0 +1,13 @@
+import { getPairingUri } from 'src/logic/wallets/pairing/utils'
+import { useEffect, useState } from 'react'
+
+export const useGetPairingUri = (): string | undefined => {
+  const onboardUri = getPairingUri()
+  const [uri, setUri] = useState<string>()
+
+  useEffect(() => {
+    setUri(onboardUri)
+  }, [onboardUri])
+
+  return uri
+}

--- a/src/logic/wallets/pairing/utils.ts
+++ b/src/logic/wallets/pairing/utils.ts
@@ -3,7 +3,7 @@ import { Wallet } from 'bnc-onboard/dist/src/interfaces'
 import { getDisabledWallets } from 'src/config'
 import { PAIRING_MODULE_NAME } from 'src/logic/wallets/pairing/module'
 import { WALLETS } from 'src/config/chain.d'
-import onboard from 'src/logic/wallets/onboard'
+import onboard, { getOnboardInstance } from 'src/logic/wallets/onboard'
 
 export const initPairing = async (): Promise<void> => {
   await onboard().walletSelect(PAIRING_MODULE_NAME)
@@ -23,7 +23,8 @@ export const isPairingModule = (name: Wallet['name'] = onboard().getState().wall
   return name === PAIRING_MODULE_NAME
 }
 
-export const getPairingUri = (wcUri: string): string => {
+export const getPairingUri = (): string | undefined => {
+  const wcUri = getOnboardInstance().getState().wallet.provider?.wc?.uri
   const PAIRING_MODULE_URI_PREFIX = 'safe-'
-  return `${PAIRING_MODULE_URI_PREFIX}${wcUri}`
+  return wcUri ? `${PAIRING_MODULE_URI_PREFIX}${wcUri}` : undefined
 }


### PR DESCRIPTION
## What it solves
Resolves #3589 

## How this PR fixes it
The QR Code uri is now saved and updated within the `PairingDetails` component state whenever the uri from the onboard instance changes. This triggers necessary rerenders in order to display the correct QR Code.

## How to test it

1. Open the Safe app
2. Connect to the safe by scanning the QR Code
3. Press Reject on your phone
4. Refresh the QR Code
5. Observe that the new QR code can be used again
