### PR TITLE
chore: Bump web3 version to 1.7.0

### DIFF
--- a/src/logic/hooks/useEstimateSafeCreationGas.tsx
+++ b/src/logic/hooks/useEstimateSafeCreationGas.tsx
@@ -7,6 +7,7 @@ import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
 import { calculateGasPrice, getFeesPerGas, setMaxPrioFeePerGas } from 'src/logic/wallets/ethTransactions'
 import { userAccountSelector } from '../wallets/store/selectors'
 import { getNativeCurrency } from 'src/config'
+import { isMaxFeeParam } from 'src/logic/safe/transactions/gas'
 
 type EstimateSafeCreationGasProps = {
   addresses: string[]
@@ -32,7 +33,7 @@ const estimateGas = async (
   const [gasEstimation, gasPrice, feesPerGas] = await Promise.all([
     estimateGasForDeployingSafe(addresses, numOwners, userAccount, safeCreationSalt),
     calculateGasPrice(),
-    getFeesPerGas(),
+    isMaxFeeParam() ? getFeesPerGas() : { maxPriorityFeePerGas: 0, maxFeePerGas: 0 },
   ])
 
   const estimatedGasCosts = gasEstimation * parseInt(gasPrice, 10)


### PR DESCRIPTION
## What it solves
Resolves #3586 

## How this PR fixes it
- Version [1.7.0](https://github.com/ChainSafe/web3.js/releases/tag/v1.7.0) of web3.js changed the first parameter type for `getFeeHistory` from `number` to `hex`. Using `number` type with the Gnosischain RPC caused errors.
- We also check that the network supports EIP-1559 before fetching `getFeeHistory` in `useEstimateSafeCreationGas`. This is in line with our implementation in `useEstimateTransactionGas`

## How to test it
1. Open a Safe on Gnosischain
2. Create a transaction
3. Observe that the fee estimation works

## ToDos
~Only use `getFeeHistory` on networks that support it. There seems to be an error when creating a Safe on Arbitrum~