### PR TITLE
fix: bump Client GW SDK version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@gnosis.pm/safe-core-sdk": "^1.3.0",
     "@gnosis.pm/safe-deployments": "^1.8.0",
     "@gnosis.pm/safe-react-components": "^0.9.7",
-    "@gnosis.pm/safe-react-gateway-sdk": "2.8.3",
+    "@gnosis.pm/safe-react-gateway-sdk": "^2.8.6",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.0",
     "@material-ui/lab": "4.0.0-alpha.60",

--- a/src/components/DecodeTxs/index.tsx
+++ b/src/components/DecodeTxs/index.tsx
@@ -101,25 +101,27 @@ export const BasicTxInfo = ({
 export const getParameterElement = (parameter: DecodedDataBasicParameter, index: number): ReactElement => {
   let valueElement
 
-  if (parameter.type === 'address') {
-    valueElement = (
-      <PrefixedEthHashInfo
-        hash={parameter.value}
-        showAvatar
-        textSize="lg"
-        showCopyBtn
-        explorerUrl={getExplorerInfo(parameter.value)}
-      />
-    )
-  }
-
-  if (parameter.type === 'bytes') {
-    valueElement = (
-      <FlexWrapper margin={5}>
-        <Text size="lg">{getByteLength(parameter.value)} bytes</Text>
-        <CopyToClipboardBtn textToCopy={parameter.value} />
-      </FlexWrapper>
-    )
+  if (!Array.isArray(parameter.value)) {
+    switch (parameter.type) {
+      case 'address':
+        valueElement = (
+          <PrefixedEthHashInfo
+            hash={parameter.value}
+            showAvatar
+            textSize="lg"
+            showCopyBtn
+            explorerUrl={getExplorerInfo(parameter.value)}
+          />
+        )
+        break
+      case 'bytes':
+        valueElement = (
+          <FlexWrapper margin={5}>
+            <Text size="lg">{getByteLength(parameter.value)} bytes</Text>
+            <CopyToClipboardBtn textToCopy={parameter.value} />
+          </FlexWrapper>
+        )
+    }
   }
 
   if (!valueElement) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,13 +1947,6 @@
     react-media "^1.10.0"
     web3-utils "^1.6.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@2.8.3":
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.3.tgz#413875ab6eaedf5cad6c2d6f27e503e9a7715d21"
-  integrity sha512-M0Ay+A3ea+5eHD3uSQ+Hu3h7EzAE8F8pI0mZGuFioCUmZMa3Sv1K7OFDvXoL7Na/J2MVmOpyamBlyB5CPHpGyQ==
-  dependencies:
-    isomorphic-unfetch "^3.1.0"
-
 "@gnosis.pm/safe-react-gateway-sdk@^2.5.6":
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.7.4.tgz#3a1d96e30d10e4859579b558586fd25cd4ae3480"
@@ -1965,6 +1958,13 @@
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.5.tgz#3b82b993ae64a5fde1a96a4b0c47a97514839055"
   integrity sha512-lrZ3gXzbNzIjIzYDs21d7I3fwwHi01YFnD+2+5Kuy0+fJAiONYXih2Z9Q4h3RS/AgzTHfL+G7WB6XB0V8GMVCQ==
+  dependencies:
+    isomorphic-unfetch "^3.1.0"
+
+"@gnosis.pm/safe-react-gateway-sdk@^2.8.6":
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.6.tgz#842c1f40ed6bd9164965836d7c4abcfe0a009af2"
+  integrity sha512-XPDOGQtUc1AON/xM4y5mGWMQ/VVaajRXVEdVmKCWOboK0bk1spkuD5oyo9hF0SB3f+lClIagb9PojOurjjWogw==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 


### PR DESCRIPTION
## How this PR fixes it
- Upgrade `@gnosis.pm/safe-react-gateway-sdk` to the latest published version.
- Adapts `getParameterElement()` to handle the upgraded types
