### PR TITLE
fix: Revert back to using onboard() in order to get the onboard instance

### DIFF
--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -112,9 +112,6 @@ const getOnboard = (chainId: ChainId): API => {
 }
 
 let currentOnboardInstance: API
-export const getOnboardInstance = (): API => {
-  return currentOnboardInstance
-}
 const onboard = (): API => {
   const chainId = _getChainId()
   if (!currentOnboardInstance || currentOnboardInstance.getState().appNetworkId.toString() !== chainId) {

--- a/src/logic/wallets/pairing/utils.ts
+++ b/src/logic/wallets/pairing/utils.ts
@@ -3,7 +3,7 @@ import { Wallet } from 'bnc-onboard/dist/src/interfaces'
 import { getDisabledWallets } from 'src/config'
 import { PAIRING_MODULE_NAME } from 'src/logic/wallets/pairing/module'
 import { WALLETS } from 'src/config/chain.d'
-import onboard, { getOnboardInstance } from 'src/logic/wallets/onboard'
+import onboard from 'src/logic/wallets/onboard'
 
 export const initPairing = async (): Promise<void> => {
   await onboard().walletSelect(PAIRING_MODULE_NAME)
@@ -24,7 +24,7 @@ export const isPairingModule = (name: Wallet['name'] = onboard().getState().wall
 }
 
 export const getPairingUri = (): string | undefined => {
-  const wcUri = getOnboardInstance().getState().wallet.provider?.wc?.uri
+  const wcUri = onboard().getState().wallet.provider?.wc?.uri
   const PAIRING_MODULE_URI_PREFIX = 'safe-'
   return wcUri ? `${PAIRING_MODULE_URI_PREFIX}${wcUri}` : undefined
 }


### PR DESCRIPTION
## What it solves
Resolves #3589 

## How this PR fixes it
Reverting back to use `onboard()` in order to get the onboard instance.

## How to test it
1. Open the Safe app
2. Press on Connect Wallet
3. Observe that it doesn't crash
