### PR TITLE
fix: Check that last used provider is enabled before loading it

### DIFF
--- a/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
@@ -9,6 +9,7 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { KeyRing } from 'src/components/AppLayout/Header/components/KeyRing'
 import { isPairingSupported } from 'src/logic/wallets/pairing/utils'
+// We need lazy import because the component imports static css that should only be applied if the component is rendered
 const PairingDetails = lazy(() => import('src/components/AppLayout/Header/components/ProviderDetails/PairingDetails'))
 
 const styles = () => ({

--- a/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { lazy, ReactElement } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import { Card } from '@gnosis.pm/safe-react-components'
 import styled from 'styled-components'
@@ -9,7 +9,7 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { KeyRing } from 'src/components/AppLayout/Header/components/KeyRing'
 import { isPairingSupported } from 'src/logic/wallets/pairing/utils'
-import PairingDetails from 'src/components/AppLayout/Header/components/ProviderDetails/PairingDetails'
+const PairingDetails = lazy(() => import('src/components/AppLayout/Header/components/ProviderDetails/PairingDetails'))
 
 const styles = () => ({
   header: {

--- a/src/components/AppLayout/Header/index.tsx
+++ b/src/components/AppLayout/Header/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, Suspense } from 'react'
+import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 
 import Layout from './components/Layout'
@@ -16,6 +16,7 @@ import {
 } from 'src/logic/wallets/store/selectors'
 import onboard, { loadLastUsedProvider } from 'src/logic/wallets/onboard'
 import { isSupportedWallet } from 'src/logic/wallets/utils/walletList'
+import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 
 const HeaderComponent = (): React.ReactElement => {
   const provider = useSelector(providerNameSelector)
@@ -56,11 +57,7 @@ const HeaderComponent = (): React.ReactElement => {
 
   const getProviderDetailsBased = () => {
     if (!loaded) {
-      return (
-        <Suspense fallback={null}>
-          <ConnectDetails />
-        </Suspense>
-      )
+      return wrapInSuspense(<ConnectDetails />)
     }
 
     return (

--- a/src/components/AppLayout/Header/index.tsx
+++ b/src/components/AppLayout/Header/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, Suspense } from 'react'
 import { useSelector } from 'react-redux'
 
 import Layout from './components/Layout'
@@ -15,6 +15,7 @@ import {
   userEnsSelector,
 } from 'src/logic/wallets/store/selectors'
 import onboard, { loadLastUsedProvider } from 'src/logic/wallets/onboard'
+import { isSupportedWallet } from 'src/logic/wallets/utils/walletList'
 
 const HeaderComponent = (): React.ReactElement => {
   const provider = useSelector(providerNameSelector)
@@ -27,7 +28,8 @@ const HeaderComponent = (): React.ReactElement => {
   useEffect(() => {
     const tryToConnectToLastUsedProvider = async () => {
       const lastUsedProvider = loadLastUsedProvider()
-      if (lastUsedProvider) {
+      const isProviderEnabled = lastUsedProvider && isSupportedWallet(lastUsedProvider)
+      if (isProviderEnabled) {
         await onboard().walletSelect(lastUsedProvider)
       }
     }
@@ -54,7 +56,11 @@ const HeaderComponent = (): React.ReactElement => {
 
   const getProviderDetailsBased = () => {
     if (!loaded) {
-      return <ConnectDetails />
+      return (
+        <Suspense fallback={null}>
+          <ConnectDetails />
+        </Suspense>
+      )
     }
 
     return (

--- a/src/logic/wallets/utils/walletList.ts
+++ b/src/logic/wallets/utils/walletList.ts
@@ -68,7 +68,7 @@ const wallets = (chainId: ChainId): Wallet[] => {
   ]
 }
 
-export const isSupportedWallet = (name: WALLETS): boolean => {
+export const isSupportedWallet = (name: WALLETS | string): boolean => {
   return !getDisabledWallets().some((walletName) => {
     // walletName is config wallet name, name is the wallet module name and differ
     return walletName.replace(/\s/g, '').toLowerCase() === name.replace(/\s/g, '').toLowerCase()


### PR DESCRIPTION
## What it solves
Relates to #3589 

## How this PR fixes it
- Before trying to load the last used provider we now also check that it is still enabled in our config
- Lazy import `PairingModule` because it imports static css to hide the first result in the onboard window which is MetaMask in case the pairing module is disabled

## How to test it
1. Open the Safe app with dev CGW
2. Connect to the safe via mobile app
3. Disconnect
4. Switch to prod CGW
5. Try to connect via MetaMask
6. Observe that App doesn't crash
7. Observe that the onboard popup doesn't automatically open
