### PR TITLE
fix: supported wallets

### DIFF
--- a/src/logic/wallets/utils/walletList.ts
+++ b/src/logic/wallets/utils/walletList.ts
@@ -78,8 +78,11 @@ export const isSupportedWallet = (name: WALLETS | string): boolean => {
 export const getSupportedWallets = (chainId: ChainId): WalletSelectModuleOptions['wallets'] => {
   const supportedWallets: WalletSelectModuleOptions['wallets'] = wallets(chainId)
     .filter(({ walletName, desktop }) => {
+      if (!isSupportedWallet(walletName)) {
+        return false
+      }
       // Desktop vs. Web app wallet support
-      return isSupportedWallet(walletName) && window.isDesktop ? desktop : true
+      return window.isDesktop ? desktop : true
     })
     .map(({ desktop: _, ...rest }) => rest)
 


### PR DESCRIPTION
## What it solves
Broken wallet support

## How this PR fixes it
If a wallet is unsupported they are filtered out of the `getSupportedWallets`. They are further filtered depending on whether the build environment is the desktop/web app.

## How to test it
Open the Onboard modal and observe that the supported wallets match that of the CGW.