### PR TITLE
fix: Set safeTxGas to 0 when rejecting a tx

### DIFF
--- a/src/logic/hooks/__tests__/useEstimateSafeTxGas.test.ts
+++ b/src/logic/hooks/__tests__/useEstimateSafeTxGas.test.ts
@@ -12,15 +12,35 @@ jest.mock('react-redux', () => {
 
 describe('useEstimateSafeTxGas', () => {
   it(`should return 0 if it is not a tx creation`, () => {
+    const spy = jest.spyOn(gas, 'estimateSafeTxGas')
+
     const { result } = renderHook(() =>
       useEstimateSafeTxGas({
         txAmount: '',
         txData: '',
         txRecipient: '',
         isCreation: false,
+        isRejectTx: false,
       }),
     )
     expect(result.current).toBe('0')
+    expect(spy).toHaveBeenCalledTimes(0)
+  })
+
+  it(`should return 0 if it is a reject tx`, () => {
+    const spy = jest.spyOn(gas, 'estimateSafeTxGas')
+
+    const { result } = renderHook(() =>
+      useEstimateSafeTxGas({
+        txAmount: '',
+        txData: '',
+        txRecipient: '',
+        isCreation: false,
+        isRejectTx: true,
+      }),
+    )
+    expect(result.current).toBe('0')
+    expect(spy).toHaveBeenCalledTimes(0)
   })
 
   it(`calls estimateSafeTxGas if it is a tx creation`, () => {
@@ -32,6 +52,7 @@ describe('useEstimateSafeTxGas', () => {
         txData: '',
         txRecipient: '',
         isCreation: true,
+        isRejectTx: false,
       }),
     )
     expect(spy).toHaveBeenCalledTimes(1)
@@ -48,6 +69,7 @@ describe('useEstimateSafeTxGas', () => {
         txData: '',
         txRecipient: '',
         isCreation: true,
+        isRejectTx: false,
       }),
     )
     expect(spy).toHaveBeenCalledTimes(1)

--- a/src/logic/hooks/useEstimateSafeTxGas.tsx
+++ b/src/logic/hooks/useEstimateSafeTxGas.tsx
@@ -7,6 +7,7 @@ import { currentSafe } from 'src/logic/safe/store/selectors'
 
 type UseEstimateSafeTxGasProps = {
   isCreation: boolean
+  isRejectTx: boolean
   txData: string
   txRecipient: string
   txAmount: string
@@ -15,6 +16,7 @@ type UseEstimateSafeTxGasProps = {
 
 export const useEstimateSafeTxGas = ({
   isCreation,
+  isRejectTx,
   txData,
   txRecipient,
   txAmount,
@@ -24,7 +26,7 @@ export const useEstimateSafeTxGas = ({
   const { address: safeAddress, currentVersion: safeVersion } = useSelector(currentSafe) ?? {}
 
   useEffect(() => {
-    if (!isCreation) return
+    if (!isCreation || isRejectTx) return
     const estimateSafeTxGasCall = async () => {
       try {
         const safeTxGasEstimation = await estimateSafeTxGas(

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -117,6 +117,7 @@ export const TxModalWrapper = ({
 
   const safeTxGasEstimation = useEstimateSafeTxGas({
     isCreation,
+    isRejectTx,
     txData,
     txRecipient: txTo || safeAddress,
     txAmount: txValue,


### PR DESCRIPTION
## What it solves
Resolves #3516 

[Discussion on Slack](https://gnosisinc.slack.com/archives/CQB729LLF/p1644236001648339?thread_ts=1644235724.832739&cid=CQB729LLF)

## How this PR fixes it
When creating a reject Tx we now hard-code `safeTxGas` with 0

## How to test it
1. Open the Safe app
2. Create and Queue a Transaction
3. Reject the Transaction
4. Observe that the new Transaction is titled correctly

## Analytics changes

## Screenshots
![Screenshot 2022-03-01 at 17 44 03](https://user-images.githubusercontent.com/5880855/156211214-e775e7ca-dfed-47b3-a904-5536384482b6.png)

