### PR TITLE
fix: Remove Beamer cookies on consent withdraw

### DIFF
--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -8,15 +8,15 @@ import Link from 'src/components/layout/Link'
 import { COOKIES_KEY, BannerCookiesType, COOKIE_IDS, COOKIE_ALERTS } from 'src/logic/cookies/model/cookie'
 import { closeCookieBanner, openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { cookieBannerState } from 'src/logic/cookies/store/selectors'
-import { loadFromCookie, saveCookie } from 'src/logic/cookies/utils'
+import { loadFromCookie, removeCookies, saveCookie } from 'src/logic/cookies/utils'
 import { mainFontFamily, md, primary, screenSm } from 'src/theme/variables'
-import { loadGoogleAnalytics, removeCookies } from 'src/utils/googleAnalytics'
+import { GA_COOKIE_LIST, loadGoogleAnalytics } from 'src/utils/googleAnalytics'
 import { closeIntercom, isIntercomLoaded, loadIntercom } from 'src/utils/intercom'
 import AlertRedIcon from './assets/alert-red.svg'
 import IntercomIcon from './assets/intercom.png'
 import { useSafeAppUrl } from 'src/logic/hooks/useSafeAppUrl'
 import { CookieAttributes } from 'js-cookie'
-import { closeBeamer, loadBeamer } from 'src/utils/beamer'
+import { BEAMER_COOKIE_LIST, closeBeamer, loadBeamer } from 'src/utils/beamer'
 
 const isDesktop = process.env.REACT_APP_BUILD_FOR_DESKTOP
 
@@ -189,11 +189,12 @@ const CookiesBanner = (): ReactElement => {
     setShowIntercom(localSupportAndUpdates)
 
     if (!localAnalytics) {
-      removeCookies()
+      removeCookies(GA_COOKIE_LIST)
     }
 
     if (!localSupportAndUpdates) {
       closeBeamer(beamerScriptRef)
+      removeCookies(BEAMER_COOKIE_LIST)
       if (isIntercomLoaded()) {
         closeIntercom()
       }

--- a/src/logic/cookies/utils/index.ts
+++ b/src/logic/cookies/utils/index.ts
@@ -1,6 +1,11 @@
 import Cookies, { CookieAttributes } from 'js-cookie'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
+export type Cookie = {
+  name: string
+  path: string
+}
+
 const PREFIX = 'v1_MAINNET__'
 
 export const loadFromCookie = async <T extends Record<string, any>>(
@@ -37,3 +42,9 @@ export const saveCookie = async <T extends Record<string, any>>(
 }
 
 export const removeCookie = (key: string, path: string, domain: string): void => Cookies.remove(key, { path, domain })
+
+export const removeCookies = (cookieList: Cookie[]): void => {
+  // Extracts the main domain, e.g. gnosis-safe.io
+  const subDomain = location.host.split('.').slice(-2).join('.')
+  cookieList.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${subDomain}`))
+}

--- a/src/logic/cookies/utils/index.ts
+++ b/src/logic/cookies/utils/index.ts
@@ -44,7 +44,7 @@ export const saveCookie = async <T extends Record<string, any>>(
 export const removeCookie = (key: string, path: string, domain: string): void => Cookies.remove(key, { path, domain })
 
 export const removeCookies = (cookieList: Cookie[]): void => {
-  // Extracts the main domain, e.g. gnosis-safe.io
-  const subDomain = location.host.split('.').slice(-2).join('.')
-  cookieList.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${subDomain}`))
+  // Extracts domain, e.g. gnosis-safe.io
+  const domain = location.host.split('.').slice(-2).join('.')
+  cookieList.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${domain}`))
 }

--- a/src/utils/beamer.ts
+++ b/src/utils/beamer.ts
@@ -1,6 +1,15 @@
 import { BEAMER_ID } from './constants'
 import { MutableRefObject } from 'react'
 import { BeamerConfig } from 'src/types/Beamer'
+import { Cookie } from 'src/logic/cookies/utils'
+
+export const BEAMER_COOKIE_LIST: Cookie[] = [
+  { name: `_BEAMER_LAST_POST_SHOWN_${BEAMER_ID}`, path: '/' },
+  { name: `_BEAMER_DATE_${BEAMER_ID}`, path: '/' },
+  { name: `_BEAMER_FIRST_VISIT_${BEAMER_ID}`, path: '/' },
+  { name: `_BEAMER_USER_ID_${BEAMER_ID}`, path: '/' },
+  { name: `_BEAMER_FILTER_BY_URL_${BEAMER_ID}`, path: '/' },
+]
 
 const BEAMER_URL = 'https://app.getbeamer.com/js/beamer-embed.js'
 

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -5,7 +5,7 @@ import { getChainInfo, _getChainId } from 'src/config'
 
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { COOKIES_KEY, BannerCookiesType } from 'src/logic/cookies/model/cookie'
-import { loadFromCookie, removeCookie } from 'src/logic/cookies/utils'
+import { Cookie, loadFromCookie } from 'src/logic/cookies/utils'
 import { GOOGLE_ANALYTICS_ID, IS_PRODUCTION } from './constants'
 import { capitalize } from './css'
 
@@ -73,7 +73,7 @@ export const SETTINGS_EVENTS: Record<string, EventArgs> = {
   OWNERS: { ...SAFE_EVENTS.SETTINGS, label: 'Owners' },
 }
 
-export const COOKIES_LIST = [
+export const GA_COOKIE_LIST: Cookie[] = [
   { name: '_ga', path: '/' },
   { name: '_gat', path: '/' },
   { name: '_gid', path: '/' },
@@ -178,11 +178,4 @@ export const useAnalytics = (): UseAnalyticsResponse => {
   )
 
   return { trackPage, trackEvent }
-}
-
-// we remove GA cookies manually as react-ga does not provides a utility for it.
-export const removeCookies = (): void => {
-  // Extracts the main domain, e.g. gnosis-safe.io
-  const subDomain = location.host.split('.').slice(-2).join('.')
-  COOKIES_LIST.forEach((cookie) => removeCookie(cookie.name, cookie.path, `.${subDomain}`))
 }


### PR DESCRIPTION
## What it solves
Resolves #3608 

## How this PR fixes it
When withdrawing consent for _Community Support & Updates_ cookies all `_BEAMER` cookies are deleted

## How to test it
1. Open the Safe app
2. Accept all cookies
3. Observe `_BEAMER` cookies being added
4. Open Cookie Preferences
5. Uncheck _Community Support & Updates_ and save
6. Reload the page
7. Observe `_BEAMER` cookies not existing anymore
