### PR TITLE
fix: enable detected wallet

### DIFF
--- a/src/config/chain.d.ts
+++ b/src/config/chain.d.ts
@@ -17,6 +17,7 @@ export const CHAIN_ID: Record<ChainName, ChainId> = {
 
 // Values match that required of onboard and returned by CGW
 export enum WALLETS {
+  ONBOARD_DETECTED_WALLET = 'detectedwallet',
   SAFE_MOBILE = 'safeMobile',
   METAMASK = 'metamask',
   WALLET_CONNECT = 'walletConnect',

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -97,7 +97,7 @@ const getOnboard = (chainId: ChainId): API => {
     },
     walletSelect: {
       description: 'Please select a wallet to connect to Gnosis Safe',
-      wallets: [{ walletName: 'detectedwallet' }, ...(getSupportedWallets(chainId) || [])],
+      wallets: getSupportedWallets(chainId),
     },
     walletCheck: [
       { checkName: 'derivationPath' },

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -97,7 +97,7 @@ const getOnboard = (chainId: ChainId): API => {
     },
     walletSelect: {
       description: 'Please select a wallet to connect to Gnosis Safe',
-      wallets: getSupportedWallets(chainId),
+      wallets: [{ walletName: 'detectedwallet' }, ...(getSupportedWallets(chainId) || [])],
     },
     walletCheck: [
       { checkName: 'derivationPath' },

--- a/src/logic/wallets/utils/walletList.ts
+++ b/src/logic/wallets/utils/walletList.ts
@@ -37,6 +37,10 @@ const wallets = (chainId: ChainId): Wallet[] => {
       LedgerTransport: (window as any).TransportNodeHid,
     },
     {
+      walletName: WALLETS.ONBOARD_DETECTED_WALLET,
+      desktop: false,
+    },
+    {
       walletName: WALLETS.KEYSTONE,
       desktop: false,
       rpcUrl,


### PR DESCRIPTION
## What it solves
Resolves #3607

## How this PR fixes it
Onboard now has the option of using a detected wallet.

## How to test it
- Install the frame.sh browser extension
- Open the onboard modal and see the option of connecting to Frame wallet