### PR TITLE
fix: clarify nonce warning

### DIFF
--- a/src/components/ReviewInfoText/ReviewInfoText.test.tsx
+++ b/src/components/ReviewInfoText/ReviewInfoText.test.tsx
@@ -66,7 +66,7 @@ describe('<ReviewInfoText>', () => {
 
     expect(screen.getByText(/6/)).toBeInTheDocument()
     expect(screen.getByText(/9/)).toBeInTheDocument()
-    expect(screen.getByText(/is below the latest transaction's nonce./)).toBeInTheDocument()
-    expect(screen.getByText(/Your transaction might fail./)).toBeInTheDocument()
+    expect(screen.getByText(/is below the latest transaction's nonce in your queue./)).toBeInTheDocument()
+    expect(screen.getByText(/Please verify the submitted nonce./)).toBeInTheDocument()
   })
 })

--- a/src/components/ReviewInfoText/index.tsx
+++ b/src/components/ReviewInfoText/index.tsx
@@ -59,7 +59,8 @@ export const ReviewInfoText = ({
           /* tx in the past */ <>
             Nonce&nbsp;
             <b>{safeTxNonce}</b>
-            &nbsp;is below the latest transaction&apos;s nonce. Your transaction might fail. Please use nonce&nbsp;
+            &nbsp;is below the latest transaction&apos;s nonce in your queue. Please verify the submitted nonce. The
+            next recommended nonce is &nbsp;
             <b>{recommendedNonce}</b>.
           </>
         )}


### PR DESCRIPTION
## What it solves
Resolves #3616

## How this PR fixes it
When submitting a transaction with a nonce lower than the queue but higher than that of the Safe, the warning does not signify failure of the transaction.

## How to test it
- Create and queue a transaction 2 nonces higher than that of the Safe nonce.
- Create a transaction but edit the nonce to be 1 higher than that of the Safe nonce.
- Observe the new warning message

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/156563139-b4cc1b60-a594-4164-abc5-e39a872eb235.png)