### PR TITLE
Chore: change the NFT action to a manual trigger

### DIFF
--- a/.github/workflows/mint.yml
+++ b/.github/workflows/mint.yml
@@ -1,9 +1,11 @@
 name: Mint PR NFT
 
 on:
-  pull_request:
-    branches:
-      - dev
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: 'PR number'
+        required: true
 
 jobs:
   mint:
@@ -18,7 +20,7 @@ jobs:
           wallet-key: ${{ secrets.WALLET_KEY }}
           contract: ${{ secrets.CONTRACT_ADDRESS }}
           function: "tokenURI(uint256 _tokenId)"
-          inputs: '[ ${{ github.event.number }} ]'
+          inputs: '[ ${{ github.event.inputs.prNumber }} ]'
           value: "0"
 
       - name: Mint
@@ -30,17 +32,17 @@ jobs:
           wallet-key: ${{ secrets.WALLET_KEY }}
           contract: ${{ secrets.CONTRACT_ADDRESS }}
           function: "mint(address _to, uint256 _tokenId, string _uri)"
-          inputs: '[ "${{ secrets.WALLET_ADDRESS }}", ${{ github.event.number }}, "https://github.com/gnosis/safe-react/pull/${{ github.event.number }}" ]'
+          inputs: '[ "${{ secrets.WALLET_ADDRESS }}", ${{ github.event.inputs.prNumber }}, "https://github.com/gnosis/safe-react/pull/${{ github.event.inputs.prNumber }}" ]'
           value: "0"
 
       - name: Set success comment
         if: steps.mint.outcome == 'success'
         uses: peter-evans/create-or-update-comment@v1
         with:
-          issue-number: ${{ github.event.number }}
+          issue-number: ${{ github.event.inputs.prNumber }}
           body: |
-            [<img alt="GitMint NFT preview" width="200" src="https://gitsvg.katspaugh.workers.dev/?svg=1&url=https://github.com/gnosis/safe-react/pull/${{ github.event.number }}" />](https://blockscout.com/xdai/mainnet/token/${{ secrets.CONTRACT_ADDRESS }}/instance/${{ github.event.number }})
+            [<img alt="GitMint NFT preview" width="200" src="https://gitsvg.katspaugh.workers.dev/?svg=1&url=https://github.com/gnosis/safe-react/pull/${{ github.event.inputs.prNumber }}" />](https://blockscout.com/xdai/mainnet/token/${{ secrets.CONTRACT_ADDRESS }}/instance/${{ github.event.inputs.prNumber }})
 
             Dear @${{ github.event.pull_request.user.login }},
-            Thank you for your contribution! Please, let us know your Ethereum address to receive [this NFT on Gnosis Chain](https://epor.io/tokens/${{ secrets.CONTRACT_ADDRESS }}/${{ github.event.number }}?network=xDai).
+            Thank you for your contribution! Please, let us know your Ethereum address to receive [this NFT on Gnosis Chain](https://epor.io/tokens/${{ secrets.CONTRACT_ADDRESS }}/${{ github.event.inputs.prNumber }}?network=xDai).
             Cheers! 🏆


### PR DESCRIPTION
Instead of triggering the action on each PR, we'll be manually launching it via the GitHub UI and pasting a target PR number.