### PR TITLE
Fix typo in Settings Component

### DIFF
--- a/src/routes/safe/components/Settings/Appearance/index.tsx
+++ b/src/routes/safe/components/Settings/Appearance/index.tsx
@@ -53,7 +53,7 @@ const Appearance = (): ReactElement => {
     <>
       <Container>
         <Heading tag="h2">Use Chain-Specific Addresses</Heading>
-        <Paragraph>You can choose whether to prepend EIP-3770 short chain names accross Safes.</Paragraph>
+        <Paragraph>You can choose whether to prepend EIP-3770 short chain names across Safes.</Paragraph>
         <StyledPrefixedEthHashInfo hash={safeAddress} />
         <FormGroup>
           <FormControlLabel


### PR DESCRIPTION
## What it solves
Resolves #
A typo in the Settings page accross -> across
## How this PR fixes it

## How to test it

## Analytics changes

## Screenshots
