### PR TITLE
fix: Only hide first wallet if mobile pairing is enabled

### DIFF
--- a/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
@@ -9,6 +9,7 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { KeyRing } from 'src/components/AppLayout/Header/components/KeyRing'
 import { isPairingSupported } from 'src/logic/wallets/pairing/utils'
+import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 // We need lazy import because the component imports static css that should only be applied if the component is rendered
 const PairingDetails = lazy(() => import('src/components/AppLayout/Header/components/ProviderDetails/PairingDetails'))
 
@@ -52,7 +53,7 @@ const ConnectDetails = ({ classes }): ReactElement => (
       <ConnectButton data-testid="heading-connect-btn" />
     </Block>
 
-    {isPairingSupported() && <PairingDetails classes={classes} />}
+    {isPairingSupported() && wrapInSuspense(<PairingDetails classes={classes} />)}
   </StyledCard>
 )
 

--- a/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement } from 'react'
+import { CSSProperties, ReactElement, useEffect } from 'react'
 import Skeleton from '@material-ui/lab/Skeleton'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import IconButton from '@material-ui/core/IconButton'
@@ -10,9 +10,6 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import usePairing from 'src/logic/wallets/pairing/hooks/usePairing'
 import { initPairing, isPairingModule } from 'src/logic/wallets/pairing/utils'
-
-// Hides first wallet in Onboard modal (pairing module)
-import 'src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css'
 import { useGetPairingUri } from 'src/logic/wallets/pairing/hooks/useGetPairingUri'
 
 const StyledDivider = styled(Divider)`
@@ -31,6 +28,17 @@ const PairingDetails = ({ classes }: { classes: Record<string, string> }): React
   const uri = useGetPairingUri()
   const isPairingLoaded = isPairingModule()
   usePairing()
+
+  // Hides first wallet in Onboard modal (pairing module)
+  useEffect(() => {
+    const style = document.createElement('style')
+    style.innerHTML = '.bn-onboard-modal-select-wallets li:first-of-type {display: none;}'
+    document.head.appendChild(style)
+
+    return () => {
+      style.remove()
+    }
+  }, [])
 
   return (
     <>

--- a/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
@@ -12,6 +12,8 @@ import usePairing from 'src/logic/wallets/pairing/hooks/usePairing'
 import { initPairing, isPairingModule } from 'src/logic/wallets/pairing/utils'
 import { useGetPairingUri } from 'src/logic/wallets/pairing/hooks/useGetPairingUri'
 
+const HIDE_PAIRING_STYLE = '.bn-onboard-modal-select-wallets li:first-of-type {display: none;}'
+
 const StyledDivider = styled(Divider)`
   width: calc(100% + 40px);
   margin-left: -20px;
@@ -32,7 +34,7 @@ const PairingDetails = ({ classes }: { classes: Record<string, string> }): React
   // Hides first wallet in Onboard modal (pairing module)
   useEffect(() => {
     const style = document.createElement('style')
-    style.innerHTML = '.bn-onboard-modal-select-wallets li:first-of-type {display: none;}'
+    style.innerHTML = HIDE_PAIRING_STYLE
     document.head.appendChild(style)
 
     return () => {

--- a/src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css
+++ b/src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css
@@ -1,4 +1,0 @@
-/* Hides pairing module from Onboard wallet selection modal */
-.bn-onboard-modal-select-wallets li:first-of-type {
-  display: none;
-}

--- a/src/components/AppLayout/Header/index.tsx
+++ b/src/components/AppLayout/Header/index.tsx
@@ -16,7 +16,6 @@ import {
 } from 'src/logic/wallets/store/selectors'
 import onboard, { loadLastUsedProvider } from 'src/logic/wallets/onboard'
 import { isSupportedWallet } from 'src/logic/wallets/utils/walletList'
-import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 
 const HeaderComponent = (): React.ReactElement => {
   const provider = useSelector(providerNameSelector)
@@ -57,7 +56,7 @@ const HeaderComponent = (): React.ReactElement => {
 
   const getProviderDetailsBased = () => {
     if (!loaded) {
-      return wrapInSuspense(<ConnectDetails />)
+      return <ConnectDetails />
     }
 
     return (


### PR DESCRIPTION
## What it solves
Resolves #3624 

## How this PR fixes it
Instead of normally importing the css within `PairingDetails` and leaving it there we now import it on mount and remove it once the component unmounts.

## Additional refactors
`wrapInSuspense` was moved closer to the component that required it (`PairingDetails`)

## How to test it
1. Open the Safe app
2. Connect to a network that has mobile pairing enabled
3. Click "Connect Wallet
4. Switch to a network that has mobile pairing disabled e.g. Gnosis Chain
5. Click on "Connect Wallet" > "Connect"
6. Observe that MetaMask (first wallet) is visible

## Screenshot
![Screenshot 2022-03-07 at 12 15 13](https://user-images.githubusercontent.com/5880855/157020981-9fe9bd45-e60c-4c47-8b1d-0d4b458a505a.png)

