### PR TITLE
Revert "fix: enable detected wallet (#3612)"

### DIFF
--- a/src/config/chain.d.ts
+++ b/src/config/chain.d.ts
@@ -17,7 +17,6 @@ export const CHAIN_ID: Record<ChainName, ChainId> = {
 
 // Values match that required of onboard and returned by CGW
 export enum WALLETS {
-  ONBOARD_DETECTED_WALLET = 'detectedwallet',
   SAFE_MOBILE = 'safeMobile',
   METAMASK = 'metamask',
   WALLET_CONNECT = 'walletConnect',

--- a/src/logic/wallets/utils/walletList.ts
+++ b/src/logic/wallets/utils/walletList.ts
@@ -37,10 +37,6 @@ const wallets = (chainId: ChainId): Wallet[] => {
       LedgerTransport: (window as any).TransportNodeHid,
     },
     {
-      walletName: WALLETS.ONBOARD_DETECTED_WALLET,
-      desktop: false,
-    },
-    {
       walletName: WALLETS.KEYSTONE,
       desktop: false,
       rpcUrl,


### PR DESCRIPTION
This reverts commit d68693497a452bb8efc4f7917cbb8aff3cf2abf7.

## What it solves
Resolves #3607

## How this PR fixes it
Onboard no longer detects injected wallets.

This was added in favour of 'fixing' Frame support but it didn't work. There does not seem to be any historical implementation of it either and in an effort to avoid future bugs, it will be reverted.

## How to test it
Open the Onboard modal and observe that "Detected Wallet" is no longer shown.