### PR TITLE
fix: Extract safe address when using currentSafe selector

### DIFF
--- a/src/logic/safe/store/selectors/index.ts
+++ b/src/logic/safe/store/selectors/index.ts
@@ -20,10 +20,12 @@ export const latestMasterContractVersion = createSelector(safesState, (safeState
   safeState.get('latestMasterContractVersion'),
 )
 
-export const currentSafe = createSelector([safesAsMap], (safes: SafesMap) => {
-  const address = extractSafeAddress()
-  return safes.get(address, baseSafe(address))
-})
+export const currentSafe = createSelector(
+  [safesAsMap, () => extractSafeAddress()],
+  (safes: SafesMap, address: string) => {
+    return safes.get(address, baseSafe(address))
+  },
+)
 
 const baseSafe = (address = '') => makeSafe({ address })
 


### PR DESCRIPTION
## What it solves
Resolves #3565 

## How this PR fixes it
When switching networks, the `currentSafe` selector didn't get an up-to-date safe address sometimes but instead used a cached value. Moving the `extractSafeAddress` call to the selector arguments solves this issue.

## How to test it
1. Open the safe app
2. Switch to safes in different networks so that they are saved in localStorage
3. Connect with mobile pairing
4. Switch to other networks
5. Observe that the last used safe of those networks is correctly loaded and visible in the sidebar
6. Observe that there is no Safe loading error visible
