### PR TITLE
fix: Don't shrink sidebar on smaller screens

### DIFF
--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -41,6 +41,7 @@ const SidebarWrapper = styled.aside`
   width: 200px;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   z-index: 1;
 
   padding: 8px 8px 0 8px;


### PR DESCRIPTION
## What it solves
Relates to https://github.com/gnosis/safe-react/pull/3620#issuecomment-1062134989

## How this PR fixes it
Changes the sidebar so it doesn't shrink and keeps its fixed width of 200px at all times

## How to test it
1. Open the safe app
2. Change the viewport to a lower width
3. Observe that the sidebar width doesn't change

## Screenshots
![Screenshot 2022-03-09 at 11 27 34](https://user-images.githubusercontent.com/5880855/157423407-89da2ac4-e849-4401-9d5b-e2401f1425d3.png)

