### PR TITLE
fix: pass alert key to the openBanner callback

### DIFF
--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -204,14 +204,17 @@ const CookiesBanner = isDesktop
       const { cookieBannerOpen } = useSelector(cookieBannerState)
       const isSafeAppView = useSafeAppUrl().getAppUrl() !== null
 
-      const openBanner = useCallback((): void => {
-        dispatch(
-          openCookieBanner({
-            cookieBannerOpen: true,
-            key: COOKIE_IDS.INTERCOM,
-          }),
-        )
-      }, [dispatch])
+      const openBanner = useCallback(
+        (key?: COOKIE_IDS): void => {
+          dispatch(
+            openCookieBanner({
+              cookieBannerOpen: true,
+              key,
+            }),
+          )
+        },
+        [dispatch],
+      )
 
       const closeBanner = useCallback((): void => {
         dispatch(closeCookieBanner())
@@ -290,7 +293,9 @@ const CookiesBanner = isDesktop
       return (
         <>
           {/* A fake Intercom button before Intercom is loaded */}
-          {!localSupportAndUpdates && !isSafeAppView && <FakeIntercomButton onClick={openBanner} />}
+          {!localSupportAndUpdates && !isSafeAppView && (
+            <FakeIntercomButton onClick={() => openBanner(COOKIE_IDS.INTERCOM)} />
+          )}
 
           {/* The cookie banner itself */}
           {cookieBannerOpen && (


### PR DESCRIPTION
## What it solves
Resolves #3638

## How this PR fixes it
The openBanner callback receives a key to set an alert message.

## How to test it
Open a Incognito window. The Cookie banner shall display initially without any warning

## Screenshots
![Screen Shot 2022-03-09 at 14 40 25](https://user-images.githubusercontent.com/32431609/157453067-0cbe996e-5cb0-4193-89bf-b1763b38ce88.png)

