### PR TITLE
fix: Delete Beamer cookies only if it was previously loaded

### DIFF
--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -114,7 +114,7 @@ const CookiesBannerForm = (props: {
       <div className={classes.content}>
         {key && (
           <div className={classes.intercomAlert}>
-            <img src={AlertRedIcon} />
+            <img src={AlertRedIcon} alt="" />
             {COOKIE_ALERTS[key]}
           </div>
         )}
@@ -176,6 +176,7 @@ const CookiesBannerForm = (props: {
 const FakeIntercomButton = ({ onClick }: { onClick: () => void }): ReactElement => {
   return (
     <img
+      alt="Open Intercom"
       style={{
         position: 'fixed',
         cursor: 'pointer',
@@ -245,8 +246,6 @@ const CookiesBanner = isDesktop
         cookiesAnalytics: boolean,
       ): void => {
         closeBanner()
-        cookiesSupportAndUpdates ? loadBeamer() : unloadBeamer()
-        cookiesAnalytics ? loadGoogleAnalytics() : unloadGoogleAnalytics()
         saveNewCookieState(cookiesNecessary, cookiesSupportAndUpdates, cookiesAnalytics)
 
         setLocalNecessary(cookiesNecessary)
@@ -266,12 +265,15 @@ const CookiesBanner = isDesktop
 
         const { acceptedNecessary, acceptedSupportAndUpdates, acceptedAnalytics } = cookiesState
 
-        acceptedSupportAndUpdates && loadBeamer()
-        acceptedAnalytics && loadGoogleAnalytics()
         setLocalNecessary(acceptedNecessary)
         setLocalSupportAndUpdates(acceptedSupportAndUpdates)
         setLocalAnalytics(acceptedAnalytics)
       }, [setLocalNecessary, setLocalSupportAndUpdates, setLocalAnalytics, openBanner])
+
+      // Load or unload analytics depending on user choice
+      useEffect(() => {
+        localAnalytics ? loadGoogleAnalytics() : unloadGoogleAnalytics()
+      }, [localAnalytics])
 
       // Toggle Intercom
       useEffect(() => {
@@ -284,6 +286,11 @@ const CookiesBanner = isDesktop
           !isIntercomLoaded() && loadIntercom()
         }
       }, [localSupportAndUpdates, isSafeAppView])
+
+      // Toggle Beamer
+      useEffect(() => {
+        localSupportAndUpdates ? loadBeamer() : unloadBeamer()
+      }, [localSupportAndUpdates])
 
       return (
         <>

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -245,6 +245,8 @@ const CookiesBanner = isDesktop
         cookiesAnalytics: boolean,
       ): void => {
         closeBanner()
+        cookiesSupportAndUpdates ? loadBeamer() : unloadBeamer()
+        cookiesAnalytics ? loadGoogleAnalytics() : unloadGoogleAnalytics()
         saveNewCookieState(cookiesNecessary, cookiesSupportAndUpdates, cookiesAnalytics)
 
         setLocalNecessary(cookiesNecessary)
@@ -263,15 +265,13 @@ const CookiesBanner = isDesktop
         }
 
         const { acceptedNecessary, acceptedSupportAndUpdates, acceptedAnalytics } = cookiesState
+
+        acceptedSupportAndUpdates && loadBeamer()
+        acceptedAnalytics && loadGoogleAnalytics()
         setLocalNecessary(acceptedNecessary)
         setLocalSupportAndUpdates(acceptedSupportAndUpdates)
         setLocalAnalytics(acceptedAnalytics)
       }, [setLocalNecessary, setLocalSupportAndUpdates, setLocalAnalytics, openBanner])
-
-      // Load or unload analytics depending on user choice
-      useEffect(() => {
-        localAnalytics ? loadGoogleAnalytics() : unloadGoogleAnalytics()
-      }, [localAnalytics])
 
       // Toggle Intercom
       useEffect(() => {
@@ -284,11 +284,6 @@ const CookiesBanner = isDesktop
           !isIntercomLoaded() && loadIntercom()
         }
       }, [localSupportAndUpdates, isSafeAppView])
-
-      // Toggle Beamer
-      useEffect(() => {
-        localSupportAndUpdates ? loadBeamer() : unloadBeamer()
-      }, [localSupportAndUpdates])
 
       return (
         <>

--- a/src/utils/beamer.ts
+++ b/src/utils/beamer.ts
@@ -43,15 +43,12 @@ export const loadBeamer = async (): Promise<void> => {
   scriptRef.addEventListener('load', () => window.Beamer?.init(), { once: true })
 }
 
-const closeBeamer = (): void => {
+export const unloadBeamer = (): void => {
   if (!window.Beamer || !scriptRef) return
+
   window.Beamer.destroy()
   scriptRef.remove()
   scriptRef = null
-}
-
-export const unloadBeamer = (): void => {
-  closeBeamer()
 
   setTimeout(() => {
     local.removeMatching(BEAMER_LS_RE)

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -134,7 +134,9 @@ export const loadGoogleAnalytics = (): void => {
 }
 
 export const unloadGoogleAnalytics = (): void => {
-  removeCookies(GA_COOKIE_LIST)
+  if (analyticsLoaded) {
+    removeCookies(GA_COOKIE_LIST)
+  }
 }
 
 type UseAnalyticsResponse = {


### PR DESCRIPTION
## What it solves
Resolves #3652 

## How this PR fixes it
We split the logic for loading and unloading Beamer. While we load Beamer both on user interaction with the cookie banner and page reload, unloading it (deleting cookies) only happens on user interaction now.

## Additional fix
Since the logic was the same for Google Analytics, I included it in this fix.

## How to test it
1. Open the Safe app
2. Accept all cookies
3. Observe that "Whats new" has a green dot next to it
4. Click on "Whats new"
5. Reload the page
6. Observe that Beamer cookies / localStorage are not deleted/reset
7. Observe that "Whats new" doesn't have a green dot anymore
