### PR TITLE
fix: Hide first wallet in onboard modal if mobile pairing is enabled

### DIFF
--- a/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/ConnectDetails.tsx
@@ -10,7 +10,6 @@ import Row from 'src/components/layout/Row'
 import { KeyRing } from 'src/components/AppLayout/Header/components/KeyRing'
 import { isPairingSupported } from 'src/logic/wallets/pairing/utils'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
-// We need lazy import because the component imports static css that should only be applied if the component is rendered
 const PairingDetails = lazy(() => import('src/components/AppLayout/Header/components/ProviderDetails/PairingDetails'))
 
 const styles = () => ({

--- a/src/components/AppLayout/Header/components/ProviderDetails/HidePairingModule.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/HidePairingModule.tsx
@@ -1,0 +1,6 @@
+import 'src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css'
+import { ReactElement } from 'react'
+
+const HidePairingModule = (): ReactElement => <></>
+
+export default HidePairingModule

--- a/src/components/AppLayout/Header/components/ProviderDetails/HidePairingModule.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/HidePairingModule.tsx
@@ -1,6 +1,19 @@
-import 'src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css'
-import { ReactElement } from 'react'
+import { useEffect } from 'react'
 
-const HidePairingModule = (): ReactElement => <></>
+const HIDE_PAIRING_STYLE = '.bn-onboard-modal-select-wallets li:first-of-type {display: none;}'
+
+const HidePairingModule = (): null => {
+  useEffect(() => {
+    const style = document.createElement('style')
+    style.innerHTML = HIDE_PAIRING_STYLE
+    document.head.appendChild(style)
+
+    return () => {
+      style.remove()
+    }
+  }, [])
+
+  return null
+}
 
 export default HidePairingModule

--- a/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
+++ b/src/components/AppLayout/Header/components/ProviderDetails/PairingDetails.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement, useEffect } from 'react'
+import { CSSProperties, ReactElement } from 'react'
 import Skeleton from '@material-ui/lab/Skeleton'
 import RefreshIcon from '@material-ui/icons/Refresh'
 import IconButton from '@material-ui/core/IconButton'
@@ -11,8 +11,6 @@ import Row from 'src/components/layout/Row'
 import usePairing from 'src/logic/wallets/pairing/hooks/usePairing'
 import { initPairing, isPairingModule } from 'src/logic/wallets/pairing/utils'
 import { useGetPairingUri } from 'src/logic/wallets/pairing/hooks/useGetPairingUri'
-
-const HIDE_PAIRING_STYLE = '.bn-onboard-modal-select-wallets li:first-of-type {display: none;}'
 
 const StyledDivider = styled(Divider)`
   width: calc(100% + 40px);
@@ -30,17 +28,6 @@ const PairingDetails = ({ classes }: { classes: Record<string, string> }): React
   const uri = useGetPairingUri()
   const isPairingLoaded = isPairingModule()
   usePairing()
-
-  // Hides first wallet in Onboard modal (pairing module)
-  useEffect(() => {
-    const style = document.createElement('style')
-    style.innerHTML = HIDE_PAIRING_STYLE
-    document.head.appendChild(style)
-
-    return () => {
-      style.remove()
-    }
-  }, [])
 
   return (
     <>

--- a/src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css
+++ b/src/components/AppLayout/Header/components/ProviderDetails/hidePairingModule.css
@@ -1,3 +1,0 @@
-.bn-onboard-modal-select-wallets li:first-of-type {
-    display: none;
-}

--- a/src/components/AppLayout/Header/index.tsx
+++ b/src/components/AppLayout/Header/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { lazy, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 
 import Layout from './components/Layout'
@@ -16,6 +16,12 @@ import {
 } from 'src/logic/wallets/store/selectors'
 import onboard, { loadLastUsedProvider } from 'src/logic/wallets/onboard'
 import { isSupportedWallet } from 'src/logic/wallets/utils/walletList'
+import { isPairingSupported } from 'src/logic/wallets/pairing/utils'
+import { wrapInSuspense } from 'src/utils/wrapInSuspense'
+
+const HidePairingModule = lazy(
+  () => import('src/components/AppLayout/Header/components/ProviderDetails/HidePairingModule'),
+)
 
 const HeaderComponent = (): React.ReactElement => {
   const provider = useSelector(providerNameSelector)
@@ -74,7 +80,12 @@ const HeaderComponent = (): React.ReactElement => {
   const info = getProviderInfoBased()
   const details = getProviderDetailsBased()
 
-  return <Layout providerDetails={details} providerInfo={info} />
+  return (
+    <>
+      {isPairingSupported() && wrapInSuspense(<HidePairingModule />)}
+      <Layout providerDetails={details} providerInfo={info} />
+    </>
+  )
 }
 
 export default HeaderComponent


### PR DESCRIPTION
## What it solves
Resolves #3624 

## How this PR fixes it
Instead of including the css for hiding the first wallet within `PairingDetails` it is now included within the `Header` component that always exists.

## How to test it
1. Open the Safe app
2. Navigate to Create Safe
3. Click on Connect
4. Observe that "Safe Mobile" Link is not visible
5. Click on Connect Wallet > Connect in the Header
6. Observe that "Safe Mobile" Link is not visible

