### PR TITLE
fix: asset types

### DIFF
--- a/src/logic/collectibles/sources/Gnosis.ts
+++ b/src/logic/collectibles/sources/Gnosis.ts
@@ -1,4 +1,4 @@
-import { SafeCollectibleResponse, TransactionTokenType } from '@gnosis.pm/safe-react-gateway-sdk'
+import { SafeCollectibleResponse, TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { Collectibles, NFTAsset, NFTAssets, NFTTokens } from 'src/logic/collectibles/sources/collectibles.d'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
@@ -12,7 +12,7 @@ type TokenResult = {
   logoUri: string
   name: string
   symbol: string
-  type: TransactionTokenType
+  type: TokenType
 }
 
 type FetchResult = {
@@ -27,7 +27,7 @@ class Gnosis {
       logoUri,
       name: tokenName,
       symbol: tokenSymbol,
-      type: TransactionTokenType.ERC721,
+      type: TokenType.ERC721,
     }))
 
     return assets

--- a/src/routes/safe/components/Transactions/TxList/TokenTransferAmount.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TokenTransferAmount.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@gnosis.pm/safe-react-components'
-import { TransactionTokenType } from '@gnosis.pm/safe-react-gateway-sdk'
+import { TokenType } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement } from 'react'
 import styled from 'styled-components'
 
@@ -34,7 +34,7 @@ export const TokenTransferAmount = ({ assetInfo }: TokenTransferAmountProps): Re
         height={26}
         onError={(error) => {
           error.currentTarget.onerror = null
-          error.currentTarget.src = assetInfo.tokenType === TransactionTokenType.ERC721 ? NFTIcon : TokenPlaceholder
+          error.currentTarget.src = assetInfo.tokenType === TokenType.ERC721 ? NFTIcon : TokenPlaceholder
         }}
         src={assetInfo.logoUri}
       />

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -42,6 +42,7 @@ jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => {
     // We require some of the enums/types from the original module
     ...originalModule,
     Operation: jest.fn(),
+    TokenType: jest.fn(),
     TransactionTokenType: jest.fn(),
     TransactionStatus: jest.fn(),
     TransferDirection: jest.fn(),


### PR DESCRIPTION
## What it solves
Comments made by @dasanra (https://github.com/gnosis/safe-react/pull/3640)

## How this PR fixes it
Assets now use `TokenType` instead of the transaction-specific type.