### PR TITLE
feat: Add getCommunicationInfo method and new prop to SafeInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@ethersproject/hash": "^5.5.0",
-    "@gnosis.pm/safe-apps-sdk": "6.2.0",
+    "@gnosis.pm/safe-apps-sdk": "7.3.0",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
     "@gnosis.pm/safe-deployments": "^1.8.0",

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -191,7 +191,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
       return tx
     })
 
-    communicator?.on(Methods.getCommunicationInfo, async () => ({
+    communicator?.on(Methods.getEnvironmentInfo, async () => ({
       origin: document.location.origin,
     }))
 

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -34,6 +34,7 @@ import { SignMessageModal } from './SignMessageModal'
 import { web3HttpProviderOptions } from 'src/logic/wallets/getWeb3'
 import { useThirdPartyCookies } from '../hooks/useThirdPartyCookies'
 import { ThirdPartyCookiesWarning } from './ThirdPartyCookiesWarning'
+import { grantedSelector } from 'src/routes/safe/container/selector'
 
 const AppWrapper = styled.div`
   display: flex;
@@ -87,6 +88,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
   const { address: safeAddress, ethBalance, owners, threshold } = useSelector(currentSafe)
   const { nativeCurrency, chainId, chainName, shortName } = getChainInfo()
   const safeName = useSelector((state) => addressBookEntryName(state, { address: safeAddress }))
+  const granted = useSelector(grantedSelector)
   const { trackEvent } = useAnalytics()
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [confirmTransactionModal, setConfirmTransactionModal] =
@@ -174,6 +176,9 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
   const communicator = useAppCommunicator(iframeRef, safeApp)
 
   useEffect(() => {
+    /**
+     * @deprecated: getEnvInfo is a legacy method. Should not be used
+     */
     communicator?.on('getEnvInfo', () => ({
       txServiceUrl: getTxServiceUrl(),
     }))
@@ -186,6 +191,10 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
       return tx
     })
 
+    communicator?.on(Methods.getCommunicationInfo, async () => ({
+      origin: document.location.origin,
+    }))
+
     communicator?.on(Methods.getSafeInfo, () => ({
       safeAddress,
       // FIXME `network` is deprecated. we should find how many apps are still using it
@@ -194,6 +203,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
       chainId: parseInt(chainId, 10),
       owners,
       threshold,
+      isReadOnly: !granted,
     }))
 
     communicator?.on(Methods.getSafeBalances, async (msg) => {
@@ -263,6 +273,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
     chainName,
     shortName,
     safeAppWeb3Provider,
+    granted,
   ])
 
   const onUserTxConfirm = (safeTxHash: string, requestId: RequestId) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,6 +1922,14 @@
     "@gnosis.pm/safe-react-gateway-sdk" "^2.5.6"
     ethers "^5.4.7"
 
+"@gnosis.pm/safe-apps-sdk@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-7.3.0.tgz#3a3ed38b75657a7d5cd58d5a6884ec60087b05a8"
+  integrity sha512-1f6VHJWqPRKAEg/m+fbO1XiaDrsTcI3PQg31A0ciHATlVVoh35BYXryijaQxXblLzz4eDgbbIXQdNAH683j87Q==
+  dependencies:
+    "@gnosis.pm/safe-react-gateway-sdk" "^2.10.0"
+    ethers "^5.4.7"
+
 "@gnosis.pm/safe-apps-sdk@^6.2.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-6.3.0.tgz#19f8bff136bdfdf9003745e4202e1cb85322e493"
@@ -1965,7 +1973,7 @@
     react-media "^1.10.0"
     web3-utils "^1.6.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@^2.10.1":
+"@gnosis.pm/safe-react-gateway-sdk@^2.10.0", "@gnosis.pm/safe-react-gateway-sdk@^2.10.1":
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.10.1.tgz#62f4abf733855e734aa1eab4be4778ccd08fe689"
   integrity sha512-uIosTEqmoxhCy7WS8sIzXde2nJQwzC+KfNoeDQVeLZtEpnRZQ7R+N/qDtORMUJfKeyc8cIwkKXmVc2DRgSRxOQ==


### PR DESCRIPTION
# What it solves
Resolves https://github.com/gnosis/safe-apps-sdk/issues/301, resolves https://github.com/gnosis/safe-react-apps/issues/374

# How this PR fixes it
We are doing 2 different things here:

1) Adding a new method `getCommunicationInfo()` used by returning some info about the communicator. By now we are returning the origin as we need it in the walletConnect app and is difficult to get it inside an iframe (Current approach `ancestorOrigins` is not supported on Firefox

2) We are including a new property `isReadOnly` on the SafeInfo object allowing as to know safe apps if the safe-web is on READ-ONLY mode

### ⚠️ Build going to fail until I update the pending SDK version with the methods and types ⚠️