### PR TITLE
fix: shrink input label when placeholder exists

### DIFF
--- a/src/components/forms/TextField/index.tsx
+++ b/src/components/forms/TextField/index.tsx
@@ -1,4 +1,4 @@
-import MuiTextField from '@material-ui/core/TextField'
+import MuiTextField, { TextFieldProps } from '@material-ui/core/TextField'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 
 import { lg } from 'src/theme/variables'
@@ -39,6 +39,8 @@ type Props = {
   disabled?: boolean
   rowsMax?: number
   className?: string
+  placeholder?: string
+  InputLabelProps?: TextFieldProps['InputLabelProps']
 }
 
 const TextField = (props: Props): React.ReactElement => {
@@ -50,6 +52,7 @@ const TextField = (props: Props): React.ReactElement => {
     rows,
     testId,
     text,
+    InputLabelProps: _InputLabelProps,
     ...rest
   } = props
   const classes = useStyles()
@@ -74,6 +77,10 @@ const TextField = (props: Props): React.ReactElement => {
     className: `${inputRoot} ${statusClasses}`,
     disableUnderline: disableUnderline,
   }
+  const InputLabelProps = {
+    ..._InputLabelProps,
+    ...(rest?.placeholder && { shrink: true }),
+  }
 
   return (
     <MuiTextField
@@ -81,6 +88,7 @@ const TextField = (props: Props): React.ReactElement => {
       helperText={hasError && showError ? errorMessage : helperText || ''}
       inputProps={inputProps} // blank in order to force to have helper text
       InputProps={inputRootProps}
+      InputLabelProps={InputLabelProps}
       multiline={multiline}
       name={name}
       onChange={onChange}

--- a/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
+++ b/src/routes/CreateSafePage/steps/OwnersAndConfirmationsNewSafeStep.tsx
@@ -155,7 +155,6 @@ function OwnersAndConfirmationsNewSafeStep(): ReactElement {
                     name={nameFieldName}
                     placeholder={ownerName}
                     label="Owner Name"
-                    InputLabelProps={{ shrink: true }}
                     type="text"
                     validate={minMaxLength(0, 50)}
                     testId={nameFieldName}

--- a/src/routes/LoadSafePage/steps/LoadSafeOwnersStep.tsx
+++ b/src/routes/LoadSafePage/steps/LoadSafeOwnersStep.tsx
@@ -53,7 +53,6 @@ function LoadSafeOwnersStep(): ReactElement {
                     name={ownerFieldName}
                     placeholder={ownerName}
                     label="Owner Name"
-                    InputLabelProps={{ shrink: true }}
                     type="text"
                     validate={minMaxLength(0, 50)}
                     testId={`load-safe-owner-name-${index}`}


### PR DESCRIPTION
## What it solves
Resolves #3662

## How this PR fixes it
Whenever a placeholder exists, the label is shrunk.

## How to test it
Observe shrunken labels in fields that have placeholders.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/158197271-1ef4420f-26f0-4fbe-8197-82b62e4bee3a.png)
