### PR TITLE
fix: Avoid showing ThirdPartyApp message for the cookies warning flow

### DIFF
--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -18,6 +18,7 @@ import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { TransactionParams } from '../components/AppFrame'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
 import { getLegacyChainName } from '../utils'
+import { THIRD_PARTY_COOKIES_CHECK_URL } from './useThirdPartyCookies'
 
 type InterfaceMessageProps<T extends InterfaceMessageIds> = {
   messageId: T
@@ -112,9 +113,10 @@ const useIframeMessageHandler = (
         data: SDKMessageToPayload[SDKMessageIds]
       }>,
     ) => {
-      if (message.origin === window.origin) {
+      if (message.origin === window.origin || message.origin === THIRD_PARTY_COOKIES_CHECK_URL) {
         return
       }
+
       if (!selectedApp?.url.includes(message.origin)) {
         console.error(`ThirdPartyApp: A message was received from an unknown origin ${message.origin}`)
         return

--- a/src/routes/safe/components/Apps/hooks/useThirdPartyCookies.ts
+++ b/src/routes/safe/components/Apps/hooks/useThirdPartyCookies.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 
-const THIRD_PARTY_COOKIES_CHECK_URL = 'https://third-party-cookies-check.gnosis-safe.com'
+export const THIRD_PARTY_COOKIES_CHECK_URL = 'https://third-party-cookies-check.gnosis-safe.com'
 const SHOW_ALERT_TIMEOUT = 10000
 
 const isSafari = (): boolean => {


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-react-apps/issues/383

## How this PR fixes it
By adding a condition  to not show the message when the origin is the iframe validating the third party cookies activation

## How to test it
1) Third party cookies warning should continue to work as before
2) ThirdPartyApp message should not be present in the console