### PR TITLE
chore: bump safe-react-components version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
     "@gnosis.pm/safe-deployments": "^1.8.0",
-    "@gnosis.pm/safe-react-components": "^0.9.8",
+    "@gnosis.pm/safe-react-components": "^1.1.2",
     "@gnosis.pm/safe-react-gateway-sdk": "^2.10.1",
     "@gnosis.pm/safe-web3-lib": "^1.0.0",
     "@material-ui/core": "^4.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,10 +1965,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.8.0.tgz#856c15517274f924539ea4df40fffe6f009249a7"
   integrity sha512-xK2ZZXxCEGOw+6UZAeUmvqE/4C/XTpYmv1a8KzKUgSOxcGkHsIDqcjdKjqif7gOdnwHl4+XXJUtDQEuSLT4Scg==
 
-"@gnosis.pm/safe-react-components@^0.9.8":
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-components/-/safe-react-components-0.9.8.tgz#b61f0641bbc00ada0c71428be824e69192110c17"
-  integrity sha512-yOq7QScr+s27GTEsmBZe7fOXd5ADe4Wy4wlpu0crpsgyDmiJWl3H/K+ynLyq+dwGM6aVIAgFcIId2dEnwzdQew==
+"@gnosis.pm/safe-react-components@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-components/-/safe-react-components-1.1.2.tgz#26daeae23f5cd0811d79bfb3497d046b85441aa9"
+  integrity sha512-CEQ334Q46DAgxxxXZg8hdccIUvyuERw1qdhlSHqGnoVXD4r/bYdBGMgpNOn/N/aSKARL/ZUjVcbzvjpkCiqt1Q==
   dependencies:
     react-media "^1.10.0"
     web3-utils "^1.6.0"


### PR DESCRIPTION
Update the `safe-react-components` dependency to make use of new theme background color.

Figma: https://www.figma.com/file/3EUA9pvjt0P5xNLKOzbbEJ/Visual-segregation-for-Tx?node-id=1%3A119