### PR TITLE
Fix: refresh pairing QR code with a timeout

### DIFF
--- a/src/logic/wallets/pairing/hooks/useGetPairingUri.ts
+++ b/src/logic/wallets/pairing/hooks/useGetPairingUri.ts
@@ -6,7 +6,9 @@ export const useGetPairingUri = (): string | undefined => {
   const [uri, setUri] = useState<string>()
 
   useEffect(() => {
-    setUri(onboardUri)
+    setTimeout(() => {
+      setUri(getPairingUri())
+    }, 100)
   }, [onboardUri])
 
   return uri


### PR DESCRIPTION
## What it solves
Resolves #3669

## How this PR fixes it
There seems to be a delay between when a previous provider is disconnected and a new WC URI is generated.
A very scientific fix, I know.