### PR TITLE
feat: Change manifest.json requirements for Safe Apps

### DIFF
--- a/src/routes/safe/components/Apps/__tests__/utils.test.ts
+++ b/src/routes/safe/components/Apps/__tests__/utils.test.ts
@@ -7,6 +7,12 @@ describe('SafeApp manifest', () => {
       description: 'a test',
       error: false,
       iconPath: 'icon.png',
+      icons: [
+        {
+          src: 'icon.png',
+          sizes: '512x512',
+        },
+      ],
       providedBy: 'test',
     }
 

--- a/src/routes/safe/components/Apps/__tests__/utils.test.ts
+++ b/src/routes/safe/components/Apps/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { isAppManifestValid } from '../utils'
+import { getAppIcon, isAppManifestValid } from '../utils'
 
 describe('SafeApp manifest', () => {
   it('It should return true given a manifest with mandatory values supplied', async () => {
@@ -42,5 +42,39 @@ describe('SafeApp manifest', () => {
     // @ts-expect-error we're testing handling invalid data
     const result = isAppManifestValid(manifest)
     expect(result).toBe(false)
+  })
+
+  it.only('It should return the best icon given an icons array', () => {
+    const icons = [
+      {
+        src: 'one.png',
+        sizes: '48x48',
+        type: 'image/webp',
+      },
+      {
+        src: 'two.png',
+        sizes: '48x48',
+      },
+      {
+        src: 'three.png',
+        sizes: '72x72 96x96 128x128',
+      },
+      {
+        src: 'four.png',
+        sizes: '72x72 96x96 256x256',
+      },
+      {
+        src: 'five.svg',
+        sizes: 'any',
+      },
+    ]
+
+    expect(getAppIcon(icons)).toBe('five.svg')
+    icons.splice(icons.length - 1, 1)
+    expect(getAppIcon(icons)).toBe('three.png')
+    icons.splice(icons.length - 2, 1)
+    expect(getAppIcon(icons)).toBe('four.png')
+    icons.splice(icons.length - 1, 1)
+    expect(getAppIcon(icons)).toBe('one.png')
   })
 })

--- a/src/routes/safe/components/Apps/__tests__/utils.test.ts
+++ b/src/routes/safe/components/Apps/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { getAppIcon, isAppManifestValid } from '../utils'
 
 describe('SafeApp manifest', () => {
-  it('It should return true given a manifest with mandatory values supplied', async () => {
+  it('It should return true given a manifest with mandatory values supplied', () => {
     const manifest = {
       name: 'test',
       description: 'a test',
@@ -20,7 +20,7 @@ describe('SafeApp manifest', () => {
     expect(result).toBe(true)
   })
 
-  it('It should return false given a manifest without name', async () => {
+  it('It should return false given a manifest without name', () => {
     const manifest = {
       name: '',
       description: 'a test',
@@ -32,7 +32,7 @@ describe('SafeApp manifest', () => {
     expect(result).toBe(false)
   })
 
-  it('It should return false given a manifest without description', async () => {
+  it('It should return false given a manifest without description', () => {
     const manifest = {
       name: 'test',
       description: '',
@@ -44,7 +44,7 @@ describe('SafeApp manifest', () => {
     expect(result).toBe(false)
   })
 
-  it.only('It should return the best icon given an icons array', () => {
+  it('It should return the best icon given an icons array', () => {
     const icons = [
       {
         src: 'one.png',

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -305,7 +305,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
 
     const loadApp = async () => {
       try {
-        const app = await getAppInfoFromUrl(appUrl)
+        const app = await getAppInfoFromUrl(appUrl, false)
         setSafeApp(app)
       } catch (err) {
         logError(Errors._900, `${appUrl}, ${err.message}`)

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -43,9 +43,7 @@ export const isAppManifestValid = (appInfo: AppManifest): boolean =>
   // `appInfo` exists and `name` exists
   !!appInfo?.name &&
   // if `name` exists is not 'unknown'
-  appInfo.name !== 'unknown' &&
-  // `icons` exists and have at least one element with an `src` prop
-  !!appInfo?.icons?.[0]?.src
+  appInfo.name !== 'unknown'
 
 export const getEmptySafeApp = (url = ''): SafeApp => {
   return {

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -63,7 +63,7 @@ export const getEmptySafeApp = (url = ''): SafeApp => {
   }
 }
 
-export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp> => {
+export const getAppInfoFromUrl = memoize(async (appUrl: string, validateManifest = true): Promise<SafeApp> => {
   let res = {
     ...getEmptySafeApp(),
     error: true,
@@ -86,7 +86,7 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
   }
 
   // verify imported app fulfil safe requirements
-  if (!appInfo || !isAppManifestValid(appInfo)) {
+  if (validateManifest && (!appInfo || !isAppManifestValid(appInfo))) {
     throw Error('App manifest does not fulfil the required structure.')
   }
 

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -11,8 +11,8 @@ import { SafeApp } from './types'
 type AppManifestIcon = {
   src: string
   sizes: string
-  type: string
-  purpose: string
+  type?: string
+  purpose?: string
 }
 
 export interface AppManifest {

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -43,7 +43,9 @@ export const isAppManifestValid = (appInfo: AppManifest): boolean =>
   // `appInfo` exists and `name` exists
   !!appInfo?.name &&
   // if `name` exists is not 'unknown'
-  appInfo.name !== 'unknown'
+  appInfo.name !== 'unknown' &&
+  // `icons` exists and have at least one element with an `src` prop
+  !!appInfo?.icons?.[0]?.src
 
 export const getEmptySafeApp = (url = ''): SafeApp => {
   return {

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -120,7 +120,7 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
 
 export const getAppIcon = (icons: AppManifestIcon[]): string => {
   const svgIcon = icons.find(
-    (icon) => icon?.sizes?.includes('any') || icon?.type === 'image/svg+xml' || icon?.purpose === 'any',
+    (icon) => icon?.sizes?.includes('any') || icon?.type === 'image/svg+xml' || icon?.purpose?.includes('any'),
   )
 
   if (svgIcon) {

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -119,9 +119,7 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
 })
 
 export const getAppIcon = (icons: AppManifestIcon[]): string => {
-  const svgIcon = icons.find(
-    (icon) => icon?.sizes?.includes('any') || icon?.type === 'image/svg+xml' || icon?.purpose?.includes('any'),
-  )
+  const svgIcon = icons.find((icon) => icon?.sizes?.includes('any') || icon?.type === 'image/svg+xml')
 
   if (svgIcon) {
     return svgIcon.src

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -25,6 +25,7 @@ export interface AppManifest {
 
 export const APPS_STORAGE_KEY = 'APPS_STORAGE_KEY'
 export const PINNED_SAFE_APP_IDS = 'PINNED_SAFE_APP_IDS'
+const MIN_ICON_WIDTH = 128
 
 const removeLastTrailingSlash = (url: string): string => {
   return url.replace(/\/+$/, '')
@@ -118,7 +119,9 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
 })
 
 export const getAppIcon = (icons: AppManifestIcon[]): string => {
-  const svgIcon = icons.find((icon) => icon?.sizes?.includes('any') || icon?.type === 'image/svg+xml')
+  const svgIcon = icons.find(
+    (icon) => icon?.sizes?.includes('any') || icon?.type === 'image/svg+xml' || icon?.purpose === 'any',
+  )
 
   if (svgIcon) {
     return svgIcon.src
@@ -126,7 +129,7 @@ export const getAppIcon = (icons: AppManifestIcon[]): string => {
 
   for (const icon of icons) {
     for (const size of icon.sizes.split(' ')) {
-      if (Number(size?.split('x')[0]) >= 128) {
+      if (Number(size?.split('x')[0]) >= MIN_ICON_WIDTH) {
         return icon.src
       }
     }

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -8,10 +8,18 @@ import { SafeAppAccessPolicyTypes } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { SafeApp } from './types'
 
+type AppManifestIcon = {
+  src: string
+  sizes: string
+  type: string
+  purpose: string
+}
+
 export interface AppManifest {
   name: string
-  iconPath: string
-  description: string
+  iconPath?: string
+  description?: string
+  icons?: AppManifestIcon[]
   providedBy: string
 }
 
@@ -35,9 +43,7 @@ export const isAppManifestValid = (appInfo: AppManifest): boolean =>
   // `appInfo` exists and `name` exists
   !!appInfo?.name &&
   // if `name` exists is not 'unknown'
-  appInfo.name !== 'unknown' &&
-  // `description` exists
-  !!appInfo.description
+  appInfo.name !== 'unknown'
 
 export const getEmptySafeApp = (url = ''): SafeApp => {
   return {
@@ -88,8 +94,8 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
 
   const appInfoData = {
     name: appInfo.name,
-    iconPath: appInfo.iconPath,
-    description: appInfo.description,
+    iconPath: appInfo?.icons?.[0]?.src || appInfo.iconPath,
+    description: appInfo.description || '',
     providedBy: appInfo.providedBy,
   }
 
@@ -101,7 +107,7 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
     loadingStatus: FETCH_STATUS.SUCCESS,
   }
 
-  const concatenatedImgPath = `${noTrailingSlashUrl}/${appInfo.iconPath}`
+  const concatenatedImgPath = `${noTrailingSlashUrl}/${appInfoData.iconPath}`
   if (await canLoadAppImage(concatenatedImgPath)) {
     res.iconUrl = concatenatedImgPath
   }

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -26,7 +26,7 @@ export interface AppManifest {
 export const APPS_STORAGE_KEY = 'APPS_STORAGE_KEY'
 export const PINNED_SAFE_APP_IDS = 'PINNED_SAFE_APP_IDS'
 const MIN_ICON_WIDTH = 128
-const MANIFEST_ERROR_MESSAGE = 'App manifest does not fulfil the required structure.'
+const MANIFEST_ERROR_MESSAGE = 'Manifest does not fulfil the required structure.'
 
 const removeLastTrailingSlash = (url: string): string => {
   return url.replace(/\/+$/, '')
@@ -88,10 +88,11 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string, validateManifest
 
   // verify imported app fulfil safe requirements
   if (!appInfo || !isAppManifestValid(appInfo)) {
+    const errorMessage = `${appInfo.name || 'Safe App'}: ${MANIFEST_ERROR_MESSAGE}`
     if (validateManifest) {
-      throw Error(MANIFEST_ERROR_MESSAGE)
+      throw Error(errorMessage)
     } else {
-      console.error(MANIFEST_ERROR_MESSAGE)
+      console.error(errorMessage)
     }
   }
 

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -88,11 +88,10 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string, validateManifest
 
   // verify imported app fulfil safe requirements
   if (!appInfo || !isAppManifestValid(appInfo)) {
-    const errorMessage = `${appInfo.name || 'Safe App'}: ${MANIFEST_ERROR_MESSAGE}`
     if (validateManifest) {
-      throw Error(errorMessage)
+      throw Error(`App ${MANIFEST_ERROR_MESSAGE.toLocaleLowerCase()}`)
     } else {
-      console.error(errorMessage)
+      console.error(`${appInfo.name || 'Safe App'}: ${MANIFEST_ERROR_MESSAGE}`)
     }
   }
 

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -96,8 +96,8 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
 
   const appInfoData = {
     name: appInfo.name,
-    iconPath: appInfo.icons ? getAppIcon(appInfo.icons) : appInfo.iconPath,
-    description: appInfo.description || '',
+    iconPath: appInfo.icons?.length ? getAppIcon(appInfo.icons) : appInfo.iconPath,
+    description: appInfo.description,
     providedBy: appInfo.providedBy,
   }
 

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -26,6 +26,7 @@ export interface AppManifest {
 export const APPS_STORAGE_KEY = 'APPS_STORAGE_KEY'
 export const PINNED_SAFE_APP_IDS = 'PINNED_SAFE_APP_IDS'
 const MIN_ICON_WIDTH = 128
+const MANIFEST_ERROR_MESSAGE = 'App manifest does not fulfil the required structure.'
 
 const removeLastTrailingSlash = (url: string): string => {
   return url.replace(/\/+$/, '')
@@ -86,8 +87,12 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string, validateManifest
   }
 
   // verify imported app fulfil safe requirements
-  if (validateManifest && (!appInfo || !isAppManifestValid(appInfo))) {
-    throw Error('App manifest does not fulfil the required structure.')
+  if (!appInfo || !isAppManifestValid(appInfo)) {
+    if (validateManifest) {
+      throw Error(MANIFEST_ERROR_MESSAGE)
+    } else {
+      console.error(MANIFEST_ERROR_MESSAGE)
+    }
   }
 
   // the DB origin field has a limit of 100 characters

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -18,7 +18,7 @@ type AppManifestIcon = {
 export interface AppManifest {
   name: string
   iconPath?: string
-  description?: string
+  description: string
   icons?: AppManifestIcon[]
   providedBy: string
 }
@@ -43,7 +43,9 @@ export const isAppManifestValid = (appInfo: AppManifest): boolean =>
   // `appInfo` exists and `name` exists
   !!appInfo?.name &&
   // if `name` exists is not 'unknown'
-  appInfo.name !== 'unknown'
+  appInfo.name !== 'unknown' &&
+  // `description` exists
+  !!appInfo.description
 
 export const getEmptySafeApp = (url = ''): SafeApp => {
   return {

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -96,7 +96,7 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
 
   const appInfoData = {
     name: appInfo.name,
-    iconPath: appInfo?.icons?.[0]?.src || appInfo.iconPath,
+    iconPath: appInfo.icons ? getAppIcon(appInfo.icons) : appInfo.iconPath,
     description: appInfo.description || '',
     providedBy: appInfo.providedBy,
   }
@@ -116,6 +116,24 @@ export const getAppInfoFromUrl = memoize(async (appUrl: string): Promise<SafeApp
 
   return res
 })
+
+export const getAppIcon = (icons: AppManifestIcon[]): string => {
+  const svgIcon = icons.find((icon) => icon?.sizes?.includes('any') || icon?.type === 'image/svg+xml')
+
+  if (svgIcon) {
+    return svgIcon.src
+  }
+
+  for (const icon of icons) {
+    for (const size of icon.sizes.split(' ')) {
+      if (Number(size?.split('x')[0]) >= 128) {
+        return icon.src
+      }
+    }
+  }
+
+  return icons[0].src || ''
+}
 
 export const getIpfsLinkFromEns = memoize(async (name: string): Promise<string | undefined> => {
   try {


### PR DESCRIPTION
# What it solves
resolves https://github.com/gnosis/safe-react-apps/issues/313

# How this PR fixes it
We are making `description` and `iconPath`  properties optional.

Besides that we are adding support for the `icons` web manifest standard prop as some apps are going this way and is the real standard (For example Sushi as the related bug stands out)

# How to test it
1) Access Sushi app
  1.1) Create a transaction by making a swap
  1.2) Icon and name should be visible
  1.3) If the manifest has some missing prop (As Sushi) then a console.error message should be showed
2) Add a new Custom apps with the [new manifest structure](https://github.com/gnosis/safe-react-apps/pull/388) using icons property. The apps should be added with no issue
3) Add a new Custom apps with the current manifest structure. The apps should be added with no issue
4) Add custom apps with manifests not complying the structure. The app should fail to be added
