### PR TITLE
fix: only sanitise pending store when empty `chainId` exists

### DIFF
--- a/src/logic/safe/store/reducer/pendingTransactions.ts
+++ b/src/logic/safe/store/reducer/pendingTransactions.ts
@@ -46,7 +46,7 @@ export const pendingTransactionsReducer = handleActions<PendingTransactionsState
       // Omit id from the pending transactions on current chain
       const { [id]: _, ...newChainState } = state[chainId] || {}
 
-      if (Object.keys(newChainState[chainId] || {}).length === 0) {
+      if (newChainState?.[chainId] && Object.keys(newChainState[chainId]).length === 0) {
         // Omit chainId from the pending transactions if no pending transactions on chain
         const { [chainId]: _, ...newState } = state
         return newState


### PR DESCRIPTION
## What it solves
Early emptying of pending store

## How this PR fixes it
The `chainId`s presence in the pending transaction store is checked before verifying it's length.

## How to test it
Add a pending transaction and wait for it to succeed. Observe no presence of `pendingTransactions[chainId]` in the store.