### PR TITLE
fix: only disconnect WC when a `peerId` exists

### DIFF
--- a/src/logic/wallets/walletConnect/utils.ts
+++ b/src/logic/wallets/walletConnect/utils.ts
@@ -56,10 +56,10 @@ export const getWCWalletInterface = (
     // (prevents us from accessing balance via Onboard, but via web3 works)
     balance: {},
     disconnect: () => {
-      provider.disconnect()
-      // Clear WC cache, fixing "Missing or invalid topic field" error
-      const { storageId } = (provider.wc as any)._sessionStorage
-      localStorage.removeItem(storageId)
+      // Only disconnect if connected
+      if (provider.wc.peerId) {
+        provider.disconnect()
+      }
     },
   }
 }

--- a/src/logic/wallets/walletConnect/utils.ts
+++ b/src/logic/wallets/walletConnect/utils.ts
@@ -57,6 +57,9 @@ export const getWCWalletInterface = (
     balance: {},
     disconnect: () => {
       provider.disconnect()
+      // Clear WC cache, fixing "Missing or invalid topic field" error
+      const { storageId } = (provider.wc as any)._sessionStorage
+      localStorage.removeItem(storageId)
     },
   }
 }


### PR DESCRIPTION
## What it solves
Resolves #3581

## How this PR fixes it
WC only disconnects if a `peerId` is present (a successful connection occurred).

## How to test it
1. Open the WC modal on a network and then close it without scanning the QR code.
2. Switch network and open the modal again.
3. Observe no "Missing or invalid topic" error message in the console.