### PR TITLE
fix: clear pending status when transaction reverts

### DIFF
--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -17,7 +17,7 @@ import { currentSafeCurrentVersion } from 'src/logic/safe/store/selectors'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { providerSelector } from 'src/logic/wallets/store/selectors'
-import { didTxFail, generateSafeTxHash } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
+import { didTxRevert, generateSafeTxHash } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
 import { getNonce, canExecuteCreatedTx, navigateToTx } from 'src/logic/safe/store/actions/utils'
 import fetchTransactions from './transactions/fetchTransactions'
 import { AppReduxState } from 'src/store'
@@ -206,7 +206,7 @@ export class TxSender {
         this.onComplete(undefined, confirmCallback)
       })
       .then((receipt) => {
-        if (didTxFail(receipt)) {
+        if (didTxRevert(receipt)) {
           throw Error('Transaction failed')
         }
       })

--- a/src/logic/safe/store/actions/transactions/utils/transactionHelpers.ts
+++ b/src/logic/safe/store/actions/transactions/utils/transactionHelpers.ts
@@ -12,7 +12,7 @@ export const generateSafeTxHash = (safeAddress: string, safeVersion: string, txA
   return `0x${TypedDataUtils.sign<typeof messageTypes>(typedData).toString('hex')}`
 }
 
-export const didTxFail = (receipt: TransactionReceipt): boolean => {
+export const didTxRevert = (receipt: TransactionReceipt): boolean => {
   if (!receipt) {
     throw new Error('No transaction receipt provided')
   }

--- a/src/logic/safe/store/actions/transactions/utils/transactionHelpers.ts
+++ b/src/logic/safe/store/actions/transactions/utils/transactionHelpers.ts
@@ -1,4 +1,5 @@
 import { TypedDataUtils } from 'eth-sig-util'
+import { TransactionReceipt } from 'web3-core'
 
 import { TxArgs } from 'src/logic/safe/store/models/types/transaction'
 import { getEip712MessageTypes, generateTypedDataFrom } from 'src/logic/safe/transactions/offchainSigner/EIP712Signer'
@@ -9,4 +10,11 @@ export const generateSafeTxHash = (safeAddress: string, safeVersion: string, txA
   const messageTypes = getEip712MessageTypes(safeVersion)
 
   return `0x${TypedDataUtils.sign<typeof messageTypes>(typedData).toString('hex')}`
+}
+
+export const didTxFail = (receipt: TransactionReceipt): boolean => {
+  if (!receipt) {
+    throw new Error('No transaction receipt provided')
+  }
+  return receipt.status === false
 }

--- a/src/logic/safe/store/actions/transactions/utils/transactionHelpers.ts
+++ b/src/logic/safe/store/actions/transactions/utils/transactionHelpers.ts
@@ -13,8 +13,5 @@ export const generateSafeTxHash = (safeAddress: string, safeVersion: string, txA
 }
 
 export const didTxRevert = (receipt: TransactionReceipt): boolean => {
-  if (!receipt) {
-    throw new Error('No transaction receipt provided')
-  }
-  return receipt.status === false
+  return receipt?.status === false
 }

--- a/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
+++ b/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
@@ -181,7 +181,7 @@ describe('PendingTxMonitor', () => {
       }
     })
 
-    it.only('checks each pending tx', async () => {
+    it('checks each pending tx', async () => {
       jest.spyOn(store.store, 'getState').mockImplementation(() => ({
         pendingTransactions: {
           '4': {

--- a/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
+++ b/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
@@ -181,7 +181,7 @@ describe('PendingTxMonitor', () => {
       }
     })
 
-    it('checks each pending tx', async () => {
+    it.only('checks each pending tx', async () => {
       jest.spyOn(store.store, 'getState').mockImplementation(() => ({
         pendingTransactions: {
           '4': {
@@ -197,8 +197,23 @@ describe('PendingTxMonitor', () => {
 
       jest.spyOn(web3.getWeb3().eth, 'getBlockNumber').mockImplementation(() => Promise.resolve(0))
 
-      // Can return null if transaction is pending: https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#gettransactionreceipt
-      PendingTxMonitor._isTxMined = jest.fn(() => Promise.reject(null as unknown as TransactionReceipt))
+      PendingTxMonitor._isTxMined = jest.fn(() =>
+        Promise.resolve({
+          blockHash: '0x123',
+          blockNumber: 1,
+          transactionHash: 'fakeTxHash',
+          transactionIndex: 0,
+          from: '0x123',
+          to: '0x123',
+          cumulativeGasUsed: 1,
+          gasUsed: 1,
+          contractAddress: '0x123',
+          logs: [],
+          status: true, // Mined successfully
+          logsBloom: '0x123',
+          effectiveGasPrice: 0,
+        }),
+      )
 
       await PendingTxMonitor.monitorAllTxs()
 

--- a/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
+++ b/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
@@ -1,4 +1,4 @@
-import { Transaction } from 'web3-core'
+import { TransactionReceipt } from 'web3-core'
 
 import * as store from 'src/store'
 import * as web3 from 'src/logic/wallets/getWeb3'
@@ -65,7 +65,23 @@ describe('PendingTxMonitor', () => {
 
   describe('monitorTx', () => {
     it("doesn't clear the pending transaction if it was mined", async () => {
-      PendingTxMonitor._isTxMined = jest.fn(() => Promise.resolve())
+      PendingTxMonitor._isTxMined = jest.fn(() =>
+        Promise.resolve({
+          blockHash: '0x123',
+          blockNumber: 1,
+          transactionHash: 'fakeTxHash',
+          transactionIndex: 0,
+          from: '0x123',
+          to: '0x123',
+          cumulativeGasUsed: 1,
+          gasUsed: 1,
+          contractAddress: '0x123',
+          logs: [],
+          status: true, // Mined successfully
+          logsBloom: '0x123',
+          effectiveGasPrice: 0,
+        }),
+      )
 
       const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
 
@@ -77,9 +93,42 @@ describe('PendingTxMonitor', () => {
 
       expect(dispatchSpy).not.toBeCalled()
     })
+    it('clears the pending transaction if it failed', async () => {
+      PendingTxMonitor._isTxMined = jest.fn(() =>
+        Promise.resolve({
+          blockHash: '0x123',
+          blockNumber: 1,
+          transactionHash: 'fakeTxHash',
+          transactionIndex: 0,
+          from: '0x123',
+          to: '0x123',
+          cumulativeGasUsed: 1,
+          gasUsed: 1,
+          contractAddress: '0x123',
+          logs: [],
+          status: false, // Mining failed
+          logsBloom: '0x123',
+          effectiveGasPrice: 0,
+        }),
+      )
+
+      const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
+
+      await PendingTxMonitor.monitorTx(0, 'fakeTxId', 'fakeTxHash', {
+        numOfAttempts: 1,
+        startingDelay: 0,
+        timeMultiple: 0,
+      })
+
+      expect(dispatchSpy).toBeCalledWith({
+        type: 'pendingTransactions/remove',
+        payload: { id: 'fakeTxId' },
+      })
+    })
 
     it('clears the pending transaction it the tx was not mined within 50 blocks', async () => {
-      PendingTxMonitor._isTxMined = jest.fn(() => Promise.reject())
+      // Can return null if transaction is pending: https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#gettransactionreceipt
+      PendingTxMonitor._isTxMined = jest.fn(() => Promise.reject(null as unknown as TransactionReceipt))
 
       const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
 
@@ -148,7 +197,8 @@ describe('PendingTxMonitor', () => {
 
       jest.spyOn(web3.getWeb3().eth, 'getBlockNumber').mockImplementation(() => Promise.resolve(0))
 
-      PendingTxMonitor._isTxMined = jest.fn(() => Promise.resolve())
+      // Can return null if transaction is pending: https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#gettransactionreceipt
+      PendingTxMonitor._isTxMined = jest.fn(() => Promise.reject(null as unknown as TransactionReceipt))
 
       await PendingTxMonitor.monitorAllTxs()
 

--- a/src/logic/safe/transactions/pendingTxMonitor.ts
+++ b/src/logic/safe/transactions/pendingTxMonitor.ts
@@ -1,4 +1,5 @@
 import { backOff, IBackOffOptions } from 'exponential-backoff'
+import { TransactionReceipt } from 'web3-core'
 
 import { NOTIFICATIONS } from 'src/logic/notifications'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
@@ -6,20 +7,25 @@ import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { store } from 'src/store'
 import { removePendingTransaction } from 'src/logic/safe/store/actions/pendingTransactions'
 import { pendingTxIdsByChain } from 'src/logic/safe/store/selectors/pendingTransactions'
+import { didTxFail } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
 
-const _isTxMined = async (sessionBlockNumber: number, txHash: string): Promise<void> => {
+const _isTxMined = async (sessionBlockNumber: number, txHash: string): Promise<TransactionReceipt> => {
   const MAX_WAITING_BLOCK = sessionBlockNumber + 50
 
   const web3 = getWeb3()
 
+  const receipt = await web3.eth.getTransactionReceipt(txHash)
+
   if (
     // Transaction hasn't yet been mined
-    !(await web3.eth.getTransactionReceipt(txHash)) &&
+    !receipt &&
     // The current block is within waiting window
     (await web3.eth.getBlockNumber()) <= MAX_WAITING_BLOCK
   ) {
     throw new Error('Pending transaction not found')
   }
+
+  return receipt
 }
 
 // Progressively after 10s, 20s, 40s, 80s, 160s, 320s - total of 6.5 minutes
@@ -37,13 +43,19 @@ const monitorTx = async (
     numOfAttempts: MAX_ATTEMPTS,
   },
 ): Promise<void> => {
-  return backOff(() => PendingTxMonitor._isTxMined(sessionBlockNumber, txHash), options).catch(() => {
-    // Unsuccessfully mined (threw in last backOff attempt)
-    store.dispatch(removePendingTransaction({ id: txId }))
-    store.dispatch(enqueueSnackbar(NOTIFICATIONS.TX_PENDING_FAILED_MSG))
-  })
-  // If mined, pending status is removed in the transaction middleware
-  // when a transaction is added to historical transactions list
+  return backOff(() => PendingTxMonitor._isTxMined(sessionBlockNumber, txHash), options)
+    .then((receipt) => {
+      if (didTxFail(receipt)) {
+        store.dispatch(removePendingTransaction({ id: txId }))
+      }
+      // If successfully mined, pending status is removed in the transaction
+      // middleware when a transaction is added to historical transactions list
+    })
+    .catch(() => {
+      // Unsuccessfully mined (threw in last backOff attempt)
+      store.dispatch(removePendingTransaction({ id: txId }))
+      store.dispatch(enqueueSnackbar(NOTIFICATIONS.TX_PENDING_FAILED_MSG))
+    })
 }
 
 const monitorAllTxs = async (): Promise<void> => {

--- a/src/logic/safe/transactions/pendingTxMonitor.ts
+++ b/src/logic/safe/transactions/pendingTxMonitor.ts
@@ -7,7 +7,7 @@ import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { store } from 'src/store'
 import { removePendingTransaction } from 'src/logic/safe/store/actions/pendingTransactions'
 import { pendingTxIdsByChain } from 'src/logic/safe/store/selectors/pendingTransactions'
-import { didTxFail } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
+import { didTxRevert } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
 
 const _isTxMined = async (sessionBlockNumber: number, txHash: string): Promise<TransactionReceipt> => {
   const MAX_WAITING_BLOCK = sessionBlockNumber + 50
@@ -45,7 +45,7 @@ const monitorTx = async (
 ): Promise<void> => {
   return backOff(() => PendingTxMonitor._isTxMined(sessionBlockNumber, txHash), options)
     .then((receipt) => {
-      if (didTxFail(receipt)) {
+      if (didTxRevert(receipt)) {
         store.dispatch(removePendingTransaction({ id: txId }))
       }
       // If successfully mined, pending status is removed in the transaction


### PR DESCRIPTION
## What it solves
Pending statuses pesisting upon transaction failure

## How this PR fixes it
When a transaction reverts ([`receipt.status === false`](https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#eth-gettransactionreceipt-return)), it's pending status is cleared.

In the `TxSender` the `txId` is saved after proposal as it is used as refrence to clear the pending status. A reverted transaction throws instead of the `promiEvent` returning the receipt.

## How to test it
1. Create an execute a transaction that would revert and observe the pending status clear upon reversion
2. Create an execute a transaction with a low gas limit then refresh (to initiate the pending watch). Observe the pending status also clear.