### PR TITLE
fix: tweak events + don't trigger GA on dev

### DIFF
--- a/src/components/ExecuteCheckbox/index.tsx
+++ b/src/components/ExecuteCheckbox/index.tsx
@@ -7,6 +7,8 @@ import { sm } from 'src/theme/variables'
 import Row from 'src/components/layout/Row'
 import Img from 'src/components/layout/Img'
 import InfoIcon from 'src/assets/icons/info.svg'
+import { trackEvent } from 'src/utils/googleTagManager'
+import { MODALS_EVENTS } from 'src/utils/events/modals'
 
 const StyledRow = styled(Row)`
   align-items: center;
@@ -28,8 +30,9 @@ interface ExecuteCheckboxProps {
 }
 
 const ExecuteCheckbox = ({ checked, onChange }: ExecuteCheckboxProps): ReactElement => {
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    onChange(e.target.checked)
+  const handleChange = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean): void => {
+    trackEvent({ ...MODALS_EVENTS.EXECUTE_TX, label: checked })
+    onChange(checked)
   }
   return (
     <StyledRow>

--- a/src/components/SafeListSidebar/SafeList/index.tsx
+++ b/src/components/SafeListSidebar/SafeList/index.tsx
@@ -2,7 +2,7 @@ import MuiList from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import styled from 'styled-components'
 import makeStyles from '@material-ui/core/styles/makeStyles'
-import { Fragment, ReactElement } from 'react'
+import { Fragment, ReactElement, useEffect } from 'react'
 import { Text } from '@gnosis.pm/safe-react-components'
 import { Link } from 'react-router-dom'
 import uniqBy from 'lodash/uniqBy'
@@ -17,6 +17,9 @@ import { useSelector } from 'react-redux'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import useOwnerSafes from 'src/logic/safe/hooks/useOwnerSafes'
 import { getChains } from 'src/config/cache/chains'
+import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
+import { trackEvent } from 'src/utils/googleTagManager'
+import { getChainById } from 'src/config'
 
 const MAX_EXPANDED_SAFES = 3
 
@@ -74,6 +77,19 @@ export const SafeList = ({ onSafeClick }: Props): ReactElement => {
   const ownedSafes = useOwnerSafes()
   const localSafes = useLocalSafes()
   const curChainId = useSelector(currentChainId)
+
+  useEffect(() => {
+    const addedSafes = localSafes?.[curChainId]?.length || 0
+    if (addedSafes === 0) {
+      return
+    }
+    const event = OVERVIEW_EVENTS.ADDED_SAFES_ON_NETWORK
+    trackEvent({
+      ...event,
+      action: `${event.action} ${getChainById(curChainId).chainName}`,
+      label: addedSafes,
+    })
+  }, [localSafes, curChainId])
 
   return (
     <StyledList>

--- a/src/components/Track/index.tsx
+++ b/src/components/Track/index.tsx
@@ -1,13 +1,13 @@
 import { ReactElement, Fragment, useEffect, useRef } from 'react'
 
-import { GTM_EVENT, trackEvent } from 'src/utils/googleTagManager'
+import { EventLabel, GTM_EVENT, trackEvent } from 'src/utils/googleTagManager'
 
 type Props = {
   children: ReactElement
   as?: 'span' | 'div'
   category: string
   action: string
-  label?: string | number | boolean
+  label?: EventLabel
 }
 
 const Track = ({ children, as: Wrapper = 'div', ...trackData }: Props): typeof children => {

--- a/src/logic/safe/hooks/useLocalSafes.tsx
+++ b/src/logic/safe/hooks/useLocalSafes.tsx
@@ -4,8 +4,6 @@ import { useSelector } from 'react-redux'
 import { sortedSafeListSelector } from 'src/components/SafeListSidebar/selectors'
 import { getChains } from 'src/config/cache/chains'
 import { ChainId } from 'src/config/chain.d'
-import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
-import { trackEvent } from 'src/utils/googleTagManager'
 import { SafeRecordProps } from '../store/models/safe'
 import { getLocalNetworkSafesById } from '../utils'
 
@@ -23,21 +21,12 @@ const useLocalSafes = (): LocalSafes => {
   // Reload added Safes from the localStorage when addedAddresses changes
   useEffect(() => {
     const getLocalSafes = () => {
-      getChains().forEach(({ chainId, chainName }) => {
+      getChains().forEach(({ chainId }) => {
         const localSafe = getLocalNetworkSafesById(chainId)
         setLocalSafes((prevSafes) => ({
           ...prevSafes,
           ...(localSafe && { [chainId]: localSafe }),
         }))
-
-        if (localSafe && localSafe.length > 0) {
-          const event = OVERVIEW_EVENTS.ADDED_SAFES_ON_NETWORK
-          trackEvent({
-            ...event,
-            action: `${event.action} ${chainName}`,
-            label: localSafe.length,
-          })
-        }
       })
     }
 

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -92,7 +92,7 @@ const Collectibles = (): React.ReactElement => {
   const nftTokens = useSelector(orderedNFTAssets)
   const nftAssetsFromNftTokens = useSelector(nftAssetsFromNftTokensSelector)
 
-  const nftAmount = useMemo(() => nftAssetsFromNftTokens.length, [nftAssetsFromNftTokens])
+  const nftAmount = useMemo(() => nftTokens.length, [nftTokens])
   useEffect(() => {
     trackEvent({ ...ASSETS_EVENTS.NFT_AMOUNT, label: nftAmount })
   }, [nftAmount])

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewSendFundsTx/index.tsx
@@ -33,6 +33,8 @@ import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/scree
 import { isSpendingLimit } from 'src/routes/safe/components/Transactions/helpers/utils'
 import { TransferAmount } from 'src/routes/safe/components/Balances/SendModal/TransferAmount'
 import { getStepTitle } from 'src/routes/safe/components/Balances/SendModal/utils'
+import { trackEvent } from 'src/utils/googleTagManager'
+import { MODALS_EVENTS } from 'src/utils/events/modals'
 
 const useStyles = makeStyles(styles)
 
@@ -99,6 +101,8 @@ const ReviewSendFundsTx = ({ onClose, onPrev, tx }: ReviewTxProps): React.ReactE
       const spendingLimitTokenAddress = isSendingNativeToken ? ZERO_ADDRESS : txToken.address
       const spendingLimit = getSpendingLimitContract()
       try {
+        trackEvent(MODALS_EVENTS.USE_SPENDING_LIMIT)
+
         await spendingLimit.methods
           .executeAllowanceTransfer(
             safeAddress,

--- a/src/routes/safe/components/Transactions/TxList/QueueTransactions.tsx
+++ b/src/routes/safe/components/Transactions/TxList/QueueTransactions.tsx
@@ -19,10 +19,12 @@ export const QueueTransactions = (): ReactElement => {
     [transactions],
   )
   useEffect(() => {
-    trackEvent({
-      ...TX_LIST_EVENTS.QUEUED_TXS,
-      label: queuedTxCount,
-    })
+    if (queuedTxCount > 0) {
+      trackEvent({
+        ...TX_LIST_EVENTS.QUEUED_TXS,
+        label: queuedTxCount,
+      })
+    }
   }, [queuedTxCount])
 
   if (count === 0 && isLoading) {

--- a/src/utils/events/modals.ts
+++ b/src/utils/events/modals.ts
@@ -30,6 +30,14 @@ const MODALS = {
     event: GTM_EVENT.CLICK,
     action: 'Edit estimation',
   },
+  EXECUTE_TX: {
+    event: GTM_EVENT.CLICK,
+    action: 'Execute transaction',
+  },
+  USE_SPENDING_LIMIT: {
+    event: GTM_EVENT.META,
+    action: 'Use spending limit',
+  },
 }
 
 const MODALS_CATEGORY = 'modals'

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -104,7 +104,7 @@ export const usePageTracking = (): void => {
 
   useEffect(() => {
     const unsubscribe = history.listen((location) => {
-      if (location.pathname === currentPathname) {
+      if (location.pathname !== currentPathname) {
         return
       }
       TagManager.dataLayer({

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -61,7 +61,7 @@ export enum GTM_EVENT {
   META = 'metadata',
 }
 
-let currentPathname = ''
+let currentPathname = history.location.pathname
 export const loadGoogleTagManager = (): void => {
   const GTM_ENVIRONMENT = IS_PRODUCTION ? GTM_ENV_AUTH.LIVE : GTM_ENV_AUTH.DEVELOPMENT
 
@@ -70,8 +70,10 @@ export const loadGoogleTagManager = (): void => {
     return
   }
 
+  // Cache name to prevent tracking of same page
+  currentPathname = history.location.pathname
+
   const page = getAnonymizedLocation()
-  currentPathname = page
 
   TagManager.initialize({
     gtmId: GOOGLE_TAG_MANAGER_ID,
@@ -104,9 +106,12 @@ export const usePageTracking = (): void => {
 
   useEffect(() => {
     const unsubscribe = history.listen((location) => {
-      if (location.pathname !== currentPathname) {
+      if (location.pathname === currentPathname) {
         return
       }
+
+      currentPathname = location.pathname
+
       TagManager.dataLayer({
         dataLayer: {
           // Must emit (custom) event in order to trigger page tracking

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -81,8 +81,6 @@ export const loadGoogleTagManager = (): void => {
       event: GTM_EVENT.PAGEVIEW,
       chainId: _getChainId(),
       page,
-      // Flag used to prevent GA triggers
-      dev: !IS_PRODUCTION,
     },
   })
 }
@@ -119,8 +117,6 @@ export const usePageTracking = (): void => {
           eventCategory: undefined,
           eventAction: undefined,
           eventLabel: undefined,
-          // Flag used to prevent GA triggers
-          dev: !IS_PRODUCTION,
         },
       })
     })
@@ -160,8 +156,6 @@ export const trackEvent = ({
     eventCategory: category,
     eventAction: action,
     eventLabel: tryParse(label),
-    // Flag used to prevent GA triggers
-    dev: !IS_PRODUCTION,
   }
 
   if (!IS_PRODUCTION) {


### PR DESCRIPTION
## What it solves
@francovenica noticed some inconsistencies in a few events. These have been fixed/tweaked and the GTM-GA link removed on dev. environments.

## How this PR fixes it

It is possible to have production only triggers in GA but they cost with every event. Instead, the triggers have been adjusted to fire when the built-in debug mode variable (`true` by default in the development environment) is `false`.

The following events were tweaked:
- [x] 1. Duplicate page views fixed.
- [x] 2. Add "Execute transaction" checkbox tracking.
- [x] 3. Add use of spending limit tracking.
- [x] 4. Only track number of added Safes in sidebar.
- [x] 5. Parse all labels (numbers, booleans, etc. passed as strings).
- [x] 6. Track number of NFTs, not collections.

## How to test it

Preview the local branch/PR in GTM and observe no GA tags firing in GTM.

1. Repeatedly click on a transaction tab and observe only one `'pageview'` event.
2. (Un-)check the "Execute transaction" checkbox and observe a new `'cusomClick'` event.
3. Pay for a transaction from a spending limit and observe a new `'metadata'` event.
4. Open the sidebar and observe a `'metadata'` event for the number of Safes on the network. Navigating to the settings should not trigger this.
5. Add/remove an owner. Observe the owner number `'metadata'` be a number, not a string.
6. Open Collectibles and observe the total number of NFTs being tracked in a `'metadata'` event, not the number of collections.

## Analytics changes
GA events should not trigger locally or in PRs.