### PR TITLE
fix: remove `only` from test

### DIFF
--- a/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
+++ b/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
@@ -181,7 +181,7 @@ describe('PendingTxMonitor', () => {
       }
     })
 
-    it.only('checks each pending tx', async () => {
+    it('checks each pending tx', async () => {
       jest.spyOn(store.store, 'getState').mockImplementation(() => ({
         pendingTransactions: {
           '4': {


### PR DESCRIPTION
## What it solves
Remove `only` flag from test.

## How this PR fixes it
The pending watcher alterations were merged with an `only`-flagged test file. This has been removed.

## How to test it
The unit tests should still pass.