### PR TITLE
fix: improve Safe loading error handling

### DIFF
--- a/src/routes/safe/components/FetchError.tsx
+++ b/src/routes/safe/components/FetchError.tsx
@@ -8,6 +8,7 @@ interface FetchErrorProps {
   text: string
   buttonText: string
   redirectRoute: string
+  onClick?: () => void
 }
 
 const StyledLink = styled(Link)`
@@ -25,14 +26,14 @@ const ErrorContainer = styled.div`
   margin-top: -30px;
 `
 
-const FetchError = ({ text, buttonText, redirectRoute }: FetchErrorProps): ReactElement => {
+const FetchError = ({ text, buttonText, redirectRoute, onClick }: FetchErrorProps): ReactElement => {
   return (
     <ErrorContainer>
       <img src="./resources/error.png" alt="Error" />
 
       <Title size="xs">{text}</Title>
 
-      <StyledLink to={redirectRoute}>
+      <StyledLink to={redirectRoute} onClick={() => onClick?.()}>
         <Button color="primary" size="medium" variant="contained">
           {buttonText}
         </Button>

--- a/src/routes/safe/components/SafeLoadError.tsx
+++ b/src/routes/safe/components/SafeLoadError.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect } from 'react'
+import { ReactElement } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { WELCOME_ROUTE } from 'src/routes/routes'
@@ -6,20 +6,20 @@ import removeViewedSafe from 'src/logic/currentSession/store/actions/removeViewe
 import FetchError from './FetchError'
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 
-const SafeLoadError = ({ isSafeLoaded }: { isSafeLoaded: boolean }): ReactElement => {
+const SafeLoadError = (): ReactElement => {
   const dispatch = useDispatch()
   const { address } = useSelector(currentSafeWithNames)
 
-  useEffect(() => {
-    // Remove the errorneous Safe from the list of viewed safes on unmount
-    return () => {
-      if (!isSafeLoaded) {
-        dispatch(removeViewedSafe(address))
-      }
-    }
-  }, [dispatch, address, isSafeLoaded])
+  const onClick = () => dispatch(removeViewedSafe(address))
 
-  return <FetchError text="This Safe couldn't be loaded" buttonText="Back to Main Page" redirectRoute={WELCOME_ROUTE} />
+  return (
+    <FetchError
+      text="This Safe couldn't be loaded"
+      buttonText="Back to Main Page"
+      redirectRoute={WELCOME_ROUTE}
+      onClick={onClick}
+    />
+  )
 }
 
 export default SafeLoadError

--- a/src/routes/safe/components/SafeLoadError.tsx
+++ b/src/routes/safe/components/SafeLoadError.tsx
@@ -17,7 +17,7 @@ const SafeLoadError = ({ isSafeLoaded }: { isSafeLoaded: boolean }): ReactElemen
         dispatch(removeViewedSafe(address))
       }
     }
-  }, [dispatch, address])
+  }, [dispatch, address, isSafeLoaded])
 
   return <FetchError text="This Safe couldn't be loaded" buttonText="Back to Main Page" redirectRoute={WELCOME_ROUTE} />
 }

--- a/src/routes/safe/components/SafeLoadError.tsx
+++ b/src/routes/safe/components/SafeLoadError.tsx
@@ -1,18 +1,23 @@
 import { ReactElement, useEffect } from 'react'
-import { extractSafeAddress, WELCOME_ROUTE } from 'src/routes/routes'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { WELCOME_ROUTE } from 'src/routes/routes'
 import removeViewedSafe from 'src/logic/currentSession/store/actions/removeViewedSafe'
 import FetchError from './FetchError'
+import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 
-const SafeLoadError = (): ReactElement => {
+const SafeLoadError = ({ isSafeLoaded }: { isSafeLoaded: boolean }): ReactElement => {
   const dispatch = useDispatch()
+  const { address } = useSelector(currentSafeWithNames)
 
   useEffect(() => {
     // Remove the errorneous Safe from the list of viewed safes on unmount
     return () => {
-      dispatch(removeViewedSafe(extractSafeAddress()))
+      if (!isSafeLoaded) {
+        dispatch(removeViewedSafe(address))
+      }
     }
-  }, [dispatch])
+  }, [dispatch, address])
 
   return <FetchError text="This Safe couldn't be loaded" buttonText="Back to Main Page" redirectRoute={WELCOME_ROUTE} />
 }

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -49,7 +49,7 @@ const Container = (): React.ReactElement => {
     return () => {
       clearTimeout(failedTimeout)
     }
-  }, [isSafeLoaded])
+  }, [isSafeLoaded, address, addressFromUrl])
 
   const [modal, setModal] = useState({
     isOpen: false,

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -7,7 +7,7 @@ import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 import { currentSafeFeaturesEnabled, currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import { LoadingContainer } from 'src/components/LoaderContainer'
-import { generateSafeRoute, extractPrefixedSafeAddress, SAFE_ROUTES, extractSafeAddress } from 'src/routes/routes'
+import { generateSafeRoute, extractPrefixedSafeAddress, SAFE_ROUTES } from 'src/routes/routes'
 import { SAFE_POLLING_INTERVAL } from 'src/utils/constants'
 import SafeLoadError from '../components/SafeLoadError'
 import { useLoadSafe } from 'src/logic/safe/hooks/useLoadSafe'
@@ -33,12 +33,11 @@ const Container = (): React.ReactElement => {
   const isSafeLoaded = owners.length > 0
   const [hasLoadFailed, setHasLoadFailed] = useState<boolean>(false)
 
-  const addressFromUrl = extractSafeAddress()
   useLoadSafe(address) // load initially
   useSafeScheduledUpdates(address) // load every X seconds
 
   useEffect(() => {
-    if (isSafeLoaded && address === addressFromUrl) {
+    if (isSafeLoaded) {
       setHasLoadFailed(false)
       return
     }
@@ -49,7 +48,7 @@ const Container = (): React.ReactElement => {
     return () => {
       clearTimeout(failedTimeout)
     }
-  }, [isSafeLoaded, address, addressFromUrl])
+  }, [isSafeLoaded, address])
 
   const [modal, setModal] = useState({
     isOpen: false,

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -7,7 +7,7 @@ import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 import { currentSafeFeaturesEnabled, currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
 import { LoadingContainer } from 'src/components/LoaderContainer'
-import { generateSafeRoute, extractPrefixedSafeAddress, SAFE_ROUTES } from 'src/routes/routes'
+import { generateSafeRoute, extractPrefixedSafeAddress, SAFE_ROUTES, extractSafeAddress } from 'src/routes/routes'
 import { SAFE_POLLING_INTERVAL } from 'src/utils/constants'
 import SafeLoadError from '../components/SafeLoadError'
 import { useLoadSafe } from 'src/logic/safe/hooks/useLoadSafe'
@@ -33,11 +33,14 @@ const Container = (): React.ReactElement => {
   const isSafeLoaded = owners.length > 0
   const [hasLoadFailed, setHasLoadFailed] = useState<boolean>(false)
 
-  useLoadSafe(address) // load initially
-  useSafeScheduledUpdates(address) // load every X seconds
+  const addressFromUrl = extractSafeAddress()
+  const safeAddress = address || addressFromUrl
+
+  useLoadSafe(safeAddress) // load initially
+  useSafeScheduledUpdates(safeAddress) // load every X seconds
 
   useEffect(() => {
-    if (isSafeLoaded) {
+    if (isSafeLoaded && address === safeAddress) {
       setHasLoadFailed(false)
       return
     }

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -59,7 +59,7 @@ const Container = (): React.ReactElement => {
   })
 
   if (hasLoadFailed) {
-    return <SafeLoadError isSafeLoaded={isSafeLoaded} />
+    return <SafeLoadError />
   }
 
   if (!isSafeLoaded) {

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -48,7 +48,7 @@ const Container = (): React.ReactElement => {
     return () => {
       clearTimeout(failedTimeout)
     }
-  }, [isSafeLoaded, address])
+  }, [isSafeLoaded])
 
   const [modal, setModal] = useState({
     isOpen: false,


### PR DESCRIPTION
## What it solves
Safe loading error screen persisting

## How this PR fixes it
If the Safe fails to load, but then succeeds on the next scheduled poll, the "Safe couldn't be loaded" error screen is removed.

## How to test it
Open a Safe on a throttled connection and observe the error message appear. When the loading has succeeded, it should now dissapear and not remove it from the viewed Safes cache.