### PR TITLE
Removes all USD references

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@gnosis.pm/safe-apps-sdk": "6.2.0",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
-    "@gnosis.pm/safe-deployments": "^1.8.0",
+    "@gnosis.pm/safe-deployments": "https://github.com/shyftfederation/safe-deployments.git#36f8fe1cb7d74c5a01844b9d95c94aed1dfe9ddb",
     "@gnosis.pm/safe-react-components": "^0.9.8",
     "@gnosis.pm/safe-react-gateway-sdk": "^2.8.6",
     "@gnosis.pm/safe-web3-lib": "^1.0.0",

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -188,7 +188,6 @@ const SafeHeader = ({
           </StyledLabel>
         )}
 
-        <StyledText size="xl">{balance}</StyledText>
         <StyledButton size="md" disabled={!granted} color="primary" variant="contained" onClick={onNewTransactionClick}>
           <FixedIcon type="arrowSentWhite" />
           <Text size="xl" color="white">

--- a/src/routes/safe/components/Balances/Coins/index.tsx
+++ b/src/routes/safe/components/Balances/Coins/index.tsx
@@ -20,7 +20,6 @@ import AssetTableCell from 'src/routes/safe/components/Balances/AssetTableCell'
 import {
   BALANCE_TABLE_ASSET_ID,
   BALANCE_TABLE_BALANCE_ID,
-  BALANCE_TABLE_VALUE_ID,
   generateColumns,
   getBalanceData,
   BalanceData,
@@ -106,25 +105,6 @@ const Coins = (props: Props): React.ReactElement => {
                   }
                   case BALANCE_TABLE_BALANCE_ID: {
                     cellItem = <div data-testid={`balance-${row[BALANCE_TABLE_ASSET_ID].symbol}`}>{row[id]}</div>
-                    break
-                  }
-                  case BALANCE_TABLE_VALUE_ID: {
-                    // If there are no values for that row but we have balances, we display as '0.00 {CurrencySelected}'
-                    // In case we don't have balances, we display a skeleton
-                    const showCurrencyValueRow = row[id] || row[BALANCE_TABLE_BALANCE_ID]
-                    const valueWithCurrency = row[id] ? row[id] : `0.00 ${selectedCurrency}`
-                    cellItem =
-                      showCurrencyValueRow && selectedCurrency ? (
-                        <div className={classes.currencyValueRow}>
-                          {valueWithCurrency}
-                          <CurrencyTooltip
-                            valueWithCurrency={valueWithCurrency}
-                            balanceWithSymbol={row[BALANCE_TABLE_BALANCE_ID]}
-                          />
-                        </div>
-                      ) : (
-                        <Skeleton animation="wave" />
-                      )
                     break
                   }
                   default: {

--- a/src/routes/safe/components/Balances/dataFetcher.ts
+++ b/src/routes/safe/components/Balances/dataFetcher.ts
@@ -4,7 +4,6 @@ import { TableColumn } from 'src/components/Table/types.d'
 import { Token } from 'src/logic/tokens/store/model/token'
 export const BALANCE_TABLE_ASSET_ID = 'asset'
 export const BALANCE_TABLE_BALANCE_ID = 'balance'
-export const BALANCE_TABLE_VALUE_ID = 'value'
 
 const getTokenPriceInCurrency = (balance: string, currencySelected?: string): string => {
   if (!currencySelected) {
@@ -18,7 +17,6 @@ export interface BalanceData {
   assetOrder: string
   balance: string
   balanceOrder: number
-  value: string
   valueOrder: number
 }
 
@@ -36,7 +34,6 @@ export const getBalanceData = (safeTokens: List<Token>, currencySelected?: strin
       assetOrder: token.name,
       [BALANCE_TABLE_BALANCE_ID]: `${formatAmountInUsFormat(tokenBalance?.toString() || '0')} ${token.symbol}`,
       balanceOrder: Number(tokenBalance),
-      [BALANCE_TABLE_VALUE_ID]: getTokenPriceInCurrency(fiatBalance || '0', currencySelected),
       valueOrder: Number(tokenBalance),
     }
   })
@@ -72,15 +69,6 @@ export const generateColumns = (): List<TableColumn> => {
     static: true,
   }
 
-  const value: TableColumn = {
-    id: BALANCE_TABLE_VALUE_ID,
-    align: 'right',
-    order: true,
-    label: 'Value',
-    custom: false,
-    static: true,
-    disablePadding: false,
-  }
 
-  return List([assetColumn, balanceColumn, value, actions])
+  return List([assetColumn, balanceColumn, actions])
 }


### PR DESCRIPTION
remove USD pulldown, 2. remove “value” column   3. show only the mainnet asset (or nothing) in left column