### PR TITLE
fix: initialise web3 and load contracts in middleware

### DIFF
--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -20,7 +20,7 @@ import { checksumAddress } from 'src/utils/checksumAddress'
 
 const LAST_USED_PROVIDER_KEY = 'SAFE__lastUsedProvider'
 
-export const saveLastUsedProvider = (name: string) => {
+export const saveLastUsedProvider = (name: string): void => {
   const expireInDays = (days: number) => 60 * 60 * 24 * 1000 * days
   const expiry = isPairingModule(name) ? expireInDays(1) : expireInDays(365)
   saveToStorageWithExpiry(LAST_USED_PROVIDER_KEY, name, expiry)

--- a/src/logic/wallets/onboard.ts
+++ b/src/logic/wallets/onboard.ts
@@ -3,11 +3,9 @@ import { API, Initialization } from 'bnc-onboard/dist/src/interfaces'
 import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { _getChainId, getChainName } from 'src/config'
-import { setWeb3, resetWeb3 } from 'src/logic/wallets/getWeb3'
 import transactionDataCheck from 'src/logic/wallets/transactionDataCheck'
 import { getSupportedWallets } from 'src/logic/wallets/utils/walletList'
 import { ChainId, CHAIN_ID } from 'src/config/chain.d'
-import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 import { loadFromStorageWithExpiry, removeFromStorage, saveToStorageWithExpiry } from 'src/utils/storage'
 import { store } from 'src/store'
 import updateProviderWallet from 'src/logic/wallets/store/actions/updateProviderWallet'
@@ -22,7 +20,7 @@ import { checksumAddress } from 'src/utils/checksumAddress'
 
 const LAST_USED_PROVIDER_KEY = 'SAFE__lastUsedProvider'
 
-const saveLastUsedProvider = (name: string) => {
+export const saveLastUsedProvider = (name: string) => {
   const expireInDays = (days: number) => 60 * 60 * 24 * 1000 * days
   const expiry = isPairingModule(name) ? expireInDays(1) : expireInDays(365)
   saveToStorageWithExpiry(LAST_USED_PROVIDER_KEY, name, expiry)
@@ -30,6 +28,10 @@ const saveLastUsedProvider = (name: string) => {
 
 export const loadLastUsedProvider = (): string | undefined => {
   return loadFromStorageWithExpiry<string>(LAST_USED_PROVIDER_KEY)
+}
+
+export const removeLastUsedProvider = (): void => {
+  removeFromStorage(LAST_USED_PROVIDER_KEY)
 }
 
 const getNetworkName = (chainId: ChainId) => {
@@ -46,38 +48,16 @@ const hasENSSupport = (chainId: ChainId): boolean => {
   return getChains().some((chain) => chain.chainId === chainId && chain.features.includes(FEATURES.DOMAIN_LOOKUP))
 }
 
-let prevAddress = ''
-
 const getOnboard = (chainId: ChainId): API => {
   const config: Initialization = {
     networkId: parseInt(chainId, 10),
     networkName: getNetworkName(chainId),
     subscriptions: {
       wallet: async (wallet) => {
-        if (wallet.provider) {
-          setWeb3(wallet.provider)
-          instantiateSafeContracts()
-        }
-
-        // Cache wallet for reconnection
-        if (wallet.name) {
-          saveLastUsedProvider(wallet.name)
-        }
-
         store.dispatch(updateProviderWallet(wallet.name || ''))
       },
       address: (address) => {
         store.dispatch(updateProviderAccount(checksumAddress(address) || ''))
-
-        if (address) {
-          prevAddress = address
-        }
-
-        // Wallet disconnected
-        if (!address && prevAddress) {
-          resetWeb3()
-          removeFromStorage(LAST_USED_PROVIDER_KEY)
-        }
       },
       network: (networkId) => {
         store.dispatch(updateProviderNetwork(networkId?.toString() || ''))

--- a/src/logic/wallets/store/middleware/index.ts
+++ b/src/logic/wallets/store/middleware/index.ts
@@ -9,8 +9,11 @@ import { ProviderPayloads } from 'src/logic/wallets/store/reducer'
 import { providerSelector } from '../selectors'
 import { trackEvent } from 'src/utils/googleTagManager'
 import { WALLET_EVENTS } from 'src/utils/events/wallet'
+import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
+import { resetWeb3, setWeb3 } from '../../getWeb3'
+import onboard, { removeLastUsedProvider, saveLastUsedProvider } from '../../onboard'
 
-let hasName = false
+let hasWalletName = false
 let hasAccount = false
 let hasNetwork = false
 
@@ -25,16 +28,24 @@ const providerMiddleware =
     // Onboard sends provider details via separate subscriptions: wallet, account, network
     // Payloads from all three need to be combined to be `loaded` and `available`
     if (type === PROVIDER_ACTIONS.WALLET_NAME) {
-      hasName = !!payload
+      hasWalletName = !!payload
     } else if (type === PROVIDER_ACTIONS.ACCOUNT) {
       hasAccount = !!payload
     } else if (type === PROVIDER_ACTIONS.NETWORK) {
       hasNetwork = !!payload
     } else {
+      // Dispatched actions from reducers unrelated to wallet
       return handledAction
     }
 
-    if (!hasName || !hasAccount || !hasNetwork) {
+    // No wallet is connected via onboard
+    if (!hasWalletName && !hasAccount && !hasNetwork) {
+      resetWeb3()
+      removeLastUsedProvider()
+    }
+
+    // Wallet 'partially' connected: only a subset of onboard subscription(s) have fired
+    if (!hasWalletName || !hasAccount || !hasNetwork) {
       return handledAction
     }
 
@@ -45,17 +56,27 @@ const providerMiddleware =
     // Wallet, account and network did not successfully load
     if (!loaded) {
       store.dispatch(enqueueSnackbar(enhanceSnackbarForAction(NOTIFICATIONS.CONNECT_WALLET_ERROR_MSG)))
-
       return handledAction
     }
 
-    if (available && name) {
+    if (!available) {
+      store.dispatch(enqueueSnackbar(enhanceSnackbarForAction(NOTIFICATIONS.UNLOCK_WALLET_MSG)))
+      return handledAction
+    }
+
+    // Instantiate web3/contract
+    const { wallet } = onboard().getState()
+    if (wallet.provider) {
+      setWeb3(wallet.provider)
+      instantiateSafeContracts()
+    }
+
+    if (name) {
+      saveLastUsedProvider(name)
       // Only track when account has been successfully saved to store
       if (payload === account) {
         trackEvent({ ...WALLET_EVENTS.CONNECT, label: name })
       }
-    } else {
-      store.dispatch(enqueueSnackbar(enhanceSnackbarForAction(NOTIFICATIONS.UNLOCK_WALLET_MSG)))
     }
 
     return handledAction


### PR DESCRIPTION
## What it solves
Resolves #3722

## How this PR fixes it
`setWeb3` and the instantiation of contracts has been moved to the provider middleware (as well as `resetWeb3`).

As we enable the pairing module on load, onboard's wallet subscription fires by default, meaning that the `updateProviderWallet` action is fired. Within that subscription we were saving the provider: a WalletConnect session that isn't connected (the QR code not scanned). This was causing issues retrieving the spending limit contract and preventing the Safe from loading.

## How to test it
Open a Safe with the spending limit module enabled (e.g. `/app/eth:0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7/balances`) and the wallet disconnected. The Safe should load without issues: balances, transactions, etc.

This fix affects the instantiation of the web3 object/contract loading and thus the transaction interaction must also be tested.