### PR TITLE
fix: only show footer in welcome and settings

### DIFF
--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -8,7 +8,7 @@ import Header from './Header'
 import Footer from './Footer'
 import Sidebar from './Sidebar'
 import { MobileNotSupported } from './MobileNotSupported'
-import { SAFE_ROUTES } from 'src/routes/routes'
+import { SAFE_ROUTES, WELCOME_ROUTE } from 'src/routes/routes'
 import useDarkMode from 'src/logic/hooks/useDarkMode'
 
 const Container = styled.div`
@@ -98,8 +98,8 @@ const Layout: React.FC<Props> = ({
 
   const closeMobileNotSupported = () => setMobileNotSupportedClosed(true)
 
-  const noFooter = !!matchPath(pathname, {
-    path: [SAFE_ROUTES.APPS],
+  const hasFooter = !!matchPath(pathname, {
+    path: [SAFE_ROUTES.SETTINGS, WELCOME_ROUTE],
   })
 
   return (
@@ -122,7 +122,7 @@ const Layout: React.FC<Props> = ({
         </SidebarWrapper>
         <ContentWrapper>
           <div>{children}</div>
-          {!noFooter && <Footer />}
+          {!hasFooter && <Footer />}
         </ContentWrapper>
       </BodyWrapper>
 

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -122,7 +122,7 @@ const Layout: React.FC<Props> = ({
         </SidebarWrapper>
         <ContentWrapper>
           <div>{children}</div>
-          {!hasFooter && <Footer />}
+          {hasFooter && <Footer />}
         </ContentWrapper>
       </BodyWrapper>
 

--- a/src/components/AppstoreButton/index.tsx
+++ b/src/components/AppstoreButton/index.tsx
@@ -2,6 +2,7 @@ import { ReactElement } from 'react'
 import AppstoreDarkBadge from 'src/assets/icons/appstore.svg'
 import AppstoreLightBadge from 'src/assets/icons/appstore-alt.svg'
 
+// App Store campaigns track the user interaction
 enum LINKS {
   footer = 'https://apps.apple.com/app/apple-store/id1515759131?pt=119497694&ct=Web%20App%20Footer&mt=8',
   pairing = 'https://apps.apple.com/app/apple-store/id1515759131?pt=119497694&ct=Web%20App%20Connect&mt=8',


### PR DESCRIPTION
## What it solves
Resolves #3712

## How this PR fixes it
The footer is only visible on the welcome and settings routes.

## How to test it
Open the welcome/settings routes and observe the footer. On others it should not be visible.

## Analytics changes
No analytics implementation is necessary. There is an App Store campaign in place that tracks the user interaction for us.