### PR TITLE
fix: ignore `ResizeObserver` errors

### DIFF
--- a/src/components/VirtualizedList/index.tsx
+++ b/src/components/VirtualizedList/index.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react'
+import { useEffect, ReactElement } from 'react'
+import { Virtuoso } from 'react-virtuoso'
 
-// Virtualized list throws an error regarding the ResizeObserver loop. It cannot deliver all observations
-// in one animation frame. The author of the `ResizeObserver` spec assures that it can be safely ignored:
+// The ResizeObserver cannot deliver all observations in one animation frame.
+// The author of the `ResizeObserver` spec assures that it can be safely ignored:
 // https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120
 
 const ignoreResizeObserverErrors = (e: ErrorEvent) => {
@@ -14,12 +15,13 @@ const ignoreResizeObserverErrors = (e: ErrorEvent) => {
   }
 }
 
-const useIgnoreResizeObserverError = (): null => {
+const VirtualizedList: typeof Virtuoso = ({ children, ...props }): ReactElement => {
   useEffect(() => {
     window.addEventListener('error', ignoreResizeObserverErrors)
     return () => window.removeEventListener('error', ignoreResizeObserverErrors)
   })
-  return null
+
+  return <Virtuoso {...props}>{children}</Virtuoso>
 }
 
-export default useIgnoreResizeObserverError
+export default VirtualizedList

--- a/src/components/VirtualizedList/index.tsx
+++ b/src/components/VirtualizedList/index.tsx
@@ -15,13 +15,23 @@ const ignoreResizeObserverErrors = (e: ErrorEvent) => {
   }
 }
 
-const VirtualizedList: typeof Virtuoso = ({ children, ...props }): ReactElement => {
+const VirtualizedList: typeof Virtuoso = ({ children, style, ...props }): ReactElement => {
   useEffect(() => {
     window.addEventListener('error', ignoreResizeObserverErrors)
     return () => window.removeEventListener('error', ignoreResizeObserverErrors)
   })
 
-  return <Virtuoso {...props}>{children}</Virtuoso>
+  return (
+    <Virtuoso
+      style={{
+        height: 'calc(100% - 54px)', // Remove breadcrumb height
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </Virtuoso>
+  )
 }
 
 export default VirtualizedList

--- a/src/components/VirtualizedList/index.tsx
+++ b/src/components/VirtualizedList/index.tsx
@@ -19,7 +19,7 @@ const VirtualizedList: typeof Virtuoso = ({ children, style, ...props }): ReactE
   useEffect(() => {
     window.addEventListener('error', ignoreResizeObserverErrors)
     return () => window.removeEventListener('error', ignoreResizeObserverErrors)
-  })
+  }, [])
 
   return (
     <Virtuoso

--- a/src/logic/hooks/useIgnoreResizeObserverError.ts
+++ b/src/logic/hooks/useIgnoreResizeObserverError.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+
+// Virtualized list throws an error regarding the ResizeObserver loop. It cannot deliver all observations
+// in one animation frame. The author of the `ResizeObserver` spec assures that it can be safely ignored:
+// https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120
+
+const ignoreResizeObserverErrors = (e: ErrorEvent) => {
+  const RESIZE_OBSERVER_ERRORS = [
+    'ResizeObserver loop completed with undelivered notifications.',
+    'ResizeObserver loop limit exceeded',
+  ]
+  if (RESIZE_OBSERVER_ERRORS.includes(e.message)) {
+    e.stopImmediatePropagation()
+  }
+}
+
+const useIgnoreResizeObserverError = (): null => {
+  useEffect(() => {
+    window.addEventListener('error', ignoreResizeObserverErrors)
+    return () => window.removeEventListener('error', ignoreResizeObserverErrors)
+  })
+  return null
+}
+
+export default useIgnoreResizeObserverError

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -2,7 +2,6 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 import Card from '@material-ui/core/Card'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import { useSelector } from 'react-redux'
-import { Virtuoso } from 'react-virtuoso'
 
 import Item from './components/Item'
 
@@ -17,7 +16,7 @@ import { fontColor, lg, screenSm, screenXs } from 'src/theme/variables'
 import { NFTToken } from 'src/logic/collectibles/sources/collectibles.d'
 import { trackEvent } from 'src/utils/googleTagManager'
 import { ASSETS_EVENTS } from 'src/utils/events/assets'
-import useIgnoreResizeObserverError from 'src/logic/hooks/useIgnoreResizeObserverError'
+import VirtualizedList from 'src/components/VirtualizedList'
 
 const useStyles = makeStyles(
   createStyles({
@@ -93,9 +92,6 @@ const Collectibles = (): React.ReactElement => {
   const nftTokens = useSelector(orderedNFTAssets)
   const nftAssetsFromNftTokens = useSelector(nftAssetsFromNftTokensSelector)
 
-  // Virtuoso throws errors regarding ResizeObserver
-  useIgnoreResizeObserverError()
-
   const nftAmount = useMemo(() => nftTokens.length, [nftTokens])
   useEffect(() => {
     trackEvent({ ...ASSETS_EVENTS.NFT_AMOUNT, label: nftAmount })
@@ -120,7 +116,7 @@ const Collectibles = (): React.ReactElement => {
 
   return (
     <>
-      <Virtuoso
+      <VirtualizedList
         style={{
           height: 'calc(100% - 54px)', // Remove breadcrumb height
         }}

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -117,9 +117,6 @@ const Collectibles = (): React.ReactElement => {
   return (
     <>
       <VirtualizedList
-        style={{
-          height: 'calc(100% - 54px)', // Remove breadcrumb height
-        }}
         data={nftAssetsFromNftTokens}
         itemContent={(_, nftAsset) => {
           // Larger collectible lists can cause this to be initially undefined

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -17,6 +17,7 @@ import { fontColor, lg, screenSm, screenXs } from 'src/theme/variables'
 import { NFTToken } from 'src/logic/collectibles/sources/collectibles.d'
 import { trackEvent } from 'src/utils/googleTagManager'
 import { ASSETS_EVENTS } from 'src/utils/events/assets'
+import useIgnoreResizeObserverError from 'src/logic/hooks/useIgnoreResizeObserverError'
 
 const useStyles = makeStyles(
   createStyles({
@@ -91,6 +92,9 @@ const Collectibles = (): React.ReactElement => {
   const nftLoaded = useSelector(nftLoadedSelector)
   const nftTokens = useSelector(orderedNFTAssets)
   const nftAssetsFromNftTokens = useSelector(nftAssetsFromNftTokensSelector)
+
+  // Virtuoso throws errors regarding ResizeObserver
+  useIgnoreResizeObserverError()
 
   const nftAmount = useMemo(() => nftTokens.length, [nftTokens])
   useEffect(() => {


### PR DESCRIPTION
## What it solves
Resolves `ResizeObserver` errors.

## How this PR fixes it
The virtualization of the collectibles list resulted in some [`ResizeObserver` errors](https://sentry.io/organizations/gnosis/issues/3121178886/?project=5436884&query=is%3Aunresolved&sort=freq&statsPeriod=14d). These can, however, be [safely ignored](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120). Fix found via the React Virtuoso issue board [here](https://github.com/petyosi/react-virtuoso/issues/369).

## How to test it
1. Open a Safe with a large number of collectibles, e.g. `eth:0xc6400A5584db71e41B0E5dFbdC769b54B91256CD` in Chrome.
2. Excessively scroll through the collectibles list.
3. Observe no `ResizeObserver` errors (`'ResizeObserver loop completed with undelivered notifications.'`,
    `'ResizeObserver loop limit exceeded'`) in the console