### PR TITLE
feat: add on-/off-chain tx event tracking

### DIFF
--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -33,6 +33,8 @@ import { getLastTransaction } from 'src/logic/safe/store/selectors/gatewayTransa
 import { TxArgs } from 'src/logic/safe/store/models/types/transaction'
 import { getContractErrorMessage } from 'src/logic/contracts/safeContractErrors'
 import { isWalletRejection } from 'src/logic/wallets/errors'
+import { trackEvent } from 'src/utils/googleTagManager'
+import { WALLET_EVENTS } from 'src/utils/events/wallet'
 
 export interface CreateTransactionArgs {
   navigateToTransactionsTab?: boolean
@@ -226,6 +228,8 @@ export class TxSender {
         // WC + Safe receives "NaN" as a string instead of a sig
         if (signature && signature !== 'NaN') {
           this.onComplete(signature, confirmCallback)
+          // Only track if onComplete succeeds
+          trackEvent(WALLET_EVENTS.OFF_CHAIN_SIGNATURE)
         } else {
           throw Error('No signature received')
         }
@@ -239,6 +243,8 @@ export class TxSender {
     // On-chain signature or execution
     try {
       await this.sendTx(confirmCallback)
+      // Only track if transaction succeeds
+      trackEvent(WALLET_EVENTS.ON_CHAIN_INTERACTION)
     } catch (err) {
       logError(Errors._803, err.message)
       this.onError(err, errorCallback)

--- a/src/logic/safe/store/actions/createTransaction.ts
+++ b/src/logic/safe/store/actions/createTransaction.ts
@@ -116,6 +116,8 @@ export class TxSender {
 
     notifications.closePending()
 
+    trackEvent(signature ? WALLET_EVENTS.OFF_CHAIN_SIGNATURE : WALLET_EVENTS.ON_CHAIN_INTERACTION)
+
     // This is used to communicate the safeTxHash to a Safe App caller
     confirmCallback?.(safeTxHash)
 
@@ -228,8 +230,6 @@ export class TxSender {
         // WC + Safe receives "NaN" as a string instead of a sig
         if (signature && signature !== 'NaN') {
           this.onComplete(signature, confirmCallback)
-          // Only track if onComplete succeeds
-          trackEvent(WALLET_EVENTS.OFF_CHAIN_SIGNATURE)
         } else {
           throw Error('No signature received')
         }
@@ -243,8 +243,6 @@ export class TxSender {
     // On-chain signature or execution
     try {
       await this.sendTx(confirmCallback)
-      // Only track if transaction succeeds
-      trackEvent(WALLET_EVENTS.ON_CHAIN_INTERACTION)
     } catch (err) {
       logError(Errors._803, err.message)
       this.onError(err, errorCallback)

--- a/src/utils/events/wallet.ts
+++ b/src/utils/events/wallet.ts
@@ -6,6 +6,14 @@ const WALLET = {
     event: GTM_EVENT.META,
     action: 'Connect wallet',
   },
+  OFF_CHAIN_SIGNATURE: {
+    event: GTM_EVENT.META,
+    action: 'Off-chain signature',
+  },
+  ON_CHAIN_INTERACTION: {
+    event: GTM_EVENT.META,
+    action: 'On-chain interaction',
+  },
 }
 
 const WALLET_CATEGORY = 'wallet'


### PR DESCRIPTION
## What it solves
Transaction tracking

## How this PR fixes it
On-/off-chain interactions now emit a tracking event if they are successful.

## How to test it
- Sign off-chain and observe a tracking event.
- Sign/execute on-chain and observe a tracking event.

## Analytics changes
![image](https://user-images.githubusercontent.com/20442784/160584771-c6495f86-d041-433c-ad45-e50464e8e939.png)