### PR TITLE
fix: Disable safeNonce input field until recommendedNonce is fetched

### DIFF
--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useState } from 'react'
+import { ReactElement, useState, ChangeEvent } from 'react'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
 import { makeStyles } from '@material-ui/core/styles'
@@ -25,7 +25,6 @@ import { isMaxFeeParam } from 'src/logic/safe/transactions/gas'
 import Paragraph from 'src/components/layout/Paragraph'
 import InputAdornment from '@material-ui/core/InputAdornment'
 import CircularProgress from '@material-ui/core/CircularProgress'
-import * as React from 'react'
 
 const StyledDivider = styled(Divider)`
   margin: 0;
@@ -105,8 +104,7 @@ export const EditTxParametersForm = ({
   const classes = useStyles()
   const { safeNonce, safeTxGas, ethNonce, ethGasLimit, ethGasPrice, ethMaxPrioFee } = txParameters
   const showSafeTxGas = useSafeTxGas()
-  const [manualSafeNonce, setManualSafeNonce] = useState<string>('')
-  const [hasChangedSafeNonce, setHasChangedSafeNonce] = useState<boolean>(false)
+  const [manualSafeNonce, setManualSafeNonce] = useState<string>()
 
   const onSubmit = (values: TxParameters) => {
     onClose(values)
@@ -116,11 +114,7 @@ export const EditTxParametersForm = ({
     onClose()
   }
 
-  const handleSafeNonceChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setHasChangedSafeNonce(true)
-    setManualSafeNonce(e.target.value)
-  }, [])
-
+  const hasChangedSafeNonce = manualSafeNonce !== undefined
   const showAdornment = !safeNonce && !hasChangedSafeNonce
   const loadingAdornment = showAdornment
     ? {
@@ -175,7 +169,7 @@ export const EditTxParametersForm = ({
                   min="0"
                   component={TextField}
                   disabled={!areSafeParamsEnabled(parametersStatus)}
-                  onChange={handleSafeNonceChange}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setManualSafeNonce(e.target.value)}
                   inputAdornment={loadingAdornment}
                 />
                 {showSafeTxGas && (

--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState, ChangeEvent } from 'react'
+import { ReactElement, useState, ChangeEvent, useCallback } from 'react'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
 import { makeStyles } from '@material-ui/core/styles'
@@ -114,6 +114,11 @@ export const EditTxParametersForm = ({
     onClose()
   }
 
+  const handleSafeNonceChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => setManualSafeNonce(e.target.value),
+    [],
+  )
+
   const hasChangedSafeNonce = manualSafeNonce !== undefined
   const showAdornment = !safeNonce && !hasChangedSafeNonce
   const loadingAdornment = showAdornment
@@ -169,7 +174,7 @@ export const EditTxParametersForm = ({
                   min="0"
                   component={TextField}
                   disabled={!areSafeParamsEnabled(parametersStatus)}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => setManualSafeNonce(e.target.value)}
+                  onChange={handleSafeNonceChange}
                   inputAdornment={loadingAdornment}
                 />
                 {showSafeTxGas && (

--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, useCallback, useState } from 'react'
 import IconButton from '@material-ui/core/IconButton'
 import Close from '@material-ui/icons/Close'
 import { makeStyles } from '@material-ui/core/styles'
@@ -23,6 +23,9 @@ import {
 import useSafeTxGas from 'src/routes/safe/components/Transactions/helpers/useSafeTxGas'
 import { isMaxFeeParam } from 'src/logic/safe/transactions/gas'
 import Paragraph from 'src/components/layout/Paragraph'
+import InputAdornment from '@material-ui/core/InputAdornment'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import * as React from 'react'
 
 const StyledDivider = styled(Divider)`
   margin: 0;
@@ -102,6 +105,8 @@ export const EditTxParametersForm = ({
   const classes = useStyles()
   const { safeNonce, safeTxGas, ethNonce, ethGasLimit, ethGasPrice, ethMaxPrioFee } = txParameters
   const showSafeTxGas = useSafeTxGas()
+  const [manualSafeNonce, setManualSafeNonce] = useState<string>('')
+  const [hasChangedSafeNonce, setHasChangedSafeNonce] = useState<boolean>(false)
 
   const onSubmit = (values: TxParameters) => {
     onClose(values)
@@ -110,6 +115,22 @@ export const EditTxParametersForm = ({
   const onCloseFormHandler = () => {
     onClose()
   }
+
+  const handleSafeNonceChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setHasChangedSafeNonce(true)
+    setManualSafeNonce(e.target.value)
+  }, [])
+
+  const showAdornment = !safeNonce && !hasChangedSafeNonce
+  const loadingAdornment = showAdornment
+    ? {
+        endAdornment: (
+          <InputAdornment position="end">
+            <CircularProgress size="16px" />
+          </InputAdornment>
+        ),
+      }
+    : null
 
   return (
     <>
@@ -128,7 +149,7 @@ export const EditTxParametersForm = ({
       <Block className={classes.container}>
         <GnoForm
           initialValues={{
-            safeNonce: safeNonce || '0',
+            safeNonce: hasChangedSafeNonce ? manualSafeNonce : safeNonce || '',
             safeTxGas: safeTxGas || '',
             ethNonce: ethNonce || '',
             ethGasLimit: ethGasLimit || '',
@@ -153,7 +174,9 @@ export const EditTxParametersForm = ({
                   type="number"
                   min="0"
                   component={TextField}
-                  disabled={!areSafeParamsEnabled(parametersStatus) || !safeNonce}
+                  disabled={!areSafeParamsEnabled(parametersStatus)}
+                  onChange={handleSafeNonceChange}
+                  inputAdornment={loadingAdornment}
                 />
                 {showSafeTxGas && (
                   <Field

--- a/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/EditTxParametersForm/index.tsx
@@ -22,8 +22,6 @@ import {
 } from 'src/routes/safe/components/Transactions/helpers/utils'
 import useSafeTxGas from 'src/routes/safe/components/Transactions/helpers/useSafeTxGas'
 import { isMaxFeeParam } from 'src/logic/safe/transactions/gas'
-import { extractSafeAddress } from 'src/routes/routes'
-import useRecommendedNonce from 'src/logic/hooks/useRecommendedNonce'
 import Paragraph from 'src/components/layout/Paragraph'
 
 const StyledDivider = styled(Divider)`
@@ -104,8 +102,6 @@ export const EditTxParametersForm = ({
   const classes = useStyles()
   const { safeNonce, safeTxGas, ethNonce, ethGasLimit, ethGasPrice, ethMaxPrioFee } = txParameters
   const showSafeTxGas = useSafeTxGas()
-  const safeAddress = extractSafeAddress()
-  const recommendedNonce = useRecommendedNonce(safeAddress)
 
   const onSubmit = (values: TxParameters) => {
     onClose(values)
@@ -132,7 +128,7 @@ export const EditTxParametersForm = ({
       <Block className={classes.container}>
         <GnoForm
           initialValues={{
-            safeNonce: safeNonce || recommendedNonce || '0',
+            safeNonce: safeNonce || '0',
             safeTxGas: safeTxGas || '',
             ethNonce: ethNonce || '',
             ethGasLimit: ethGasLimit || '',
@@ -157,7 +153,7 @@ export const EditTxParametersForm = ({
                   type="number"
                   min="0"
                   component={TextField}
-                  disabled={!areSafeParamsEnabled(parametersStatus)}
+                  disabled={!areSafeParamsEnabled(parametersStatus) || !safeNonce}
                 />
                 {showSafeTxGas && (
                   <Field

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -71,6 +71,10 @@ const StyledDivider = styled(Divider)`
 type TxParam = string | ReactElement
 type TxParameterProps = { name: TxParam; value?: TxParam | null; color?: ThemeColors } & ColoredTextProps
 const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement | null => {
+  if (value == null || value === '') {
+    return null
+  }
+
   const getEl = (prop?: TxParam) => {
     return typeof prop === 'string' ? (
       <ColoredText size="lg" {...rest}>
@@ -84,7 +88,7 @@ const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement |
   return (
     <TxParameterWrapper>
       {getEl(name)}
-      {value == null || value === '' ? <Skeleton animation="wave" width="30px" /> : getEl(value)}
+      {getEl(value)}
     </TxParameterWrapper>
   )
 }
@@ -155,12 +159,14 @@ export const TxParametersDetail = ({
           <StyledText size="md" color="placeHolder">
             Safe transaction parameters
           </StyledText>
-          <TxParameter
-            name="Safe nonce"
-            value={txParameters.safeNonce || ''}
-            isError={isTxNonceOutOfOrder}
-            color={color}
-          />
+          <TxParameterWrapper>
+            <Text size="lg" color={isTxNonceOutOfOrder ? 'error' : color}>
+              Safe nonce
+            </Text>
+            <Text size="lg" color={isTxNonceOutOfOrder ? 'error' : color}>
+              {txParameters.safeNonce ? txParameters.safeNonce : <Skeleton animation="wave" width="30px" />}
+            </Text>
+          </TxParameterWrapper>
 
           {showSafeTxGas && <TxParameter name="SafeTxGas" value={txParameters.safeTxGas || '0'} color={color} />}
           <Track {...MODALS_EVENTS.EDIT_ADVANCED_PARAMS}>

--- a/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxParametersDetail/index.tsx
@@ -27,6 +27,7 @@ import { getByteLength } from 'src/utils/getByteLength'
 import { md } from 'src/theme/variables'
 import Track from 'src/components/Track'
 import { MODALS_EVENTS } from 'src/utils/events/modals'
+import { Skeleton } from '@material-ui/lab'
 
 const TxParameterWrapper = styled.div`
   display: flex;
@@ -70,10 +71,6 @@ const StyledDivider = styled(Divider)`
 type TxParam = string | ReactElement
 type TxParameterProps = { name: TxParam; value?: TxParam | null; color?: ThemeColors } & ColoredTextProps
 const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement | null => {
-  if (value == null || value === '') {
-    return null
-  }
-
   const getEl = (prop?: TxParam) => {
     return typeof prop === 'string' ? (
       <ColoredText size="lg" {...rest}>
@@ -87,7 +84,7 @@ const TxParameter = ({ name, value, ...rest }: TxParameterProps): ReactElement |
   return (
     <TxParameterWrapper>
       {getEl(name)}
-      {getEl(value)}
+      {value == null || value === '' ? <Skeleton animation="wave" width="30px" /> : getEl(value)}
     </TxParameterWrapper>
   )
 }

--- a/src/routes/safe/container/hooks/useTransactionParameters.ts
+++ b/src/routes/safe/container/hooks/useTransactionParameters.ts
@@ -4,10 +4,8 @@ import { toWei } from 'web3-utils'
 
 import { getUserNonce } from 'src/logic/wallets/ethTransactions'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
-import { currentSafeCurrentVersion } from 'src/logic/safe/store/selectors'
 import { ParametersStatus } from 'src/routes/safe/components/Transactions/helpers/utils'
 import { extractSafeAddress } from 'src/routes/routes'
-import { AppReduxState } from 'src/store'
 import { getRecommendedNonce } from 'src/logic/safe/api/fetchSafeTxGasEstimation'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 
@@ -44,8 +42,6 @@ type Props = {
 export const useTransactionParameters = (props?: Props): TxParameters => {
   const connectedWalletAddress = useSelector(userAccountSelector)
   const safeAddress = extractSafeAddress()
-  const safeVersion = useSelector(currentSafeCurrentVersion) as string
-  const state = useSelector((state: AppReduxState) => state)
 
   // Safe Params
   const [safeNonce, setSafeNonce] = useState<string | undefined>(props?.initialSafeNonce)
@@ -103,10 +99,10 @@ export const useTransactionParameters = (props?: Props): TxParameters => {
       }
     }
 
-    if (safeNonce === undefined) {
+    if (!safeNonce) {
       getSafeNonce()
     }
-  }, [safeAddress, safeVersion, safeNonce, state])
+  }, [safeAddress, safeNonce])
 
   return {
     safeNonce,


### PR DESCRIPTION
## What it solves
Resolves #3735 

The `safeNonce` input field is initially populated with the `recommendedNonce` that is fetched. If the network is slow and the user changes the `safeNonce` in the meantime, it will be overridden once the fetch resolves. 

## How this PR fixes it
The `safeNonce` input field shows a loading indicator until the fetch request for `recommendedNonce` has been resolved or the user starts typing. If any user interaction is detected, the value won't be overwritten by the fetch anymore.

## Additional changes
- The read view displays a Skeleton element for the safe nonce as long as it is still loading
- The safe nonce input displays a loading indicator

## How to test it
1. Open the Safe App
2. Block or throttle the `/estimations` request url
3. Create a new transaction
4. Edit the Advanced Parameters
5. Observe that the safeNonce field has a loading indicator until the estimations call resolves or the user types in the field

## Screenshots
![c](https://user-images.githubusercontent.com/5880855/161071610-437245bf-b8ed-40cb-adda-c0451566bb1a.png)

