### PR TITLE
chore: use `@testing-library/cypress`

### DIFF
--- a/cypress/integration/landing.spec.js
+++ b/cypress/integration/landing.spec.js
@@ -8,22 +8,20 @@ describe('Landing page', () => {
   it('features discoverability cookies', () => {
     cy.visit('/')
 
-    const cookieBannerId = '[data-testid="cookies-banner-form"]'
+    cy.findByTestId('cookies-banner-form').contains('We use cookies to provide you with the best experience')
 
-    cy.get(cookieBannerId).contains('We use cookies to provide you with the best experience')
+    cy.findByTestId('cookies-banner-form').contains('Accept selection').click()
 
-    cy.get(cookieBannerId).contains('Accept selection').click()
-
-    cy.get(cookieBannerId).should('not.exist')
+    cy.findByTestId('cookies-banner-form').should('not.exist')
 
     cy.contains("What's new").click()
 
-    cy.get(cookieBannerId).contains('We use cookies to provide you with the best experience')
-    cy.get(cookieBannerId).contains('Please accept the community support & updates cookies.')
+    cy.findByTestId('cookies-banner-form').contains('We use cookies to provide you with the best experience')
+    cy.findByTestId('cookies-banner-form').contains('Please accept the community support & updates cookies.')
 
-    cy.get(cookieBannerId).contains('Community support & updates').click()
-    cy.get(cookieBannerId).contains('Accept selection').click()
-    cy.get(cookieBannerId).should('not.exist')
+    cy.findByTestId('cookies-banner-form').contains('Community support & updates').click()
+    cy.findByTestId('cookies-banner-form').contains('Accept selection').click()
+    cy.findByTestId('cookies-banner-form').should('not.exist')
 
     // Open the features discoverability section
     cy.wait(3000) // TODO: wait for Beamer cookies to be set

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,1 @@
+import '@testing-library/cypress/add-commands'

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@gnosis.pm/safe-core-sdk-types": "1.0.0",
     "@rescripts/cli": "^0.0.16",
     "@sentry/cli": "^1.67.2",
+    "@testing-library/cypress": "^8.0.2",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,6 +1166,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.14.6":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
+  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -2827,10 +2834,32 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/cypress@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.2.tgz#b13f0ff2424dec4368b6670dfbfb7e43af8eefc9"
+  integrity sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    "@testing-library/dom" "^8.1.0"
+
 "@testing-library/dom@^8.0.0":
   version "8.10.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.10.1.tgz#e24fed92ad51c619cf304c6f1410b4c76b1000c0"
   integrity sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/dom@^8.1.0":
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.12.0.tgz#fef5e545533fb084175dda6509ee71d7d2f72e23"
+  integrity sha512-rBrJk5WjI02X1edtiUcZhgyhgBhiut96r5Jp8J5qktKdcvLcZpKDW8i2hkGMMItxrghjXuQ5AM6aE0imnFawaw==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"


### PR DESCRIPTION
## What it solves
Adding `@testing-library/cypress`

## How this PR fixes it
We can now use the well-known `findBy*` methods in our Cypress tests.

## How to test it
The `landing.spec.js` test should continue to pass.