### PR TITLE
fix: show threshold in transaction list

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxInfoSettings.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxInfoSettings.tsx
@@ -36,7 +36,7 @@ export const TxInfoSettings = ({ settingsInfo }: TxInfoSettingsProps): ReactElem
             name={settingsInfo.owner?.name || undefined}
             avatarUrl={settingsInfo.owner?.logoUri || undefined}
           />
-          <InfoDetails title="Confirmation policy increased/decreased to:">{settingsInfo.threshold}</InfoDetails>
+          <InfoDetails title="Confirmation policy changed to:">{settingsInfo.threshold}</InfoDetails>
         </InfoDetails>
       )
     }
@@ -59,7 +59,7 @@ export const TxInfoSettings = ({ settingsInfo }: TxInfoSettingsProps): ReactElem
       )
     }
     case 'CHANGE_THRESHOLD': {
-      return <InfoDetails title="Confirmation policy increased/decreased to:">{settingsInfo.threshold}</InfoDetails>
+      return <InfoDetails title="Confirmation policy changed to:">{settingsInfo.threshold}</InfoDetails>
     }
     case 'CHANGE_IMPLEMENTATION': {
       return (

--- a/src/routes/safe/components/Transactions/TxList/hooks/useTransactionType.ts
+++ b/src/routes/safe/components/Transactions/TxList/hooks/useTransactionType.ts
@@ -63,7 +63,7 @@ export const useTransactionType = (tx: Transaction): TxTypeProps => {
             // We only have the current threshold as reference, therefore threshold/n
             setType({
               icon,
-              text: safe.threshold === newThreshold ? method : `${method}ChangeThreshold (${newThreshold}/n)`,
+              text: safe.threshold === newThreshold ? method : `${method} + changeThreshold (${newThreshold}/n)`,
             })
             break
           }


### PR DESCRIPTION
## What it solves
Resolves #3723

## How this PR fixes it
The method name is now explicit, e.g. `addOwner` or `addOwnerChangeThreshold 1/n`. The description has also been modified: `Confirmation policy changed to`.

## How to test it
Add/remove owners whilst (not) changing the threshold, or change the threshold. Observe the changes in the transaction list.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/161292781-d9cd49ac-d4f0-43a7-90f5-ba2184c70dca.png)
