### PR TITLE
Add GTM safe apps event tracking

### DIFF
--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -69,7 +69,9 @@ class AppCommunicator {
         event: GTM_EVENT.SAFE_APP,
         name: this.app.name,
         method: msg.data.method,
-        params: msg.data.params,
+        params: msg.data.params
+          ? JSON.parse(JSON.stringify(msg.data.params).replaceAll(/0x[a-fA-F0-9]{40}/g, 'ethereum-address'))
+          : undefined,
         sdkVersion: msg.data.env.sdkVersion,
       })
 

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -10,6 +10,7 @@ import {
 } from '@gnosis.pm/safe-apps-sdk'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { SafeApp } from './types'
+import { GTM_EVENT, trackSafeAppEvent } from 'src/utils/googleTagManager'
 
 type MessageHandler = (
   msg: SDKMessageEvent,
@@ -64,6 +65,15 @@ class AppCommunicator {
     const hasHandler = this.canHandleMessage(msg)
 
     if (validMessage && hasHandler) {
+      trackSafeAppEvent({
+        event: GTM_EVENT.SAFE_APP,
+        name: this.app.name,
+        method: msg.data.method,
+        params: msg.data.params,
+        sdkVersion: msg.data.env.sdkVersion,
+        oui: 3,
+      })
+
       const handler = this.handlers.get(msg.data.method)
       try {
         // @ts-expect-error Handler existence is checked in this.canHandleMessage

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -71,7 +71,6 @@ class AppCommunicator {
         method: msg.data.method,
         params: msg.data.params,
         sdkVersion: msg.data.env.sdkVersion,
-        oui: 3,
       })
 
       const handler = this.handlers.get(msg.data.method)

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -10,7 +10,7 @@ import {
 } from '@gnosis.pm/safe-apps-sdk'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { SafeApp } from './types'
-import { trackSafeAppEvent } from 'src/utils/googleTagManager'
+import { trackSafeAppMessage } from 'src/utils/googleTagManager'
 
 type MessageHandler = (
   msg: SDKMessageEvent,
@@ -68,7 +68,7 @@ class AppCommunicator {
     const hasHandler = this.canHandleMessage(msg)
 
     if (validMessage && hasHandler) {
-      trackSafeAppEvent({
+      trackSafeAppMessage({
         app: this.app,
         method: msg.data.method,
         params: msg.data.params,

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -10,7 +10,7 @@ import {
 } from '@gnosis.pm/safe-apps-sdk'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
 import { SafeApp } from './types'
-import { GTM_EVENT, trackSafeAppEvent } from 'src/utils/googleTagManager'
+import { trackSafeAppEvent } from 'src/utils/googleTagManager'
 
 type MessageHandler = (
   msg: SDKMessageEvent,
@@ -69,7 +69,6 @@ class AppCommunicator {
 
     if (validMessage && hasHandler) {
       trackSafeAppEvent({
-        event: GTM_EVENT.SAFE_APP,
         app: this.app,
         method: msg.data.method,
         params: msg.data.params,

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -69,9 +69,7 @@ class AppCommunicator {
         event: GTM_EVENT.SAFE_APP,
         name: this.app.name,
         method: msg.data.method,
-        params: msg.data.params
-          ? JSON.stringify(msg.data.params).replaceAll(/0x[a-fA-F0-9]{40}/g, 'ethereum-address')
-          : undefined,
+        params: msg.data.params,
         sdkVersion: msg.data.env.sdkVersion,
       })
 

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -16,7 +16,10 @@ type MessageHandler = (
   msg: SDKMessageEvent,
 ) => void | MethodToResponse[Methods] | ErrorResponse | Promise<MethodToResponse[Methods] | ErrorResponse | void>
 
-type LegacyMethods = 'getEnvInfo'
+export enum LegacyMethods {
+  getEnvInfo = 'getEnvInfo',
+}
+
 type SDKMethods = Methods | LegacyMethods
 
 class AppCommunicator {

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -70,7 +70,7 @@ class AppCommunicator {
     if (validMessage && hasHandler) {
       trackSafeAppEvent({
         event: GTM_EVENT.SAFE_APP,
-        name: this.app.name,
+        app: this.app,
         method: msg.data.method,
         params: msg.data.params,
         sdkVersion: msg.data.env.sdkVersion,

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -70,7 +70,7 @@ class AppCommunicator {
         name: this.app.name,
         method: msg.data.method,
         params: msg.data.params
-          ? JSON.parse(JSON.stringify(msg.data.params).replaceAll(/0x[a-fA-F0-9]{40}/g, 'ethereum-address'))
+          ? JSON.stringify(msg.data.params).replaceAll(/0x[a-fA-F0-9]{40}/g, 'ethereum-address')
           : undefined,
         sdkVersion: msg.data.env.sdkVersion,
       })

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -23,7 +23,7 @@ import { ConfirmTxModal } from './ConfirmTxModal'
 import { useIframeMessageHandler } from '../hooks/useIframeMessageHandler'
 import { EMPTY_SAFE_APP, getAppInfoFromUrl, getEmptySafeApp, getLegacyChainName } from '../utils'
 import { SafeApp } from '../types'
-import { useAppCommunicator } from '../communicator'
+import { LegacyMethods, useAppCommunicator } from '../communicator'
 import { fetchTokenCurrenciesBalances } from 'src/logic/safe/api/fetchTokenCurrenciesBalances'
 import { fetchSafeTransaction } from 'src/logic/safe/transactions/api/fetchSafeTransaction'
 import { logError, Errors } from 'src/logic/exceptions/CodedException'
@@ -179,7 +179,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
     /**
      * @deprecated: getEnvInfo is a legacy method. Should not be used
      */
-    communicator?.on('getEnvInfo', () => ({
+    communicator?.on(LegacyMethods.getEnvInfo, () => ({
       txServiceUrl: getTxServiceUrl(),
     }))
 

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -84,6 +84,8 @@ const INITIAL_CONFIRM_TX_MODAL_STATE: ConfirmTransactionModalState = {
 
 const URL_NOT_PROVIDED_ERROR = 'App url No provided or it is invalid.'
 const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be a problem with the App provider.'
+const TX_CONFIRM = 'txConfirm'
+const TX_REJECT = 'txReject'
 
 const AppFrame = ({ appUrl }: Props): ReactElement => {
   const { address: safeAddress, ethBalance, owners, threshold } = useSelector(currentSafe)
@@ -289,7 +291,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
     trackSafeAppEvent({
       event: GTM_EVENT.SAFE_APP,
       name: JSON.parse(safeApp.id).name,
-      method: 'txConfirm',
+      method: TX_CONFIRM,
       params: safeTxHash,
     })
   }
@@ -307,7 +309,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
     trackSafeAppEvent({
       event: GTM_EVENT.SAFE_APP,
       name: JSON.parse(safeApp.id).name,
-      method: 'txReject',
+      method: TX_REJECT,
       params: requestId,
     })
   }

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -35,7 +35,7 @@ import { useThirdPartyCookies } from '../hooks/useThirdPartyCookies'
 import { ThirdPartyCookiesWarning } from './ThirdPartyCookiesWarning'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import { SAFE_APPS_EVENTS } from 'src/utils/events/safeApps'
-import { GTM_EVENT, trackEvent, trackSafeAppEvent } from 'src/utils/googleTagManager'
+import { trackEvent } from 'src/utils/googleTagManager'
 import { checksumAddress } from 'src/utils/checksumAddress'
 
 const AppWrapper = styled.div`
@@ -85,8 +85,6 @@ const INITIAL_CONFIRM_TX_MODAL_STATE: ConfirmTransactionModalState = {
 
 const URL_NOT_PROVIDED_ERROR = 'App url No provided or it is invalid.'
 const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be a problem with the App provider.'
-const TX_CONFIRM = 'txConfirm'
-const TX_REJECT = 'txReject'
 
 const AppFrame = ({ appUrl }: Props): ReactElement => {
   const { address: safeAddress, ethBalance, owners, threshold } = useSelector(currentSafe)
@@ -294,12 +292,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
     // Safe Apps SDK V2 Handler
     communicator?.send({ safeTxHash }, requestId as string)
 
-    trackSafeAppEvent({
-      event: GTM_EVENT.SAFE_APP,
-      app: safeApp,
-      method: TX_CONFIRM,
-      params: safeTxHash,
-    })
+    trackEvent({ ...SAFE_APPS_EVENTS.TRANSACTION_CONFIRMED, label: safeApp.name })
   }
 
   const onTxReject = (requestId: RequestId) => {
@@ -312,12 +305,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
     // Safe Apps SDK V2 Handler
     communicator?.send('Transaction was rejected', requestId as string, true)
 
-    trackSafeAppEvent({
-      event: GTM_EVENT.SAFE_APP,
-      app: safeApp,
-      method: TX_REJECT,
-      params: requestId,
-    })
+    trackEvent({ ...SAFE_APPS_EVENTS.TRANSACTION_REJECTED, label: safeApp.name })
   }
 
   useEffect(() => {

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -35,7 +35,7 @@ import { useThirdPartyCookies } from '../hooks/useThirdPartyCookies'
 import { ThirdPartyCookiesWarning } from './ThirdPartyCookiesWarning'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import { SAFE_APPS_EVENTS } from 'src/utils/events/safeApps'
-import { trackEvent } from 'src/utils/googleTagManager'
+import { GTM_EVENT, trackEvent, trackSafeAppEvent } from 'src/utils/googleTagManager'
 
 const AppWrapper = styled.div`
   display: flex;
@@ -285,6 +285,13 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
 
     // Safe Apps SDK V2 Handler
     communicator?.send({ safeTxHash }, requestId as string)
+
+    trackSafeAppEvent({
+      event: GTM_EVENT.SAFE_APP,
+      name: JSON.parse(safeApp.id).name,
+      method: 'txConfirm',
+      params: safeTxHash,
+    })
   }
 
   const onTxReject = (requestId: RequestId) => {
@@ -296,6 +303,13 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
 
     // Safe Apps SDK V2 Handler
     communicator?.send('Transaction was rejected', requestId as string, true)
+
+    trackSafeAppEvent({
+      event: GTM_EVENT.SAFE_APP,
+      name: JSON.parse(safeApp.id).name,
+      method: 'txReject',
+      params: requestId,
+    })
   }
 
   useEffect(() => {

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -296,7 +296,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
 
     trackSafeAppEvent({
       event: GTM_EVENT.SAFE_APP,
-      name: JSON.parse(safeApp.id).name,
+      app: safeApp,
       method: TX_CONFIRM,
       params: safeTxHash,
     })
@@ -314,7 +314,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
 
     trackSafeAppEvent({
       event: GTM_EVENT.SAFE_APP,
-      name: JSON.parse(safeApp.id).name,
+      app: safeApp,
       method: TX_REJECT,
       params: requestId,
     })

--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -68,7 +68,7 @@ const useIframeMessageHandler = (
 
       trackSafeAppEvent({
         event: GTM_EVENT.SAFE_APP,
-        name: selectedApp?.id || '',
+        app: selectedApp,
         method: messageId,
         params: undefined,
         deprecated: true,

--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -19,6 +19,7 @@ import { TransactionParams } from '../components/AppFrame'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
 import { getLegacyChainName } from '../utils'
 import { THIRD_PARTY_COOKIES_CHECK_URL } from './useThirdPartyCookies'
+import { GTM_EVENT, trackSafeAppEvent } from 'src/utils/googleTagManager'
 
 type InterfaceMessageProps<T extends InterfaceMessageIds> = {
   messageId: T
@@ -64,6 +65,13 @@ const useIframeMessageHandler = (
       if (!messageId) {
         return
       }
+
+      trackSafeAppEvent({
+        event: GTM_EVENT.SAFE_APP,
+        name: selectedApp?.id || '',
+        method: messageId,
+        params: undefined,
+      })
 
       switch (messageId) {
         // typescript doesn't narrow type in switch/case statements

--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -19,7 +19,7 @@ import { TransactionParams } from '../components/AppFrame'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
 import { getLegacyChainName } from '../utils'
 import { THIRD_PARTY_COOKIES_CHECK_URL } from './useThirdPartyCookies'
-import { GTM_EVENT, trackSafeAppEvent } from 'src/utils/googleTagManager'
+import { trackSafeAppEvent } from 'src/utils/googleTagManager'
 
 type InterfaceMessageProps<T extends InterfaceMessageIds> = {
   messageId: T
@@ -67,11 +67,8 @@ const useIframeMessageHandler = (
       }
 
       trackSafeAppEvent({
-        event: GTM_EVENT.SAFE_APP,
         app: selectedApp,
         method: messageId,
-        params: undefined,
-        deprecated: true,
       })
 
       switch (messageId) {

--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -19,7 +19,8 @@ import { TransactionParams } from '../components/AppFrame'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
 import { getLegacyChainName } from '../utils'
 import { THIRD_PARTY_COOKIES_CHECK_URL } from './useThirdPartyCookies'
-import { trackSafeAppEvent } from 'src/utils/googleTagManager'
+import { getSafeAppName, trackEvent } from 'src/utils/googleTagManager'
+import { SAFE_APPS_EVENTS } from 'src/utils/events/safeApps'
 
 type InterfaceMessageProps<T extends InterfaceMessageIds> = {
   messageId: T
@@ -66,10 +67,7 @@ const useIframeMessageHandler = (
         return
       }
 
-      trackSafeAppEvent({
-        app: selectedApp,
-        method: messageId,
-      })
+      trackEvent({ ...SAFE_APPS_EVENTS.LEGACY_API_CALL, label: `${getSafeAppName(selectedApp)}-${messageId}` })
 
       switch (messageId) {
         // typescript doesn't narrow type in switch/case statements

--- a/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
+++ b/src/routes/safe/components/Apps/hooks/useIframeMessageHandler.ts
@@ -71,6 +71,7 @@ const useIframeMessageHandler = (
         name: selectedApp?.id || '',
         method: messageId,
         params: undefined,
+        deprecated: true,
       })
 
       switch (messageId) {

--- a/src/utils/events/safeApps.ts
+++ b/src/utils/events/safeApps.ts
@@ -32,7 +32,7 @@ const SAFE_APPS = {
   },
   LEGACY_API_CALL: {
     event: GTM_EVENT.META,
-    action: 'Legacy Api call',
+    action: 'Legacy API call',
   },
 }
 

--- a/src/utils/events/safeApps.ts
+++ b/src/utils/events/safeApps.ts
@@ -22,6 +22,14 @@ const SAFE_APPS = {
     event: GTM_EVENT.META,
     action: 'Add custom Safe App',
   },
+  TRANSACTION_CONFIRMED: {
+    event: GTM_EVENT.META,
+    action: 'Transaction Confirmed',
+  },
+  TRANSACTION_REJECTED: {
+    event: GTM_EVENT.META,
+    action: 'Transaction Rejected',
+  },
 }
 
 const SAFE_APPS_CATEGORY = 'safe-apps'

--- a/src/utils/events/safeApps.ts
+++ b/src/utils/events/safeApps.ts
@@ -30,6 +30,10 @@ const SAFE_APPS = {
     event: GTM_EVENT.META,
     action: 'Transaction Rejected',
   },
+  LEGACY_API_CALL: {
+    event: GTM_EVENT.META,
+    action: 'Legacy Api call',
+  },
 }
 
 const SAFE_APPS_CATEGORY = 'safe-apps'

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -194,7 +194,7 @@ export const getSafeAppName = (safeApp?: SafeApp): string => {
   try {
     const parsedSafeApp = JSON.parse(safeApp.id)
 
-    return parsedSafeApp.name || parsedSafeApp.url || parsedSafeApp
+    return parsedSafeApp.name || parsedSafeApp.url
   } catch (error) {
     return EMPTY_SAFE_APP
   }

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -179,14 +179,12 @@ export const trackSafeAppEvent = ({
   method,
   params,
   sdkVersion,
-  oui,
 }: {
   event: GTM_EVENT
   name: string
   method: string
   params: any
   sdkVersion: string
-  oui?: number
 }): void => {
   const dataLayer = {
     event,
@@ -195,7 +193,6 @@ export const trackSafeAppEvent = ({
     safeAppMethod: method,
     safeAppParams: params,
     safeAppSDKVersion: sdkVersion,
-    oui,
   }
 
   if (!IS_PRODUCTION) {

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -186,12 +186,16 @@ export const trackSafeAppEvent = ({
   params: any
   sdkVersion: string
 }): void => {
+  const DEPRECATED_METHODS = ['getEnvInfo']
+
   const dataLayer = {
     event,
     chainId: _getChainId(),
     safeAppName: name,
     safeAppMethod: method,
-    safeAppParams: params,
+    safeAppParams: params ? JSON.stringify(params).replaceAll(/0x[a-fA-F0-9]{40}/g, 'ethereum-address') : undefined,
+    safeAppEthMethod: params?.call || undefined,
+    safeAppDeprecatedMethod: DEPRECATED_METHODS.includes(method),
     safeAppSDKVersion: sdkVersion,
   }
 

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -151,7 +151,7 @@ type EventDataLayer = {
   chainId: string
   eventCategory: string
   eventAction: string
-  eventLabel: EventLabel | undefined
+  eventLabel?: EventLabel
 }
 
 export const trackEvent = ({
@@ -184,10 +184,10 @@ type SafeAppEventDataLayer = {
   chainId: string
   safeAppName: string
   safeAppMethod: string
-  safeAppParams: string | undefined
-  safeAppEthMethod: string | undefined
+  safeAppParams?: string
+  safeAppEthMethod?: string
   safeAppDeprecatedMethod: boolean
-  safeAppSDKVersion: string
+  safeAppSDKVersion?: string
 }
 
 export const trackSafeAppEvent = ({
@@ -201,7 +201,7 @@ export const trackSafeAppEvent = ({
   name: string
   method: string
   params: any
-  sdkVersion: string
+  sdkVersion?: string
 }): void => {
   const dataLayer: SafeAppEventDataLayer = {
     event,

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -196,12 +196,14 @@ export const trackSafeAppEvent = ({
   method,
   params,
   sdkVersion,
+  deprecated = false,
 }: {
   event: GTM_EVENT
   name: string
   method: string
   params: any
   sdkVersion?: string
+  deprecated?: boolean
 }): void => {
   const dataLayer: SafeAppEventDataLayer = {
     event,
@@ -210,7 +212,7 @@ export const trackSafeAppEvent = ({
     safeAppMethod: method,
     safeAppParams: params ? JSON.stringify(params).replaceAll(ETHEREUM_ADDRESS_REGEX, ETHEREUM_ADDRESS) : undefined,
     safeAppEthMethod: params?.call || undefined,
-    safeAppDeprecatedMethod: Object.values<string>(LegacyMethods).includes(method),
+    safeAppDeprecatedMethod: deprecated || Object.values<string>(LegacyMethods).includes(method),
     safeAppSDKVersion: sdkVersion,
   }
 

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -16,6 +16,7 @@ import { _getChainId } from 'src/config'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { Cookie, removeCookies } from 'src/logic/cookies/utils'
 import { LegacyMethods } from 'src/routes/safe/components/Apps/communicator'
+import { SafeApp } from 'src/routes/safe/components/Apps/types'
 
 export const getAnonymizedLocation = ({ pathname, search, hash }: Location = history.location): string => {
   const ANON_SAFE_ADDRESS = 'SAFE_ADDRESS'
@@ -192,23 +193,25 @@ type SafeAppEventDataLayer = {
 
 export const trackSafeAppEvent = ({
   event,
-  name,
+  app,
   method,
   params,
   sdkVersion,
   deprecated = false,
 }: {
   event: GTM_EVENT
-  name: string
+  app?: SafeApp
   method: string
   params: any
   sdkVersion?: string
   deprecated?: boolean
 }): void => {
+  const safeApp = JSON.parse(app?.id || 'unknown')
+
   const dataLayer: SafeAppEventDataLayer = {
     event,
     chainId: _getChainId(),
-    safeAppName: name,
+    safeAppName: safeApp.name || safeApp.url || safeApp,
     safeAppMethod: method,
     safeAppParams: params ? JSON.stringify(params).replaceAll(ETHEREUM_ADDRESS_REGEX, ETHEREUM_ADDRESS) : undefined,
     safeAppEthMethod: params?.call || undefined,

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -16,6 +16,7 @@ import { _getChainId } from 'src/config'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { Cookie, removeCookies } from 'src/logic/cookies/utils'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
+import { EMPTY_SAFE_APP } from 'src/routes/safe/components/Apps/utils'
 
 export const getAnonymizedLocation = ({ pathname, search, hash }: Location = history.location): string => {
   const ANON_SAFE_ADDRESS = 'SAFE_ADDRESS'
@@ -177,7 +178,7 @@ export const trackEvent = ({
 }
 
 type SafeAppEventDataLayer = {
-  event: GTM_EVENT
+  event: GTM_EVENT.SAFE_APP
   chainId: string
   safeAppName: string
   safeAppMethod: string
@@ -186,9 +187,17 @@ type SafeAppEventDataLayer = {
 }
 
 export const getSafeAppName = (safeApp?: SafeApp): string => {
-  const parsedSafeApp = JSON.parse(safeApp?.id || 'Unknown Safe App')
+  if (!safeApp?.id) {
+    return EMPTY_SAFE_APP
+  }
 
-  return parsedSafeApp.name || parsedSafeApp.url || parsedSafeApp
+  try {
+    const parsedSafeApp = JSON.parse(safeApp.id)
+
+    return parsedSafeApp.name || parsedSafeApp.url || parsedSafeApp
+  } catch (error) {
+    return EMPTY_SAFE_APP
+  }
 }
 
 export const trackSafeAppMessage = ({
@@ -207,7 +216,7 @@ export const trackSafeAppMessage = ({
     chainId: _getChainId(),
     safeAppName: getSafeAppName(app),
     safeAppMethod: method,
-    safeAppEthMethod: params?.call || undefined,
+    safeAppEthMethod: params?.call,
     safeAppSDKVersion: sdkVersion,
   }
 

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -186,7 +186,13 @@ type SafeAppEventDataLayer = {
   safeAppSDKVersion?: string
 }
 
-export const trackSafeAppEvent = ({
+export const getSafeAppName = (safeApp?: SafeApp): string => {
+  const parsedSafeApp = JSON.parse(safeApp?.id || 'Unknown Safe App')
+
+  return parsedSafeApp.name || parsedSafeApp.url || parsedSafeApp
+}
+
+export const trackSafeAppMessage = ({
   app,
   method,
   params,
@@ -197,12 +203,10 @@ export const trackSafeAppEvent = ({
   params?: any
   sdkVersion?: string
 }): void => {
-  const safeApp = JSON.parse(app?.id || 'Unknown Safe App')
-
   const dataLayer: SafeAppEventDataLayer = {
     event: GTM_EVENT.SAFE_APP,
     chainId: _getChainId(),
-    safeAppName: safeApp.name || safeApp.url || safeApp,
+    safeAppName: getSafeAppName(app),
     safeAppMethod: method,
     safeAppEthMethod: params?.call || undefined,
     safeAppSDKVersion: sdkVersion,

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -15,7 +15,6 @@ import {
 import { _getChainId } from 'src/config'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { Cookie, removeCookies } from 'src/logic/cookies/utils'
-import { LegacyMethods } from 'src/routes/safe/components/Apps/communicator'
 import { SafeApp } from 'src/routes/safe/components/Apps/types'
 
 export const getAnonymizedLocation = ({ pathname, search, hash }: Location = history.location): string => {
@@ -177,9 +176,6 @@ export const trackEvent = ({
   track(dataLayer)
 }
 
-const ETHEREUM_ADDRESS_REGEX = /0x[a-fA-F0-9]{40}/g
-const ETHEREUM_ADDRESS = 'ETHEREUM_ADDRESS'
-
 type SafeAppEventDataLayer = {
   event: GTM_EVENT
   chainId: string
@@ -187,35 +183,28 @@ type SafeAppEventDataLayer = {
   safeAppMethod: string
   safeAppParams?: string
   safeAppEthMethod?: string
-  safeAppDeprecatedMethod: boolean
   safeAppSDKVersion?: string
 }
 
 export const trackSafeAppEvent = ({
-  event,
   app,
   method,
   params,
   sdkVersion,
-  deprecated = false,
 }: {
-  event: GTM_EVENT
   app?: SafeApp
   method: string
-  params: any
+  params?: any
   sdkVersion?: string
-  deprecated?: boolean
 }): void => {
-  const safeApp = JSON.parse(app?.id || 'unknown')
+  const safeApp = JSON.parse(app?.id || 'Unknown Safe App')
 
   const dataLayer: SafeAppEventDataLayer = {
-    event,
+    event: GTM_EVENT.SAFE_APP,
     chainId: _getChainId(),
     safeAppName: safeApp.name || safeApp.url || safeApp,
     safeAppMethod: method,
-    safeAppParams: params ? JSON.stringify(params).replaceAll(ETHEREUM_ADDRESS_REGEX, ETHEREUM_ADDRESS) : undefined,
     safeAppEthMethod: params?.call || undefined,
-    safeAppDeprecatedMethod: deprecated || Object.values<string>(LegacyMethods).includes(method),
     safeAppSDKVersion: sdkVersion,
   }
 

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -59,6 +59,7 @@ export enum GTM_EVENT {
   PAGEVIEW = 'pageview',
   CLICK = 'customClick',
   META = 'metadata',
+  SAFE_APP = 'safeApp',
 }
 
 let currentPathname = history.location.pathname
@@ -161,6 +162,40 @@ export const trackEvent = ({
     eventCategory: category,
     eventAction: action,
     eventLabel: tryParse(label),
+  }
+
+  if (!IS_PRODUCTION) {
+    console.info('[GTM]', dataLayer)
+  }
+
+  TagManager.dataLayer({
+    dataLayer,
+  })
+}
+
+export const trackSafeAppEvent = ({
+  event,
+  name,
+  method,
+  params,
+  sdkVersion,
+  oui,
+}: {
+  event: GTM_EVENT
+  name: string
+  method: string
+  params: any
+  sdkVersion: string
+  oui?: number
+}): void => {
+  const dataLayer = {
+    event,
+    chainId: _getChainId(),
+    safeAppName: name,
+    safeAppMethod: method,
+    safeAppParams: params,
+    safeAppSDKVersion: sdkVersion,
+    oui,
   }
 
   if (!IS_PRODUCTION) {

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -181,7 +181,6 @@ type SafeAppEventDataLayer = {
   chainId: string
   safeAppName: string
   safeAppMethod: string
-  safeAppParams?: string
   safeAppEthMethod?: string
   safeAppSDKVersion?: string
 }


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-apps-sdk/issues/309

## How this PR fixes it
We are adding to the current GTM container:

- 4 new variables

<img width="692" alt="image" src="https://user-images.githubusercontent.com/1576776/161509760-d7e34c86-f6fd-4b0d-870c-9c7f17dffac5.png">

- 1 trigger
 
<img width="776" alt="image" src="https://user-images.githubusercontent.com/1576776/161509865-b86e4c5e-1b8e-49fb-8522-f3811d7fad7c.png">

- 1 Safe App Tag bounded to a GA4 event

<img width="682" alt="image" src="https://user-images.githubusercontent.com/1576776/161509977-8aa95b50-60cf-444d-a41f-76449029848c.png">

- 1 Safe App tag specifying the Measurement ID for the Safe App property

<img width="674" alt="image" src="https://user-images.githubusercontent.com/1576776/161510199-72e9af14-3008-48e3-ab03-bb451aff0822.png">


## How to test it

## Analytics changes

## Screenshots
