### PR TITLE
chore: add cypress env commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,13 @@
     "sentry-upload-sourcemaps": "sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases -o $SENTRY_ORG -p $SENTRY_PROJECT files $npm_package_version upload-sourcemaps ./build/static/js/",
     "prepare": "husky install",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:open:dev": "cypress open --config baseUrl=https://safe-team.dev.gnosisdev.com/app",
+    "cypress:open:staging": "cypress open --config baseUrl=https://safe-team.staging.gnosisdev.com/app",
+    "cypress:open:prod": "cypress open --config baseUrl=https://gnosis-safe.io/app",
+    "cypress:run": "cypress run",
+    "cypress:run:dev": "cypress run --config baseUrl=https://safe-team.dev.gnosisdev.com/app",
+    "cypress:run:staging": "cypress run --config baseUrl=https://safe-team.staging.gnosisdev.com/app",
+    "cypress:run:prod": "cypress run --config baseUrl=https://gnosis-safe.io/app"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -40,14 +40,8 @@
     "update-mocks": "./scripts/update-mocks.sh",
     "sentry-upload-sourcemaps": "sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases -o $SENTRY_ORG -p $SENTRY_PROJECT files $npm_package_version upload-sourcemaps ./build/static/js/",
     "prepare": "husky install",
-    "cypress:open": "cypress open",
-    "cypress:open:dev": "cypress open --config baseUrl=https://safe-team.dev.gnosisdev.com/app",
-    "cypress:open:staging": "cypress open --config baseUrl=https://safe-team.staging.gnosisdev.com/app",
-    "cypress:open:prod": "cypress open --config baseUrl=https://gnosis-safe.io/app",
-    "cypress:run": "cypress run",
-    "cypress:run:dev": "cypress run --config baseUrl=https://safe-team.dev.gnosisdev.com/app",
-    "cypress:run:staging": "cypress run --config baseUrl=https://safe-team.staging.gnosisdev.com/app",
-    "cypress:run:prod": "cypress run --config baseUrl=https://gnosis-safe.io/app"
+    "cypress:open": "node ./scripts/cypress.js open",
+    "cypress:run": "node ./scripts/cypress.js run"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -1,0 +1,36 @@
+const rl = require('readline')
+const { exec } = require('child_process')
+
+const DEPLOYMENTS = {
+  d: 'https://safe-team.dev.gnosisdev.com/app',
+  s: 'https://safe-team.staging.gnosisdev.com/app',
+  p: 'https://gnosis-safe.io/app',
+}
+
+const readline = rl.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+})
+
+const cmd = `cypress ${process.argv[2]}`
+
+function launchCypressEnv() {
+  readline.question(
+    'Which environment do you want to test: (l)ocal, (d)evelopment, (s)taging or (p)roduction? ',
+    (env) => {
+      const key = env?.[0].toLowerCase()
+
+      if (!key || key === 'l') {
+        exec(cmd)
+      } else if (Object.keys(DEPLOYMENTS).includes(key)) {
+        exec(`${cmd} --config baseUrl=${DEPLOYMENTS[key]}`)
+      } else {
+        console.log(`\nInvalid environment.`)
+      }
+
+      readline.close()
+    },
+  )
+}
+
+launchCypressEnv()

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -18,9 +18,9 @@ function launchCypressEnv() {
   readline.question(
     'Which environment do you want to test: (l)ocal, (d)evelopment, (s)taging or (p)roduction? ',
     (env) => {
-      const key = env?.[0].toLowerCase()
+      const key = env?.[0].toLowerCase() || 'l'
 
-      if (!key || key === 'l') {
+      if (key === 'l') {
         exec(cmd)
       } else if (Object.keys(DEPLOYMENTS).includes(key)) {
         exec(`${cmd} --config baseUrl=${DEPLOYMENTS[key]}`)

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -1,36 +1,12 @@
-const rl = require('readline')
 const { exec } = require('child_process')
 
 const DEPLOYMENTS = {
-  d: 'https://safe-team.dev.gnosisdev.com/app',
-  s: 'https://safe-team.staging.gnosisdev.com/app',
-  p: 'https://gnosis-safe.io/app',
+  dev: 'https://safe-team.dev.gnosisdev.com/app',
+  staging: 'https://safe-team.staging.gnosisdev.com/app',
+  prod: 'https://gnosis-safe.io/app',
 }
 
-const readline = rl.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-})
+const command = `cypress ${process.argv[2]}`
+const env = process.argv?.[3]
 
-const cmd = `cypress ${process.argv[2]}`
-
-function launchCypressEnv() {
-  readline.question(
-    'Which environment do you want to test: (l)ocal, (d)evelopment, (s)taging or (p)roduction? ',
-    ([env = 'l']) => {
-      const key = env.toLowerCase()
-
-      if (key === 'l') {
-        exec(cmd)
-      } else if (Object.keys(DEPLOYMENTS).includes(key)) {
-        exec(`${cmd} --config baseUrl=${DEPLOYMENTS[key]}`)
-      } else {
-        console.log(`\nInvalid environment.`)
-      }
-
-      readline.close()
-    },
-  )
-}
-
-launchCypressEnv()
+exec(env ? `${command} --config baseUrl=${DEPLOYMENTS[env]}` : command)

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -17,8 +17,8 @@ const cmd = `cypress ${process.argv[2]}`
 function launchCypressEnv() {
   readline.question(
     'Which environment do you want to test: (l)ocal, (d)evelopment, (s)taging or (p)roduction? ',
-    (env) => {
-      const key = env?.[0].toLowerCase() || 'l'
+    ([env = 'l']) => {
+      const key = env.toLowerCase()
 
       if (key === 'l') {
         exec(cmd)


### PR DESCRIPTION
## What it solves
Deployment-specific Cypress commands

## How this PR fixes it
A script with optional environment argument (`dev`, `staging` or `prod`) allows for a dynamic Cypress `baseUrl`.

## How to test it
Try running:

`yarn cypress:open`
`yarn cypress:open dev`
`yarn cypress:open staging`
`yarn cypress:open prod`

`yarn cypress:run`
`yarn cypress:run dev`
`yarn cypress:run staging`
`yarn cypress:run prod`

and observe Cypress open with varying `baseUrl`s.