### PR TITLE
feat: Add Safe route for dashboard

### DIFF
--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -97,7 +97,7 @@ const SafeListItem = ({
   const handleOpenSafe = (): void => {
     onSafeClick()
     onNetworkSwitch?.()
-    history.push(generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, routesSlug))
+    history.push(generateSafeRoute(SAFE_ROUTES.DASHBOARD, routesSlug))
   }
 
   const handleLoadSafe = (): void => {

--- a/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
+++ b/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
@@ -274,7 +274,7 @@ function SafeCreationProcess(): ReactElement {
 
     const { safeName, safeCreationTxHash, safeAddress } = modalData
     history.push({
-      pathname: generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, {
+      pathname: generateSafeRoute(SAFE_ROUTES.DASHBOARD, {
         shortName: getShortName(),
         safeAddress,
       }),

--- a/src/routes/LoadSafePage/LoadSafePage.test.tsx
+++ b/src/routes/LoadSafePage/LoadSafePage.test.tsx
@@ -614,7 +614,7 @@ describe('<LoadSafePage>', () => {
 
       await waitFor(() => {
         expect(historyPushSpy).toHaveBeenCalledWith(
-          generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, {
+          generateSafeRoute(SAFE_ROUTES.DASHBOARD, {
             shortName: getShortName(),
             safeAddress: validSafeAddress,
           }),

--- a/src/routes/LoadSafePage/LoadSafePage.tsx
+++ b/src/routes/LoadSafePage/LoadSafePage.tsx
@@ -120,7 +120,7 @@ function Load(): ReactElement {
 
     // Go to the newly added Safe
     history.push(
-      generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, {
+      generateSafeRoute(SAFE_ROUTES.DASHBOARD, {
         shortName: getShortName(),
         safeAddress: checksummedAddress,
       }),

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,6 +15,7 @@ import {
   getNetworkRootRoutes,
   extractSafeAddress,
   HOME_ROUTE,
+  SAFE_ROUTES,
 } from './routes'
 import { setChainId } from 'src/logic/config/utils'
 import { setChainIdFromUrl } from 'src/utils/history'
@@ -88,7 +89,7 @@ const Routes = (): React.ReactElement => {
         }}
       />
 
-      <Route component={Home} exact path={HOME_ROUTE} />
+      <Route component={Home} exact path={[HOME_ROUTE, SAFE_ROUTES.DASHBOARD]} />
 
       <Route component={Welcome} exact path={WELCOME_ROUTE} />
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,12 +14,13 @@ import {
   LOAD_SAFE_ROUTE,
   getNetworkRootRoutes,
   extractSafeAddress,
-  HOME_ROUTE,
   SAFE_ROUTES,
+  generateSafeRoute,
 } from './routes'
 import { setChainId } from 'src/logic/config/utils'
 import { setChainIdFromUrl } from 'src/utils/history'
 import { usePageTracking } from 'src/utils/googleTagManager'
+import { getShortName } from 'src/config'
 
 const Home = React.lazy(() => import('./Home'))
 const Welcome = React.lazy(() => import('./welcome/Welcome'))
@@ -82,14 +83,21 @@ const Routes = (): React.ReactElement => {
           }
 
           if (defaultSafe) {
-            return <Redirect to={HOME_ROUTE} />
+            return (
+              <Redirect
+                to={generateSafeRoute(SAFE_ROUTES.DASHBOARD, {
+                  shortName: getShortName(),
+                  safeAddress: defaultSafe,
+                })}
+              />
+            )
           }
 
           return <Redirect to={WELCOME_ROUTE} />
         }}
       />
 
-      <Route component={Home} exact path={[HOME_ROUTE, SAFE_ROUTES.DASHBOARD]} />
+      <Route component={Home} exact path={SAFE_ROUTES.DASHBOARD} />
 
       <Route component={Welcome} exact path={WELCOME_ROUTE} />
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -22,7 +22,6 @@ import { setChainIdFromUrl } from 'src/utils/history'
 import { usePageTracking } from 'src/utils/googleTagManager'
 import { getShortName } from 'src/config'
 
-const Home = React.lazy(() => import('./Home'))
 const Welcome = React.lazy(() => import('./welcome/Welcome'))
 const CreateSafePage = React.lazy(() => import('./CreateSafePage/CreateSafePage'))
 const LoadSafePage = React.lazy(() => import('./LoadSafePage/LoadSafePage'))
@@ -96,8 +95,6 @@ const Routes = (): React.ReactElement => {
           return <Redirect to={WELCOME_ROUTE} />
         }}
       />
-
-      <Route component={Home} exact path={SAFE_ROUTES.DASHBOARD} />
 
       <Route component={Welcome} exact path={WELCOME_ROUTE} />
 

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -41,7 +41,6 @@ export const LOAD_SPECIFIC_SAFE_ROUTE = `/load/:${SAFE_ADDRESS_SLUG}?` // ? = op
 
 // Routes independant of safe/network
 export const ROOT_ROUTE = '/'
-export const HOME_ROUTE = '/home'
 export const WELCOME_ROUTE = '/welcome'
 export const OPEN_SAFE_ROUTE = '/open'
 export const LOAD_SAFE_ROUTE = generatePath(LOAD_SPECIFIC_SAFE_ROUTE) // By providing no slug, we get '/load'

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -48,6 +48,7 @@ export const LOAD_SAFE_ROUTE = generatePath(LOAD_SPECIFIC_SAFE_ROUTE) // By prov
 
 // [SAFE_SECTION_SLUG], [SAFE_SUBSECTION_SLUG] populated safe routes
 export const SAFE_ROUTES = {
+  DASHBOARD: `${ADDRESSED_ROUTE}/home`,
   ASSETS_BALANCES: `${ADDRESSED_ROUTE}/balances`, // [SAFE_SECTION_SLUG] === 'balances'
   ASSETS_BALANCES_COLLECTIBLES: `${ADDRESSED_ROUTE}/balances/collectibles`, // [SAFE_SUBSECTION_SLUG] === 'collectibles'
   TRANSACTIONS: `${ADDRESSED_ROUTE}/transactions`,

--- a/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/RemoveSafeModal/index.tsx
@@ -43,7 +43,7 @@ function getDestinationRoute(nextAvailableSafe: SafeRecordProps | undefined) {
     shortName,
     safeAddress: nextAvailableSafe.address,
   }
-  return generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, routesSlug)
+  return generateSafeRoute(SAFE_ROUTES.DASHBOARD, routesSlug)
 }
 
 const RemoveSafeModal = ({ isOpen, onClose }: RemoveSafeModalProps): React.ReactElement => {

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -1,5 +1,5 @@
 import { GenericModal, Loader } from '@gnosis.pm/safe-react-components'
-import { useState, lazy, useEffect } from 'react'
+import React, { useState, lazy, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { Redirect, Route, Switch } from 'react-router-dom'
 
@@ -21,6 +21,7 @@ export const ADDRESS_BOOK_TAB_BTN_TEST_ID = 'address-book-tab-btn'
 export const SAFE_VIEW_NAME_HEADING_TEST_ID = 'safe-name-heading'
 export const TRANSACTIONS_TAB_NEW_BTN_TEST_ID = 'transactions-tab-new-btn'
 
+const Home = React.lazy(() => import('src/routes/Home'))
 const Apps = lazy(() => import('src/routes/safe/components/Apps'))
 const Settings = lazy(() => import('src/routes/safe/components/Settings'))
 const Balances = lazy(() => import('src/routes/safe/components/Balances'))
@@ -87,6 +88,7 @@ const Container = (): React.ReactElement => {
   return (
     <>
       <Switch>
+        <Route exact path={SAFE_ROUTES.DASHBOARD} render={() => wrapInSuspense(<Home />, null)} />
         <Route
           exact
           path={[SAFE_ROUTES.ASSETS_BALANCES, SAFE_ROUTES.ASSETS_BALANCES_COLLECTIBLES]}

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -1,5 +1,5 @@
 import { GenericModal, Loader } from '@gnosis.pm/safe-react-components'
-import React, { useState, lazy, useEffect } from 'react'
+import { useState, lazy, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { Redirect, Route, Switch } from 'react-router-dom'
 
@@ -21,7 +21,7 @@ export const ADDRESS_BOOK_TAB_BTN_TEST_ID = 'address-book-tab-btn'
 export const SAFE_VIEW_NAME_HEADING_TEST_ID = 'safe-name-heading'
 export const TRANSACTIONS_TAB_NEW_BTN_TEST_ID = 'transactions-tab-new-btn'
 
-const Home = React.lazy(() => import('src/routes/Home'))
+const Home = lazy(() => import('src/routes/Home'))
 const Apps = lazy(() => import('src/routes/safe/components/Apps'))
 const Settings = lazy(() => import('src/routes/safe/components/Settings'))
 const Balances = lazy(() => import('src/routes/safe/components/Balances'))
@@ -88,11 +88,11 @@ const Container = (): React.ReactElement => {
   return (
     <>
       <Switch>
-        <Route exact path={SAFE_ROUTES.DASHBOARD} render={() => wrapInSuspense(<Home />, null)} />
+        <Route exact path={SAFE_ROUTES.DASHBOARD} render={() => wrapInSuspense(<Home />)} />
         <Route
           exact
           path={[SAFE_ROUTES.ASSETS_BALANCES, SAFE_ROUTES.ASSETS_BALANCES_COLLECTIBLES]}
-          render={() => wrapInSuspense(<Balances />, null)}
+          render={() => wrapInSuspense(<Balances />)}
         />
         <Route
           exact
@@ -102,9 +102,9 @@ const Container = (): React.ReactElement => {
             SAFE_ROUTES.TRANSACTIONS_QUEUE,
             SAFE_ROUTES.TRANSACTIONS_SINGULAR,
           ]}
-          render={() => wrapInSuspense(<TxList />, null)}
+          render={() => wrapInSuspense(<TxList />)}
         />
-        <Route exact path={SAFE_ROUTES.ADDRESS_BOOK} render={() => wrapInSuspense(<AddressBookTable />, null)} />
+        <Route exact path={SAFE_ROUTES.ADDRESS_BOOK} render={() => wrapInSuspense(<AddressBookTable />)} />
         <Route
           exact
           path={SAFE_ROUTES.APPS}
@@ -112,10 +112,10 @@ const Container = (): React.ReactElement => {
             if (!featuresEnabled.includes(FEATURES.SAFE_APPS)) {
               history.push(generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, extractPrefixedSafeAddress()))
             }
-            return wrapInSuspense(<Apps />, null)
+            return wrapInSuspense(<Apps />)
           }}
         />
-        <Route path={SAFE_ROUTES.SETTINGS} render={() => wrapInSuspense(<Settings />, null)} />
+        <Route path={SAFE_ROUTES.SETTINGS} render={() => wrapInSuspense(<Settings />)} />
         <Redirect to={SAFE_ROUTES.ASSETS_BALANCES} />
       </Switch>
       {modal.isOpen && <GenericModal {...modal} onClose={closeGenericModal} />}


### PR DESCRIPTION
## What it solves
Part of #3693 

## How this PR fixes it
Changes the Safe dashboard route from `/app/home` to `/app/<safe address>/home` and loads the Dashboard component inside `SafeContainer` so that it has access to transaction data.

Navigates the user to the Dashboard if:

1. A safe is selected from the Sidebar
2. A safe is created
3. A safe is loaded
4. A safe is removed and there is an available safe
5. `ROOT` is opened if last viewed Safe exists

## How to test it
1. Open the Safe App
6. Select a Safe from the Sidebar
7. Observe that the Dashboard is visible
8. Create a new Safe
9. Observe being navigated to the Dashboard
10. Load an existing Safe
8. Observe being navigated to the Dashboard
9. Remove a safe while having another safe on the same network
8. Observe being navigated to the Dashboard
9. Open `/` while having a last viewed Safe
10. Observe being navigated to the Dashboard
11. Open `/` while in Inkognito mode
12. Observe being navigated to Welcome page