### PR TITLE
Fix: rename Collectibles to NFTs

### DIFF
--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -61,7 +61,7 @@ const useSidebarItems = (): ListItemType[] => {
       }),
       makeEntryItem({
         disabled: !isCollectiblesEnabled,
-        label: 'Collectibles',
+        label: 'NFTs',
         iconType: 'collectibles',
         href: currentSafeRoutes.ASSETS_BALANCES_COLLECTIBLES,
       }),

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -47,8 +47,9 @@ export const LOAD_SAFE_ROUTE = generatePath(LOAD_SPECIFIC_SAFE_ROUTE) // By prov
 
 // [SAFE_SECTION_SLUG], [SAFE_SUBSECTION_SLUG] populated safe routes
 export const SAFE_ROUTES = {
-  ASSETS_BALANCES: `${ADDRESSED_ROUTE}/balances`, // [SAFE_SECTION_SLUG] === 'balances'
-  ASSETS_BALANCES_COLLECTIBLES: `${ADDRESSED_ROUTE}/balances/collectibles`, // [SAFE_SUBSECTION_SLUG] === 'collectibles'
+  ASSETS_BALANCES: `${ADDRESSED_ROUTE}/balances`,
+  ASSETS_BALANCES_COLLECTIBLES: `${ADDRESSED_ROUTE}/balances/nfts`,
+  LEGACY_COLLECTIBLES: `${ADDRESSED_ROUTE}/balances/collectibles`,
   TRANSACTIONS: `${ADDRESSED_ROUTE}/transactions`,
   TRANSACTIONS_HISTORY: `${ADDRESSED_ROUTE}/transactions/history`,
   TRANSACTIONS_QUEUE: `${ADDRESSED_ROUTE}/transactions/queue`,

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -106,9 +106,7 @@ const Collectibles = (): React.ReactElement => {
     return (
       <Card className={classes.cardOuter}>
         <div className={classes.cardInner}>
-          <Paragraph className={classes.noData}>
-            {nftLoaded ? 'No collectibles available' : 'Loading collectibles...'}
-          </Paragraph>
+          <Paragraph className={classes.noData}>{nftLoaded ? 'No NFTs available' : 'Loading NFTs...'}</Paragraph>
         </div>
       </Card>
     )

--- a/src/routes/safe/components/Balances/SendModal/screens/ChooseTxType/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ChooseTxType/index.tsx
@@ -115,12 +115,8 @@ const ChooseTxType = ({
                 variant="contained"
                 testId="modal-send-collectible-btn"
               >
-                <Img
-                  alt="Send collectible"
-                  className={classNames(classes.leftIcon, classes.iconSmall)}
-                  src={Collectible}
-                />
-                Send collectible
+                <Img alt="Send NFT" className={classNames(classes.leftIcon, classes.iconSmall)} src={Collectible} />
+                Send NFT
               </Button>
             </Track>
           )}

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewCollectible/index.tsx
@@ -102,7 +102,7 @@ const ReviewCollectible = ({ onClose, onPrev, tx }: Props): React.ReactElement =
 
   return (
     <TxModalWrapper txData={txData} txTo={tx.assetAddress} onSubmit={submitTx} onBack={onPrev}>
-      <ModalHeader onClose={onClose} subTitle={getStepTitle(2, 2)} title="Send collectible" />
+      <ModalHeader onClose={onClose} subTitle={getStepTitle(2, 2)} title="Send NFT" />
       <Hairline />
       <Block className={classes.container}>
         <SafeInfo text="Sending from" />

--- a/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendCollectible/index.tsx
@@ -116,7 +116,7 @@ const SendCollectible = ({
 
   return (
     <>
-      <ModalHeader onClose={onClose} subTitle={getStepTitle(1, 2)} title="Send collectible" />
+      <ModalHeader onClose={onClose} subTitle={getStepTitle(1, 2)} title="Send NFT" />
       <Hairline />
       <GnoForm formMutators={formMutators} initialValues={initialValues} onSubmit={handleSubmit}>
         {(...args) => {

--- a/src/routes/safe/components/Balances/index.tsx
+++ b/src/routes/safe/components/Balances/index.tsx
@@ -22,7 +22,7 @@ export const BALANCE_ROW_TEST_ID = 'balance-row'
 
 enum SECTION_NAME {
   coins = 'Coins',
-  collectibles = 'Collectibles',
+  collectibles = 'NFTs',
 }
 
 const Balances = (): ReactElement => {

--- a/src/routes/safe/container/index.tsx
+++ b/src/routes/safe/container/index.tsx
@@ -89,6 +89,15 @@ const Container = (): React.ReactElement => {
   return (
     <>
       <Switch>
+        {/* Legacy redirect */}
+        <Route
+          path={SAFE_ROUTES.LEGACY_COLLECTIBLES}
+          exact
+          render={() => (
+            <Redirect to={generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES_COLLECTIBLES, extractPrefixedSafeAddress())} />
+          )}
+        />
+
         <Route
           exact
           path={[SAFE_ROUTES.ASSETS_BALANCES, SAFE_ROUTES.ASSETS_BALANCES_COLLECTIBLES]}


### PR DESCRIPTION
## What it solves
Partially tackles #3329

## How this PR fixes it
Adjusted the copy in the UI from "Collectibles" to "NFTs".

## How to test it
Test that the old URL redirects to the new /nft URL.

## Screenshots

<img width="757" alt="Screenshot 2022-04-07 at 10 58 13" src="https://user-images.githubusercontent.com/381895/162161853-ab31478c-82a9-4251-b788-12cbe3333343.png">

<img width="560" alt="Screenshot 2022-04-07 at 10 58 42" src="https://user-images.githubusercontent.com/381895/162162007-5d3a0eee-d8b5-435f-bc68-2d183759db9e.png">

<img width="572" alt="Screenshot 2022-04-07 at 10 58 46" src="https://user-images.githubusercontent.com/381895/162162057-04454621-143d-43dd-a27e-3f746470e92a.png">

