### PR TITLE
Feat: toggle sidebar on mobile

### DIFF
--- a/src/components/AppLayout/Header/components/WalletIcon/index.tsx
+++ b/src/components/AppLayout/Header/components/WalletIcon/index.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import Col from 'src/components/layout/Col'
 import Img from 'src/components/layout/Img'
 import WALLET_ICONS from './icons'
+import { screenSm } from 'src/theme/variables'
 
 const useStyles = makeStyles({
   container: {
@@ -11,6 +12,9 @@ const useStyles = makeStyles({
     marginRight: '10px',
     letterSpacing: '-0.5px',
     flex: 'none',
+    [`@media (max-width: ${screenSm}px)`]: {
+      display: 'none',
+    },
   },
   icon: {
     maxWidth: 'none',

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { useLocation, matchPath } from 'react-router-dom'
 
@@ -10,6 +10,7 @@ import Sidebar from './Sidebar'
 import { MobileNotSupported } from './MobileNotSupported'
 import { SAFE_ROUTES, WELCOME_ROUTE } from 'src/routes/routes'
 import useDarkMode from 'src/logic/hooks/useDarkMode'
+import { screenSm } from 'src/theme/variables'
 
 const Container = styled.div`
   height: 100vh;
@@ -47,6 +48,14 @@ const SidebarWrapper = styled.aside`
   padding: 8px 8px 0 8px;
   background-color: ${({ theme }) => theme.colors.white};
   box-shadow: 0 2px 4px 0 rgba(40, 54, 61, 0.18);
+
+  @media (max-width: ${screenSm}px) {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    transition: transform 200ms ease-out;
+    transform: translateX(${({ $expanded }: { $expanded: boolean }) => ($expanded ? '0' : '-95%')});
+  }
 `
 
 const ContentWrapper = styled.div`
@@ -93,6 +102,7 @@ const Layout: React.FC<Props> = ({
   sidebarItems,
 }): React.ReactElement => {
   const [mobileNotSupportedClosed, setMobileNotSupportedClosed] = useState(false)
+  const [expanded, setExpanded] = useState(false)
   const { pathname } = useLocation()
   useDarkMode()
 
@@ -102,13 +112,21 @@ const Layout: React.FC<Props> = ({
     path: [SAFE_ROUTES.SETTINGS, WELCOME_ROUTE],
   })
 
+  const onSidebarClick = useCallback(
+    (e: React.MouseEvent): void => {
+      e.stopPropagation()
+      setExpanded((prev) => !prev)
+    },
+    [setExpanded],
+  )
+
   return (
-    <Container>
+    <Container onClick={() => setExpanded(false)}>
       <HeaderWrapper>
         <Header />
       </HeaderWrapper>
       <BodyWrapper>
-        <SidebarWrapper data-testid="sidebar">
+        <SidebarWrapper data-testid="sidebar" $expanded={expanded} onClick={onSidebarClick}>
           <Sidebar
             items={sidebarItems}
             safeAddress={safeAddress}

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { useLocation, matchPath } from 'react-router-dom'
 
 import { ListItemType } from 'src/components/List'
@@ -37,6 +37,16 @@ const BodyWrapper = styled.div`
   flex-direction: row;
 `
 
+const slideIn = keyframes`
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-95%);
+  }
+`
+
 const SidebarWrapper = styled.aside`
   height: 100%;
   width: 200px;
@@ -55,6 +65,7 @@ const SidebarWrapper = styled.aside`
     left: 0;
     transition: transform 200ms ease-out;
     transform: translateX(${({ $expanded }: { $expanded: boolean }) => ($expanded ? '0' : '-95%')});
+    animation: ${slideIn} 300ms ease-in;
   }
 `
 

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -66,6 +66,24 @@ const SidebarWrapper = styled.aside`
     transition: transform 200ms ease-out;
     transform: translateX(${({ $expanded }: { $expanded: boolean }) => ($expanded ? '0' : '-95%')});
     animation: ${slideIn} 300ms ease-in;
+
+    &:before {
+      content: '';
+      position: absolute;
+      right: -42px;
+      top: 100vh;
+      margin-top: -167px;
+      width: 40px;
+      height: 40px;
+      background-color: ${({ theme }) => theme.colors.white};
+      border: 2px solid #ececeb;
+      border-width: ${({ $expanded }: { $expanded: boolean }) => ($expanded ? '2px 2px 0 2px' : '0 2px 2px 2px')};
+      border-radius: ${({ $expanded }: { $expanded: boolean }) => ($expanded ? '6px 6px 0 0' : '0 0 6px 6px')};
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath fill='%23B2B5B2' d='M7.295 10.293c.36-.36.928-.388 1.32-.083l.094.083 3.292 3.293 3.294-3.293c.36-.36.928-.388 1.32-.083l.094.083c.36.361.389.928.084 1.32l-.084.095-4 4c-.361.36-.928.388-1.32.083l-.095-.083-3.999-4c-.39-.391-.39-1.024 0-1.415z'%3E%3C/path%3E%3C/svg%3E");
+      background-size: 100%;
+      transform: rotate(${({ $expanded }: { $expanded: boolean }) => ($expanded ? '90' : '-90')}deg);
+      transform-origin: center center;
+    }
   }
 `
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components'
 import { Button, Loader, theme, Title as TitleSRC } from '@gnosis.pm/safe-react-components'
 import { ButtonProps as ButtonPropsMUI, Modal as ModalMUI } from '@material-ui/core'
 import cn from 'classnames'
@@ -5,7 +6,7 @@ import { ReactElement, ReactNode } from 'react'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import { getModalEvent } from 'src/utils/events/modals'
 import { trackEvent } from 'src/utils/googleTagManager'
-import styled from 'styled-components'
+import { screenSm } from 'src/theme/variables'
 
 type Theme = typeof theme
 
@@ -55,6 +56,10 @@ const ModalStyled = styled(ModalMUI)`
     &.modal {
       height: auto;
       max-width: calc(100% - 130px);
+    }
+
+    @media (max-width: ${screenSm}px) {
+      width: 100vw;
     }
   }
 `

--- a/src/routes/safe/components/Balances/SendModal/screens/ChooseTxType/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/ChooseTxType/style.ts
@@ -28,6 +28,7 @@ export const useStyles = makeStyles(
     },
     buttonColumn: {
       margin: '52px 0 44px 0',
+      alignItems: 'center',
     },
     firstButton: {
       marginBottom: 12,


### PR DESCRIPTION
## What it solves
Resolves https://github.com/gnosis/safe-pm/issues/64

## How this PR fixes it
The sidebar on a small screen is shifted off screen. Only 5% of it is still visible, and if you tap on it, it will slide into view.
Tapping anywhere will again hide the sidebar.

Also adjusted modal windows to be full width.

## How to test it
Open the app on a mobile phone

## Screenshots
<img width="512" alt="Screenshot 2022-04-07 at 16 55 44" src="https://user-images.githubusercontent.com/381895/162228799-6d075ba4-a8e2-4187-b9de-04066faa80d7.png">
