### PR TITLE
feat: Sidebar redesign

### DIFF
--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -16,7 +16,7 @@ import ButtonHelper from 'src/components/ButtonHelper'
 import FlexSpacer from 'src/components/FlexSpacer'
 import Paragraph from 'src/components/layout/Paragraph'
 import { getChainInfo, getExplorerInfo } from 'src/config'
-import { border, fontColor } from 'src/theme/variables'
+import { border, fontColor, background, primaryGreen200, secondaryBackground, black400 } from 'src/theme/variables'
 import { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { copyShortNameSelector } from 'src/logic/appearance/selectors'
@@ -24,6 +24,7 @@ import { ADDRESSED_ROUTE, extractShortChainName } from 'src/routes/routes'
 import Track from 'src/components/Track'
 import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
 import Threshold from 'src/components/AppLayout/Sidebar/Threshold'
+import { trackEvent } from 'src/utils/googleTagManager'
 
 export const TOGGLE_SIDEBAR_BTN_TESTID = 'TOGGLE_SIDEBAR_BTN'
 
@@ -33,25 +34,26 @@ const Container = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin: 0 12px;
 `
 
 const IdenticonContainer = styled.div`
   width: 100%;
   margin: 14px 8px;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   position: relative;
-
-  div:first-of-type {
-    width: 32px;
-  }
 `
 const StyledIcon = styled(Icon)`
   svg {
-    height: 26px;
-    width: 26px;
+    height: 24px;
+    width: 24px;
     transform: rotateZ(-90deg);
+
+    .icon-color {
+      fill: ${black400};
+    }
 
     path:nth-child(2) {
       display: none;
@@ -68,10 +70,9 @@ const IconContainer = styled.div`
 `
 const StyledButton = styled(Button)`
   &&.MuiButton-root {
+    width: 100%;
+    height: 38px;
     padding: 0 12px;
-  }
-  *:first-child {
-    margin: 0 4px 0 0;
   }
 `
 
@@ -79,17 +80,14 @@ const StyledExplorerButton = styled(ExplorerButton)`
   border-radius: 5px;
   width: 32px;
   height: 32px;
-  background-color: #f0efee;
+  background-color: ${background};
 
   & .icon-color {
-    transition: fill 0.2s ease-in-out;
+    fill: #008c73;
   }
 
   &:hover {
     background-color: #effaf8;
-    & .icon-color {
-      fill: #008c73;
-    }
   }
 `
 
@@ -97,17 +95,14 @@ const StyledCopyToClipboardBtn = styled(CopyToClipboardBtn)`
   border-radius: 5px;
   width: 32px;
   height: 32px;
-  background-color: #f0efee;
+  background-color: ${background};
 
   & .icon-color {
-    transition: fill 0.2s ease-in-out;
+    fill: #008c73;
   }
 
   &:hover {
     background-color: #effaf8;
-    & .icon-color {
-      fill: #008c73;
-    }
   }
 `
 
@@ -117,17 +112,15 @@ const StyledQRCodeButton = styled.button`
   border-radius: 5px;
   width: 32px;
   height: 32px;
-  background-color: #f0efee;
+  background-color: ${background};
+  transition: background-color 0.2s ease-in-out;
 
   & .icon-color {
-    transition: fill 0.2s ease-in-out;
+    fill: #008c73;
   }
 
   &:hover {
     background-color: #effaf8;
-    & .icon-color {
-      fill: #008c73;
-    }
   }
 `
 
@@ -154,21 +147,42 @@ const StyledPrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
   p {
     color: ${({ theme }) => theme.colors.placeHolder};
     font-size: 14px;
+    line-height: 20px;
   }
 `
 
 const StyledLabel = styled.div`
-  background-color: ${({ theme }) => theme.colors.icon};
-  margin: 0 0 14px 0 !important;
-  padding: 4px 8px;
-  border-radius: 4px;
-  letter-spacing: 1px;
+  background-color: #e2e3e3;
+  margin-top: 14px;
+  width: 100%;
+  padding: 3px 8px;
+  box-sizing: border-box;
   p {
+    text-align: center;
     line-height: 18px;
   }
 `
 const StyledText = styled(Title)`
   margin: 0 0 14px 0;
+`
+
+const ToggleSafeListButton = styled.button`
+  cursor: pointer;
+  border: 0;
+  background-color: ${secondaryBackground};
+  border-radius: 50%;
+  width: 42px;
+  height: 42px;
+  position: absolute;
+  right: -40px;
+
+  & span {
+    margin-left: -20px;
+  }
+
+  &:hover {
+    background-color: ${primaryGreen200};
+  }
 `
 
 type Props = {
@@ -195,6 +209,11 @@ const SafeHeader = ({
 
   const hasSafeOpen = useRouteMatch(ADDRESSED_ROUTE)
 
+  const handleNewTransactionClick = () => {
+    trackEvent({ ...OVERVIEW_EVENTS.NEW_TRANSACTION })
+    onNewTransactionClick()
+  }
+
   if (!address || !hasSafeOpen) {
     return (
       <Container>
@@ -220,12 +239,11 @@ const SafeHeader = ({
       <Container>
         {/* Identicon */}
         <IdenticonContainer>
-          <FlexSpacer />
           <Threshold />
           <Identicon address={address} size="lg" />
-          <ButtonHelper onClick={onToggleSafeList} data-testid={TOGGLE_SIDEBAR_BTN_TESTID}>
+          <ToggleSafeListButton onClick={onToggleSafeList} data-testid={TOGGLE_SIDEBAR_BTN_TESTID}>
             <StyledIcon size="md" type="circleDropdown" />
-          </ButtonHelper>
+          </ToggleSafeListButton>
         </IdenticonContainer>
 
         {/* SafeInfo */}
@@ -247,32 +265,29 @@ const SafeHeader = ({
           </Track>
         </IconContainer>
 
-        {!granted && (
-          <StyledLabel>
-            <Text size="sm" color="white">
-              READ ONLY
-            </Text>
-          </StyledLabel>
-        )}
-
         <Paragraph color="black400" noMargin size="md">
           Total Balance
         </Paragraph>
         <StyledText size="xs">{balance}</StyledText>
-        <Track {...OVERVIEW_EVENTS.NEW_TRANSACTION}>
-          <StyledButton
-            size="md"
-            disabled={!granted}
-            color="primary"
-            variant="contained"
-            onClick={onNewTransactionClick}
-          >
-            <FixedIcon type="arrowSentWhite" />
-            <Text size="lg" color="white" strong>
-              New transaction
+        <StyledButton
+          size="md"
+          disabled={!granted}
+          color="primary"
+          variant="contained"
+          onClick={handleNewTransactionClick}
+        >
+          <Text size="lg" color="white" strong>
+            New Transaction
+          </Text>
+        </StyledButton>
+
+        {!granted && (
+          <StyledLabel>
+            <Text size="sm" strong>
+              READ ONLY
             </Text>
-          </StyledButton>
-        </Track>
+          </StyledLabel>
+        )}
       </Container>
     </>
   )

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   FixedIcon,
   Text,
+  Title,
   Identicon,
   Button,
   CopyToClipboardBtn,
@@ -13,6 +14,7 @@ import { useRouteMatch } from 'react-router-dom'
 
 import ButtonHelper from 'src/components/ButtonHelper'
 import FlexSpacer from 'src/components/FlexSpacer'
+import Paragraph from 'src/components/layout/Paragraph'
 import { getChainInfo, getExplorerInfo } from 'src/config'
 import { border, fontColor } from 'src/theme/variables'
 import { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
@@ -35,7 +37,7 @@ const Container = styled.div`
 
 const IdenticonContainer = styled.div`
   width: 100%;
-  margin: 8px;
+  margin: 14px 8px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -60,8 +62,9 @@ const StyledIcon = styled(Icon)`
 const IconContainer = styled.div`
   width: 100px;
   display: flex;
-  padding: 4px 0;
+  gap: 8px;
   justify-content: space-evenly;
+  margin: 14px 0;
 `
 const StyledButton = styled(Button)`
   &&.MuiButton-root {
@@ -72,12 +75,68 @@ const StyledButton = styled(Button)`
   }
 `
 
+const StyledExplorerButton = styled(ExplorerButton)`
+  border-radius: 5px;
+  width: 32px;
+  height: 32px;
+  background-color: #f0efee;
+
+  & .icon-color {
+    transition: fill 0.2s ease-in-out;
+  }
+
+  &:hover {
+    background-color: #effaf8;
+    & .icon-color {
+      fill: #008c73;
+    }
+  }
+`
+
+const StyledCopyToClipboardBtn = styled(CopyToClipboardBtn)`
+  border-radius: 5px;
+  width: 32px;
+  height: 32px;
+  background-color: #f0efee;
+
+  & .icon-color {
+    transition: fill 0.2s ease-in-out;
+  }
+
+  &:hover {
+    background-color: #effaf8;
+    & .icon-color {
+      fill: #008c73;
+    }
+  }
+`
+
+const StyledQRCodeButton = styled.button`
+  border: 0;
+  cursor: pointer;
+  border-radius: 5px;
+  width: 32px;
+  height: 32px;
+  background-color: #f0efee;
+
+  & .icon-color {
+    transition: fill 0.2s ease-in-out;
+  }
+
+  &:hover {
+    background-color: #effaf8;
+    & .icon-color {
+      fill: #008c73;
+    }
+  }
+`
+
 type StyledTextLabelProps = {
   chainInfo: ChainInfo
 }
 
 const StyledTextLabel = styled(Text)`
-  margin: -8px 0 4px -8px;
+  margin: -8px 0 0 -8px;
   padding: 4px 8px;
   width: 100%;
   text-align: center;
@@ -100,7 +159,7 @@ const StyledPrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
 
 const StyledLabel = styled.div`
   background-color: ${({ theme }) => theme.colors.icon};
-  margin: 4px 0 0 0 !important;
+  margin: 0 0 14px 0 !important;
   padding: 4px 8px;
   border-radius: 4px;
   letter-spacing: 1px;
@@ -108,8 +167,8 @@ const StyledLabel = styled.div`
     line-height: 18px;
   }
 `
-const StyledText = styled(Text)`
-  margin: 8px 0 16px 0;
+const StyledText = styled(Title)`
+  margin: 0 0 14px 0;
 `
 
 type Props = {
@@ -170,21 +229,21 @@ const SafeHeader = ({
         </IdenticonContainer>
 
         {/* SafeInfo */}
-        <StyledTextSafeName size="lg" center>
+        <StyledTextSafeName size="xl" center>
           {safeName}
         </StyledTextSafeName>
         <StyledPrefixedEthHashInfo hash={address} shortenHash={4} textSize="sm" />
         <IconContainer>
           <Track {...OVERVIEW_EVENTS.SHOW_QR}>
-            <ButtonHelper onClick={onReceiveClick}>
+            <StyledQRCodeButton onClick={onReceiveClick}>
               <Icon size="sm" type="qrCode" tooltip="Show QR code" />
-            </ButtonHelper>
+            </StyledQRCodeButton>
           </Track>
           <Track {...OVERVIEW_EVENTS.COPY_ADDRESS}>
-            <CopyToClipboardBtn textToCopy={copyChainPrefix ? `${shortName}:${address}` : `${address}`} />
+            <StyledCopyToClipboardBtn textToCopy={copyChainPrefix ? `${shortName}:${address}` : `${address}`} />
           </Track>
           <Track {...OVERVIEW_EVENTS.OPEN_EXPLORER}>
-            <ExplorerButton explorerUrl={getExplorerInfo(address)} />
+            <StyledExplorerButton explorerUrl={getExplorerInfo(address)} />
           </Track>
         </IconContainer>
 
@@ -196,7 +255,10 @@ const SafeHeader = ({
           </StyledLabel>
         )}
 
-        <StyledText size="xl">{balance}</StyledText>
+        <Paragraph color="black400" noMargin size="md">
+          Total Balance
+        </Paragraph>
+        <StyledText size="xs">{balance}</StyledText>
         <Track {...OVERVIEW_EVENTS.NEW_TRANSACTION}>
           <StyledButton
             size="md"
@@ -206,7 +268,7 @@ const SafeHeader = ({
             onClick={onNewTransactionClick}
           >
             <FixedIcon type="arrowSentWhite" />
-            <Text size="xl" color="white">
+            <Text size="lg" color="white" strong>
               New transaction
             </Text>
           </StyledButton>

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -16,7 +16,15 @@ import ButtonHelper from 'src/components/ButtonHelper'
 import FlexSpacer from 'src/components/FlexSpacer'
 import Paragraph from 'src/components/layout/Paragraph'
 import { getChainInfo, getExplorerInfo } from 'src/config'
-import { border, fontColor, background, primaryGreen200, secondaryBackground, black400 } from 'src/theme/variables'
+import {
+  secondary,
+  border,
+  fontColor,
+  background,
+  primaryLite,
+  secondaryBackground,
+  black400,
+} from 'src/theme/variables'
 import { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { copyShortNameSelector } from 'src/logic/appearance/selectors'
@@ -83,11 +91,11 @@ const StyledExplorerButton = styled(ExplorerButton)`
   background-color: ${background};
 
   & .icon-color {
-    fill: #008c73;
+    fill: ${secondary};
   }
 
   &:hover {
-    background-color: #effaf8;
+    background-color: ${primaryLite};
   }
 `
 
@@ -98,11 +106,11 @@ const StyledCopyToClipboardBtn = styled(CopyToClipboardBtn)`
   background-color: ${background};
 
   & .icon-color {
-    fill: #008c73;
+    fill: ${secondary};
   }
 
   &:hover {
-    background-color: #effaf8;
+    background-color: ${primaryLite};
   }
 `
 
@@ -116,11 +124,11 @@ const StyledQRCodeButton = styled.button`
   transition: background-color 0.2s ease-in-out;
 
   & .icon-color {
-    fill: #008c73;
+    fill: ${secondary};
   }
 
   &:hover {
-    background-color: #effaf8;
+    background-color: ${primaryLite};
   }
 `
 
@@ -181,7 +189,7 @@ const ToggleSafeListButton = styled.button`
   }
 
   &:hover {
-    background-color: ${primaryGreen200};
+    background-color: ${primaryLite};
   }
 `
 

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -23,7 +23,6 @@ import {
   primaryLite,
   secondaryBackground,
   black400,
-  gray500,
 } from 'src/theme/variables'
 import { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
@@ -162,17 +161,6 @@ const StyledPrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
   }
 `
 
-const StyledLabel = styled.div`
-  background-color: ${gray500};
-  margin-top: 14px;
-  width: 100%;
-  padding: 3px 8px;
-  box-sizing: border-box;
-  p {
-    text-align: center;
-    line-height: 18px;
-  }
-`
 const StyledText = styled(Title)`
   margin: 0 0 14px 0;
 `
@@ -291,17 +279,9 @@ const SafeHeader = ({
           onClick={handleNewTransactionClick}
         >
           <Text size="xl" color="white">
-            New Transaction
+            {granted ? 'New Transaction' : 'Read Only'}
           </Text>
         </StyledButton>
-
-        {!granted && (
-          <StyledLabel>
-            <Text size="sm" strong>
-              READ ONLY
-            </Text>
-          </StyledLabel>
-        )}
       </Container>
     </>
   )

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -23,6 +23,7 @@ import {
   primaryLite,
   secondaryBackground,
   black400,
+  gray500,
 } from 'src/theme/variables'
 import { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
@@ -192,7 +193,7 @@ const StyledPrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
 `
 
 const StyledLabel = styled.div`
-  background-color: #e2e3e3;
+  background-color: ${gray500};
   margin-top: 14px;
   width: 100%;
   padding: 3px 8px;

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -12,7 +12,6 @@ import {
 } from '@gnosis.pm/safe-react-components'
 import { useRouteMatch } from 'react-router-dom'
 
-import ButtonHelper from 'src/components/ButtonHelper'
 import FlexSpacer from 'src/components/FlexSpacer'
 import Paragraph from 'src/components/layout/Paragraph'
 import { getChainInfo, getExplorerInfo } from 'src/config'
@@ -90,11 +89,22 @@ const StyledExplorerButton = styled(ExplorerButton)`
   height: 32px;
   background-color: ${background};
 
+  & span {
+    transition: background-color 0.2s ease-in-out;
+    border-radius: 5px;
+    width: 32px;
+    height: 32px;
+    background-color: ${background};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   & .icon-color {
     fill: ${secondary};
   }
 
-  &:hover {
+  &:hover span {
     background-color: ${primaryLite};
   }
 `
@@ -105,11 +115,22 @@ const StyledCopyToClipboardBtn = styled(CopyToClipboardBtn)`
   height: 32px;
   background-color: ${background};
 
+  & span {
+    transition: background-color 0.2s ease-in-out;
+    border-radius: 5px;
+    width: 32px;
+    height: 32px;
+    background-color: ${background};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   & .icon-color {
     fill: ${secondary};
   }
 
-  &:hover {
+  &:hover span {
     background-color: ${primaryLite};
   }
 `
@@ -121,13 +142,24 @@ const StyledQRCodeButton = styled.button`
   width: 32px;
   height: 32px;
   background-color: ${background};
-  transition: background-color 0.2s ease-in-out;
+  padding: 0;
+
+  & span {
+    transition: background-color 0.2s ease-in-out;
+    border-radius: 5px;
+    width: 32px;
+    height: 32px;
+    background-color: ${background};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   & .icon-color {
     fill: ${secondary};
   }
 
-  &:hover {
+  &:hover span {
     background-color: ${primaryLite};
   }
 `
@@ -183,9 +215,12 @@ const ToggleSafeListButton = styled.button`
   height: 42px;
   position: absolute;
   right: -40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   & span {
-    margin-left: -20px;
+    margin-left: -15px;
   }
 
   &:hover {
@@ -228,9 +263,9 @@ const SafeHeader = ({
         <IdenticonContainer>
           <FlexSpacer />
           <FixedIcon type="notConnected" />
-          <ButtonHelper onClick={onToggleSafeList} data-testid={TOGGLE_SIDEBAR_BTN_TESTID}>
+          <ToggleSafeListButton onClick={onToggleSafeList} data-testid={TOGGLE_SIDEBAR_BTN_TESTID}>
             <StyledIcon size="md" type="circleDropdown" />
-          </ButtonHelper>
+          </ToggleSafeListButton>
         </IdenticonContainer>
       </Container>
     )
@@ -284,7 +319,7 @@ const SafeHeader = ({
           variant="contained"
           onClick={handleNewTransactionClick}
         >
-          <Text size="lg" color="white" strong>
+          <Text size="xl" color="white">
             New Transaction
           </Text>
         </StyledButton>

--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { useSelector } from 'react-redux'
 import {
   Icon,
@@ -84,12 +84,7 @@ const StyledButton = styled(Button)`
   }
 `
 
-const StyledExplorerButton = styled(ExplorerButton)`
-  border-radius: 5px;
-  width: 32px;
-  height: 32px;
-  background-color: ${background};
-
+const innerButtonStyle = css`
   & span {
     transition: background-color 0.2s ease-in-out;
     border-radius: 5px;
@@ -110,30 +105,22 @@ const StyledExplorerButton = styled(ExplorerButton)`
   }
 `
 
+const StyledExplorerButton = styled(ExplorerButton)`
+  border-radius: 5px;
+  width: 32px;
+  height: 32px;
+  background-color: ${background};
+
+  ${innerButtonStyle}
+`
+
 const StyledCopyToClipboardBtn = styled(CopyToClipboardBtn)`
   border-radius: 5px;
   width: 32px;
   height: 32px;
   background-color: ${background};
 
-  & span {
-    transition: background-color 0.2s ease-in-out;
-    border-radius: 5px;
-    width: 32px;
-    height: 32px;
-    background-color: ${background};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  & .icon-color {
-    fill: ${secondary};
-  }
-
-  &:hover span {
-    background-color: ${primaryLite};
-  }
+  ${innerButtonStyle}
 `
 
 const StyledQRCodeButton = styled.button`
@@ -145,24 +132,7 @@ const StyledQRCodeButton = styled.button`
   background-color: ${background};
   padding: 0;
 
-  & span {
-    transition: background-color 0.2s ease-in-out;
-    border-radius: 5px;
-    width: 32px;
-    height: 32px;
-    background-color: ${background};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  & .icon-color {
-    fill: ${secondary};
-  }
-
-  &:hover span {
-    background-color: ${primaryLite};
-  }
+  ${innerButtonStyle}
 `
 
 type StyledTextLabelProps = {

--- a/src/components/AppLayout/Sidebar/Threshold/index.tsx
+++ b/src/components/AppLayout/Sidebar/Threshold/index.tsx
@@ -15,10 +15,13 @@ const Container = styled.div`
   top: -6px;
   left: 50%;
   transform: translateX(-50%);
-  width: 24px;
-  height: 24px;
+  min-width: 26px;
+  min-height: 26px;
   box-sizing: border-box;
   margin-left: -15px;
+  display: flex;
+  align-items: center;
+  line-height: 1;
 `
 
 const Threshold = (): React.ReactElement | null => {

--- a/src/components/AppLayout/Sidebar/Threshold/index.tsx
+++ b/src/components/AppLayout/Sidebar/Threshold/index.tsx
@@ -14,7 +14,11 @@ const Container = styled.div`
   z-index: 2;
   top: -6px;
   left: 50%;
-  transform: translateX(-110%);
+  transform: translateX(-50%);
+  width: 24px;
+  height: 24px;
+  box-sizing: border-box;
+  margin-left: -15px;
 `
 
 const Threshold = (): React.ReactElement | null => {

--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -13,9 +13,11 @@ import ListIcon from 'src/components/List/ListIcon'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { loadFromCookie } from 'src/logic/cookies/utils'
 import { COOKIES_KEY, BannerCookiesType, COOKIE_IDS } from 'src/logic/cookies/model/cookie'
+import { primaryGreen200 } from 'src/theme/variables'
 
 const StyledDivider = styled(Divider)`
   margin: 16px -8px 0;
+  border-top: 1px solid #f6f7f8;
 `
 
 const HelpContainer = styled.div`
@@ -24,6 +26,7 @@ const HelpContainer = styled.div`
 
 const HelpList = styled.div`
   margin: 24px 0;
+  padding: 0 12px;
 `
 
 const HelpCenterLink = styled.a`
@@ -33,13 +36,13 @@ const HelpCenterLink = styled.a`
   box-sizing: border-box;
   text-align: left;
   align-items: center;
-  padding: 8px 16px;
+  padding: 8px 12px;
   justify-content: flex-start;
   text-decoration: none;
   border-radius: 8px;
 
   &:hover {
-    background-color: ${({ theme }) => theme.colors.background};
+    background-color: ${primaryGreen200};
   }
   p {
     font-family: ${({ theme }) => theme.fonts.fontFamily};
@@ -129,7 +132,7 @@ const Sidebar = ({
           {!isDesktop && BEAMER_ID && (
             <Track {...OVERVIEW_EVENTS.WHATS_NEW}>
               <StyledListItem id="whats-new-button" button onClick={handleClick}>
-                <ListIcon type="gift" />
+                <ListIcon type="gift" color="secondary" />
                 <StyledListItemText>What&apos;s new</StyledListItemText>
               </StyledListItem>
             </Track>
@@ -137,7 +140,7 @@ const Sidebar = ({
 
           <Track {...OVERVIEW_EVENTS.HELP_CENTER}>
             <HelpCenterLink href="https://help.gnosis-safe.io/en/" target="_blank" title="Help Center of Gnosis Safe">
-              <ListIcon type="question" />
+              <ListIcon type="question" color="secondary" />
               <StyledListItemText>Help Center</StyledListItemText>
             </HelpCenterLink>
           </Track>

--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -13,11 +13,11 @@ import ListIcon from 'src/components/List/ListIcon'
 import { openCookieBanner } from 'src/logic/cookies/store/actions/openCookieBanner'
 import { loadFromCookie } from 'src/logic/cookies/utils'
 import { COOKIES_KEY, BannerCookiesType, COOKIE_IDS } from 'src/logic/cookies/model/cookie'
-import { primaryGreen200 } from 'src/theme/variables'
+import { background, primaryLite } from 'src/theme/variables'
 
 const StyledDivider = styled(Divider)`
   margin: 16px -8px 0;
-  border-top: 1px solid #f6f7f8;
+  border-top: 1px solid ${background};
 `
 
 const HelpContainer = styled.div`
@@ -42,7 +42,7 @@ const HelpCenterLink = styled.a`
   border-radius: 8px;
 
   &:hover {
-    background-color: ${primaryGreen200};
+    background-color: ${primaryLite};
   }
   p {
     font-family: ${({ theme }) => theme.fonts.fontFamily};

--- a/src/components/AppLayout/Sidebar/index.tsx
+++ b/src/components/AppLayout/Sidebar/index.tsx
@@ -36,7 +36,7 @@ const HelpCenterLink = styled.a`
   box-sizing: border-box;
   text-align: left;
   align-items: center;
-  padding: 8px 12px;
+  padding: 6px 12px;
   justify-content: flex-start;
   text-decoration: none;
   border-radius: 8px;
@@ -132,7 +132,7 @@ const Sidebar = ({
           {!isDesktop && BEAMER_ID && (
             <Track {...OVERVIEW_EVENTS.WHATS_NEW}>
               <StyledListItem id="whats-new-button" button onClick={handleClick}>
-                <ListIcon type="gift" color="secondary" />
+                <ListIcon type="gift" color="secondary" size="sm" />
                 <StyledListItemText>What&apos;s new</StyledListItemText>
               </StyledListItem>
             </Track>
@@ -140,7 +140,7 @@ const Sidebar = ({
 
           <Track {...OVERVIEW_EVENTS.HELP_CENTER}>
             <HelpCenterLink href="https://help.gnosis-safe.io/en/" target="_blank" title="Help Center of Gnosis Safe">
-              <ListIcon type="question" color="secondary" />
+              <ListIcon type="question" color="secondary" size="sm" />
               <StyledListItemText>Help Center</StyledListItemText>
             </HelpCenterLink>
           </Track>

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -115,11 +115,6 @@ const useSidebarItems = (): ListItemType[] => {
 
     return [
       makeEntryItem({
-        label: 'Home',
-        iconType: 'home',
-        href: currentSafeRoutes.DASHBOARD,
-      }),
-      makeEntryItem({
         label: 'Assets',
         iconType: 'assets',
         href: currentSafeRoutes.ASSETS_BALANCES,

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -67,6 +67,17 @@ const useSidebarItems = (): ListItemType[] => {
       }),
     ]
 
+    const transactionsSubItems = [
+      makeEntryItem({
+        label: 'Queue',
+        href: currentSafeRoutes.TRANSACTIONS_QUEUE,
+      }),
+      makeEntryItem({
+        label: 'History',
+        href: currentSafeRoutes.TRANSACTIONS_HISTORY,
+      }),
+    ]
+
     const settingsSubItems = [
       makeEntryItem({
         label: 'Safe Details',
@@ -104,6 +115,11 @@ const useSidebarItems = (): ListItemType[] => {
 
     return [
       makeEntryItem({
+        label: 'Home',
+        iconType: 'home',
+        href: currentSafeRoutes.DASHBOARD,
+      }),
+      makeEntryItem({
         label: 'Assets',
         iconType: 'assets',
         href: currentSafeRoutes.ASSETS_BALANCES,
@@ -112,7 +128,8 @@ const useSidebarItems = (): ListItemType[] => {
       makeEntryItem({
         label: 'Transactions',
         iconType: 'transactionsInactive',
-        href: currentSafeRoutes.TRANSACTIONS_HISTORY,
+        href: currentSafeRoutes.TRANSACTIONS_QUEUE,
+        subItems: transactionsSubItems,
       }),
       makeEntryItem({
         label: 'Address Book',

--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -35,7 +35,7 @@ const useSidebarItems = (): ListItemType[] => {
       label,
       badge,
       disabled,
-      icon: <ListIcon type={iconType} />,
+      icon: <ListIcon type={iconType} size="sm" color="text" />,
       selected: href === matchSafeWithSidebarSection?.url,
       href,
       subItems,
@@ -104,18 +104,18 @@ const useSidebarItems = (): ListItemType[] => {
 
     return [
       makeEntryItem({
-        label: 'ASSETS',
+        label: 'Assets',
         iconType: 'assets',
         href: currentSafeRoutes.ASSETS_BALANCES,
         subItems: assetsSubItems,
       }),
       makeEntryItem({
-        label: 'TRANSACTIONS',
+        label: 'Transactions',
         iconType: 'transactionsInactive',
         href: currentSafeRoutes.TRANSACTIONS_HISTORY,
       }),
       makeEntryItem({
-        label: 'ADDRESS BOOK',
+        label: 'Address Book',
         iconType: 'addressBook',
         href: currentSafeRoutes.ADDRESS_BOOK,
       }),

--- a/src/components/AppLayout/index.tsx
+++ b/src/components/AppLayout/index.tsx
@@ -54,10 +54,12 @@ const SidebarWrapper = styled.aside`
   flex-direction: column;
   flex-shrink: 0;
   z-index: 1;
+  overflow: hidden;
 
   padding: 8px 8px 0 8px;
   background-color: ${({ theme }) => theme.colors.white};
-  box-shadow: 0 2px 4px 0 rgba(40, 54, 61, 0.18);
+  border-right: 1px solid #f0efee;
+  box-shadow: 1px 2px 12px rgba(40, 54, 61, 0.08);
 
   @media (max-width: ${screenSm}px) {
     position: fixed;

--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -1,14 +1,19 @@
 import styled from 'styled-components'
 import { Icon, IconTypes } from '@gnosis.pm/safe-react-components'
+import { ThemeColors, ThemeIconSize } from '@gnosis.pm/safe-react-components/dist/theme'
 
 const StyledIcon = styled(Icon)`
-  min-width: 32px !important;
+  margin-right: 14px;
 `
 
 type Props = {
   type: IconTypes
+  size?: ThemeIconSize
+  color?: ThemeColors
 }
 
-const ListItemIcon = ({ type }: Props): React.ReactElement => <StyledIcon type={type} color="placeHolder" size="md" />
+const ListItemIcon = ({ type, size, color }: Props): React.ReactElement => (
+  <StyledIcon type={type} color={color || 'placeHolder'} size={size || 'md'} />
+)
 
 export default ListItemIcon

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -9,7 +9,11 @@ import ListItem, { ListItemProps } from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Collapse from '@material-ui/core/Collapse'
 import { FixedIcon } from '@gnosis.pm/safe-react-components'
-import { secondary } from 'src/theme/variables'
+import { secondary, primaryGreen200 } from 'src/theme/variables'
+
+const ListItemWrapper = styled.div`
+  padding: 0 12px;
+`
 
 export const StyledListItem = styled(ListItem)<ListItemProps>`
   &.MuiButtonBase-root.MuiListItem-root {
@@ -21,11 +25,17 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
   }
 
   &.MuiListItem-button:hover {
+    background-color: ${primaryGreen200};
     border-radius: 8px;
   }
 
+  &.MuiListItem-root {
+    padding-top: 9px;
+    padding-bottom: 9px;
+  }
+
   &.MuiListItem-root.Mui-selected {
-    background-color: ${({ theme }) => theme.colors.background};
+    background-color: ${primaryGreen200};
     border-radius: 8px;
     color: ${({ theme }) => theme.colors.primary};
     span {
@@ -50,7 +60,17 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
 
 const StyledListSubItem = styled(ListItem)<ListItemProps>`
   &.MuiButtonBase-root.MuiListItem-root {
-    margin: 4px 0;
+    margin: 4px 0 4px 15px;
+    width: calc(100% - 15px);
+
+    &::before {
+      content: '';
+      width: 6px;
+      height: 1px;
+      background: #e1e1e1;
+      position: absolute;
+      left: -15px;
+    }
   }
 
   & .MuiListItemText-root span {
@@ -58,11 +78,12 @@ const StyledListSubItem = styled(ListItem)<ListItemProps>`
   }
 
   &.MuiListItem-button:hover {
+    background-color: ${primaryGreen200};
     border-radius: 8px;
   }
 
   &.MuiButtonBase-root.MuiListItem-root.Mui-selected {
-    background-color: ${({ theme }) => theme.colors.background};
+    background-color: ${primaryGreen200};
     border-radius: 8px;
     color: ${({ theme }) => theme.colors.primary};
     span {
@@ -77,23 +98,21 @@ const StyledListSubItem = styled(ListItem)<ListItemProps>`
 export const StyledListItemText = styled(ListItemText)`
   span {
     font-family: ${({ theme }) => theme.fonts.fontFamily};
-    font-size: 0.76em;
+    font-size: 14px;
     font-weight: 600;
     line-height: 1.5;
-    letter-spacing: 1px;
-    color: ${({ theme }) => theme.colors.placeHolder};
-    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #162d45 !important;
   }
 `
 
 const StyledListSubItemText = styled(ListItemText)`
   span {
     font-family: ${({ theme }) => theme.fonts.fontFamily};
-    font-size: 0.85em;
+    font-size: 14px;
     font-weight: 400;
-    letter-spacing: 0px;
-    color: ${({ theme }) => theme.colors.placeHolder};
-    text-transform: none;
+    letter-spacing: 0;
+    color: #162d45 !important;
   }
 `
 
@@ -129,6 +148,10 @@ const useStyles = makeStyles((theme: Theme) =>
         outline: '1px solid #dadada',
         borderRadius: '20px',
       },
+    },
+    listMui: {
+      marginLeft: '20px',
+      borderLeft: '1px solid #e1e1e1',
     },
     nested: {
       paddingLeft: theme.spacing(3),
@@ -188,7 +211,7 @@ const List = ({ items }: Props): React.ReactElement => {
         onClick={onClick}
         selected={item.selected || isSubItemSelected(item)}
       >
-        {item.icon && item.icon}
+        {item.icon && !isSubItem && item.icon}
 
         <TextAndBadgeWrapper>
           <StyledBadge badgeContent=" " color="error" invisible={!item.badge} variant="dot">
@@ -219,16 +242,16 @@ const List = ({ items }: Props): React.ReactElement => {
       {items
         .filter(({ disabled }) => !disabled)
         .map((item) => (
-          <div key={item.label}>
+          <ListItemWrapper key={item.label}>
             {getListItem(item, false)}
             {item.subItems && (
               <Collapse in={groupCollapseStatus[item.href]} timeout="auto" unmountOnExit>
-                <ListMui component="div" disablePadding>
+                <ListMui component="div" disablePadding className={classes.listMui}>
                   {item.subItems.filter(({ disabled }) => !disabled).map((subItem) => getListItem(subItem))}
                 </ListMui>
               </Collapse>
             )}
-          </div>
+          </ListItemWrapper>
         ))}
     </ListMui>
   )

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -10,7 +10,7 @@ import ListMui from '@material-ui/core/List'
 import ListItem, { ListItemProps } from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Collapse from '@material-ui/core/Collapse'
-import { background, secondary, primaryLite } from 'src/theme/variables'
+import { background, secondary, primaryLite, black500, gray500 } from 'src/theme/variables'
 
 const ListItemWrapper = styled.div`
   padding: 0 12px;
@@ -70,16 +70,16 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
 
 const StyledListSubItem = styled(ListItem)<ListItemProps>`
   &.MuiButtonBase-root.MuiListItem-root {
-    margin: 4px 0 4px 15px;
-    width: calc(100% - 15px);
+    margin: 4px 0 4px 10px;
+    width: calc(100% - 10px);
 
     &::before {
       content: '';
       width: 6px;
       height: 1px;
-      background: #e1e1e1;
+      background: ${gray500};
       position: absolute;
-      left: -15px;
+      left: -10px;
     }
   }
 
@@ -112,7 +112,7 @@ export const StyledListItemText = styled(ListItemText)`
     font-weight: 600;
     line-height: 1.5;
     letter-spacing: 0.5px;
-    color: #162d45 !important;
+    color: ${black500} !important;
   }
 `
 
@@ -122,7 +122,7 @@ const StyledListSubItemText = styled(ListItemText)`
     font-size: 14px;
     font-weight: 400;
     letter-spacing: 0;
-    color: #162d45 !important;
+    color: ${black500} !important;
   }
 `
 
@@ -161,7 +161,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     listMui: {
       marginLeft: '20px',
-      borderLeft: '1px solid #e1e1e1',
+      borderLeft: `1px solid ${gray500}`,
     },
     nested: {
       paddingLeft: theme.spacing(3),

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -68,10 +68,11 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
   }
 `
 
+const subItemLeftSpace = '10px'
 const StyledListSubItem = styled(ListItem)<ListItemProps>`
   &.MuiButtonBase-root.MuiListItem-root {
-    margin: 4px 0 4px 10px;
-    width: calc(100% - 10px);
+    margin: 4px 0 4px ${subItemLeftSpace};
+    width: calc(100% - ${subItemLeftSpace});
 
     &::before {
       content: '';
@@ -79,7 +80,7 @@ const StyledListSubItem = styled(ListItem)<ListItemProps>`
       height: 1px;
       background: ${gray500};
       position: absolute;
-      left: -10px;
+      left: -${subItemLeftSpace};
     }
   }
 

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -162,6 +162,16 @@ const useStyles = makeStyles((theme: Theme) =>
     listMui: {
       marginLeft: '20px',
       borderLeft: `1px solid ${gray500}`,
+
+      '&::after': {
+        content: '""',
+        height: '18px',
+        width: '1px',
+        position: 'absolute',
+        bottom: 0,
+        left: '-1px',
+        background: 'white',
+      },
     },
     nested: {
       paddingLeft: theme.spacing(3),

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -10,7 +10,7 @@ import ListMui from '@material-ui/core/List'
 import ListItem, { ListItemProps } from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Collapse from '@material-ui/core/Collapse'
-import { secondary, primaryGreen200 } from 'src/theme/variables'
+import { background, secondary, primaryLite } from 'src/theme/variables'
 
 const ListItemWrapper = styled.div`
   padding: 0 12px;
@@ -26,7 +26,7 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
   }
 
   &.MuiListItem-button:hover {
-    background-color: ${primaryGreen200};
+    background-color: ${primaryLite};
     border-radius: 8px;
   }
 
@@ -41,7 +41,7 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
   }
 
   &.MuiListItem-root.Mui-selected {
-    background-color: ${primaryGreen200};
+    background-color: ${primaryLite};
     border-radius: 8px;
     color: ${({ theme }) => theme.colors.primary};
     span {
@@ -88,12 +88,12 @@ const StyledListSubItem = styled(ListItem)<ListItemProps>`
   }
 
   &.MuiListItem-button:hover {
-    background-color: #f6f7f8;
+    background-color: ${background};
     border-radius: 8px;
   }
 
   &.MuiButtonBase-root.MuiListItem-root.Mui-selected {
-    background-color: #f6f7f8;
+    background-color: ${background};
     border-radius: 8px;
     color: ${({ theme }) => theme.colors.primary};
     span {

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -3,12 +3,13 @@ import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Link, useHistory } from 'react-router-dom'
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
+import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp'
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown'
 
 import ListMui from '@material-ui/core/List'
 import ListItem, { ListItemProps } from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Collapse from '@material-ui/core/Collapse'
-import { FixedIcon } from '@gnosis.pm/safe-react-components'
 import { secondary, primaryGreen200 } from 'src/theme/variables'
 
 const ListItemWrapper = styled.div`
@@ -29,6 +30,11 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
     border-radius: 8px;
   }
 
+  &.MuiListItem-gutters {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
   &.MuiListItem-root {
     padding-top: 9px;
     padding-bottom: 9px;
@@ -40,6 +46,10 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
     color: ${({ theme }) => theme.colors.primary};
     span {
       color: ${({ theme }) => theme.colors.primary};
+
+      & svg {
+        fill: ${({ theme }) => theme.colors.primary};
+      }
     }
     .icon-color {
       fill: ${({ theme }) => theme.colors.primary};
@@ -78,12 +88,12 @@ const StyledListSubItem = styled(ListItem)<ListItemProps>`
   }
 
   &.MuiListItem-button:hover {
-    background-color: ${primaryGreen200};
+    background-color: #f6f7f8;
     border-radius: 8px;
   }
 
   &.MuiButtonBase-root.MuiListItem-root.Mui-selected {
-    background-color: ${primaryGreen200};
+    background-color: #f6f7f8;
     border-radius: 8px;
     color: ${({ theme }) => theme.colors.primary};
     span {
@@ -220,7 +230,11 @@ const List = ({ items }: Props): React.ReactElement => {
         </TextAndBadgeWrapper>
 
         {item.subItems &&
-          (groupCollapseStatus[item.href] ? <FixedIcon type="chevronUp" /> : <FixedIcon type="chevronDown" />)}
+          (groupCollapseStatus[item.href] ? (
+            <KeyboardArrowUp fontSize="small" />
+          ) : (
+            <KeyboardArrowDown fontSize="small" />
+          ))}
       </ListItemAux>
     )
   }

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -60,7 +60,7 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
     background-color: ${secondary} !important;
     top: auto;
     bottom: 8px;
-    left: 31px;
+    left: 28px;
     width: 6px;
     height: 6px;
     border: white solid 1px;

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -59,8 +59,8 @@ export const StyledListItem = styled(ListItem)<ListItemProps>`
   & .beamer_icon.active {
     background-color: ${secondary} !important;
     top: auto;
-    bottom: 8px;
-    left: 28px;
+    bottom: 10px;
+    left: 22px;
     width: 6px;
     height: 6px;
     border: white solid 1px;

--- a/src/theme/variables.js
+++ b/src/theme/variables.js
@@ -25,6 +25,7 @@ module.exports = {
   background: '#F6F7F8',
   black300: '#B2BBC0',
   black400: '#566976',
+  black500: '#162D45',
   black600: '#111B22',
   boldFont: 700,
   bolderFont: 500,

--- a/src/theme/variables.js
+++ b/src/theme/variables.js
@@ -14,7 +14,6 @@ const primaryActive = '#008C73'
 const secondary = '#008C73'
 const secondaryTextOrSvg = '#B2B5B2'
 const secondaryBackground = '#f0efee'
-const primaryGreen200 = '#EFFAF8'
 const sm = '8px'
 const warningColor = '#ffc05f'
 const alertWarningColor = '#FBE5C5'
@@ -60,7 +59,6 @@ module.exports = {
   primary200: primaryLite,
   primary300: '#92C9BE',
   primary400: primaryActive,
-  primaryGreen200,
   regularFont: 400,
   red400: '#C31717',
   screenLg: 1200,

--- a/src/theme/variables.js
+++ b/src/theme/variables.js
@@ -14,6 +14,7 @@ const primaryActive = '#008C73'
 const secondary = '#008C73'
 const secondaryTextOrSvg = '#B2B5B2'
 const secondaryBackground = '#f0efee'
+const primaryGreen200 = '#EFFAF8'
 const sm = '8px'
 const warningColor = '#ffc05f'
 const alertWarningColor = '#FBE5C5'
@@ -59,6 +60,7 @@ module.exports = {
   primary200: primaryLite,
   primary300: '#92C9BE',
   primary400: primaryActive,
+  primaryGreen200,
   regularFont: 400,
   red400: '#C31717',
   screenLg: 1200,

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -15,6 +15,7 @@ $secondary: #008C73;
 
 $grey500: #E2E3E3;
 $black400: #566976;
+$black500: #162D45;
 $black600: #111B22;
 
 $headerHeight: 52px;


### PR DESCRIPTION
## What it solves
Resolves #3504 

## How this PR fixes it
- Adjusts the design according to [Figma](https://www.figma.com/file/Y9HUUDQzrbOtMpC3Nye3lt/Safe-Dashboard?node-id=997%3A3128).
- Adds Queue, History links to the navigation

## How to test it
1. Open the Safe app
3. Observe that there are links to the Transaction Queue and History
4. Observe that the Sidebar looks according to the design

## Screenshots
![Screenshot 2022-04-11 at 11 07 16](https://user-images.githubusercontent.com/5880855/162703523-24a6854b-17e1-4a68-b95b-eb4826e41088.png)

