### PR TITLE
fix: Add Home button to sidebar navigation

### DIFF
--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -115,6 +115,11 @@ const useSidebarItems = (): ListItemType[] => {
 
     return [
       makeEntryItem({
+        label: 'Home',
+        iconType: 'home',
+        href: currentSafeRoutes.DASHBOARD,
+      }),
+      makeEntryItem({
         label: 'Assets',
         iconType: 'assets',
         href: currentSafeRoutes.ASSETS_BALANCES,


### PR DESCRIPTION
## What it solves
Part of #3693 

## How this PR fixes it
Adds a Home button to the sidebar navigation

## How to test it
1. Open the Safe App
2. Select a Safe
3. Observe the Home button in the navigation
4. Click the Home button
5. Observe being navigated to the Dashboard

## Screenshots
![Screenshot 2022-04-12 at 15 04 13](https://user-images.githubusercontent.com/5880855/162968733-2475d074-d9fa-4feb-92f6-8e9dedfe79f5.png)

