### PR TITLE
feat: Featured Apps Widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
     "@gnosis.pm/safe-deployments": "^1.8.0",
     "@gnosis.pm/safe-react-components": "^1.1.2",
-    "@gnosis.pm/safe-react-gateway-sdk": "^2.10.2",
+    "@gnosis.pm/safe-react-gateway-sdk": "^2.10.3",
     "@gnosis.pm/safe-web3-lib": "^1.0.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.0",

--- a/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
@@ -1,7 +1,7 @@
 import { useAppList } from 'src/routes/safe/components/Apps/hooks/appList/useAppList'
 import { Text } from '@gnosis.pm/safe-react-components'
 import { Link } from 'react-router-dom'
-import { generateSafeRoute, SAFE_ROUTES, SafeRouteParams } from 'src/routes/routes'
+import { getSafeAppUrl, SafeRouteParams } from 'src/routes/routes'
 import { useSelector } from 'react-redux'
 import { currentSafe } from 'src/logic/safe/store/selectors'
 import { getShortName } from 'src/config'
@@ -41,7 +41,7 @@ export const FeaturedApps = (): ReactElement => {
   return (
     <>
       {featuredApps.map((app) => {
-        const appRoute = generateSafeRoute(SAFE_ROUTES.APPS, routesSlug) + `?appUrl=${app.url}`
+        const appRoute = getSafeAppUrl(app.url, routesSlug)
         return (
           <StyledRow key={app.id} margin="lg">
             <Col xs={2}>

--- a/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
@@ -1,0 +1,65 @@
+import { useAppList } from 'src/routes/safe/components/Apps/hooks/appList/useAppList'
+import { Text } from '@gnosis.pm/safe-react-components'
+import { Link } from 'react-router-dom'
+import { generateSafeRoute, SAFE_ROUTES, SafeRouteParams } from 'src/routes/routes'
+import { useSelector } from 'react-redux'
+import { currentSafe } from 'src/logic/safe/store/selectors'
+import { getShortName } from 'src/config'
+import { ReactElement, useMemo } from 'react'
+import Row from 'src/components/layout/Row'
+import Col from 'src/components/layout/Col'
+import styled from 'styled-components'
+
+const StyledImage = styled.img`
+  max-width: 64px;
+  max-height: 64px;
+`
+
+const StyledLink = styled(Link)`
+  margin-top: 10px;
+  text-decoration: none;
+`
+
+const StyledRow = styled(Row)`
+  gap: 24px;
+  flex-wrap: inherit;
+`
+
+// TODO: Replace once tags are available
+const featuredAppIds = ['29', '11']
+
+export const FeaturedApps = (): ReactElement => {
+  const { allApps } = useAppList()
+  const { address } = useSelector(currentSafe) ?? {}
+  const featuredApps = useMemo(() => allApps.filter((app) => featuredAppIds.includes(app.id)), [allApps])
+
+  const routesSlug: SafeRouteParams = {
+    shortName: getShortName(),
+    safeAddress: address,
+  }
+
+  return (
+    <>
+      {featuredApps.map((app) => {
+        const appRoute = generateSafeRoute(SAFE_ROUTES.APPS, routesSlug) + `?appUrl=${app.url}`
+        return (
+          <StyledRow key={app.id} margin="lg">
+            <Col xs={2}>
+              <StyledImage src={app.iconUrl} alt={app.name} />
+            </Col>
+            <Col xs={10} layout="column">
+              <Text size="lg" strong>
+                {app.description}
+              </Text>
+              <StyledLink to={appRoute}>
+                <Text color="primary" size="lg" strong>
+                  Use {app.name}
+                </Text>
+              </StyledLink>
+            </Col>
+          </StyledRow>
+        )
+      })}
+    </>
+  )
+}

--- a/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
@@ -10,6 +10,8 @@ import Row from 'src/components/layout/Row'
 import Col from 'src/components/layout/Col'
 import styled from 'styled-components'
 
+const FEATURED_APPS_TAGS = 'dashboard-widgets'
+
 const StyledImage = styled.img`
   max-width: 64px;
   max-height: 64px;
@@ -28,7 +30,7 @@ const StyledRow = styled(Row)`
 export const FeaturedApps = (): ReactElement => {
   const { allApps } = useAppList()
   const { address } = useSelector(currentSafe) ?? {}
-  const featuredApps = useMemo(() => allApps.filter((app) => app.tags.includes('dashboard-widgets')), [allApps])
+  const featuredApps = useMemo(() => allApps.filter((app) => app.tags.includes(FEATURED_APPS_TAGS)), [allApps])
 
   const routesSlug: SafeRouteParams = {
     shortName: getShortName(),

--- a/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
@@ -9,6 +9,7 @@ import { ReactElement, useMemo } from 'react'
 import Row from 'src/components/layout/Row'
 import Col from 'src/components/layout/Col'
 import styled from 'styled-components'
+import { SafeApp } from 'src/routes/safe/components/Apps/types'
 
 const StyledImage = styled.img`
   max-width: 64px;
@@ -25,13 +26,16 @@ const StyledRow = styled(Row)`
   flex-wrap: inherit;
 `
 
-// TODO: Replace once tags are available
-const featuredAppIds = ['29', '11']
+// TODO: Replace with type from gateway-sdk once available
+type SafeAppWithTags = SafeApp & { tags: string[] }
 
 export const FeaturedApps = (): ReactElement => {
   const { allApps } = useAppList()
   const { address } = useSelector(currentSafe) ?? {}
-  const featuredApps = useMemo(() => allApps.filter((app) => featuredAppIds.includes(app.id)), [allApps])
+  const featuredApps = useMemo(
+    () => allApps.filter((app) => (app as SafeAppWithTags).tags?.includes('dashboard-widgets')),
+    [allApps],
+  )
 
   const routesSlug: SafeRouteParams = {
     shortName: getShortName(),

--- a/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
@@ -9,7 +9,6 @@ import { ReactElement, useMemo } from 'react'
 import Row from 'src/components/layout/Row'
 import Col from 'src/components/layout/Col'
 import styled from 'styled-components'
-import { SafeApp } from 'src/routes/safe/components/Apps/types'
 
 const StyledImage = styled.img`
   max-width: 64px;
@@ -26,16 +25,10 @@ const StyledRow = styled(Row)`
   flex-wrap: inherit;
 `
 
-// TODO: Replace with type from gateway-sdk once available
-type SafeAppWithTags = SafeApp & { tags: string[] }
-
 export const FeaturedApps = (): ReactElement => {
   const { allApps } = useAppList()
   const { address } = useSelector(currentSafe) ?? {}
-  const featuredApps = useMemo(
-    () => allApps.filter((app) => (app as SafeAppWithTags).tags?.includes('dashboard-widgets')),
-    [allApps],
-  )
+  const featuredApps = useMemo(() => allApps.filter((app) => app.tags.includes('dashboard-widgets')), [allApps])
 
   const routesSlug: SafeRouteParams = {
     shortName: getShortName(),

--- a/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
@@ -30,7 +30,7 @@ const StyledRow = styled(Row)`
 export const FeaturedApps = (): ReactElement => {
   const { allApps } = useAppList()
   const { address } = useSelector(currentSafe) ?? {}
-  const featuredApps = useMemo(() => allApps.filter((app) => app.tags.includes(FEATURED_APPS_TAGS)), [allApps])
+  const featuredApps = useMemo(() => allApps.filter((app) => app.tags?.includes(FEATURED_APPS_TAGS)), [allApps])
 
   const routesSlug: SafeRouteParams = {
     shortName: getShortName(),

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -8,6 +8,7 @@ import Overview from 'src/components/Dashboard/Overview/Overview'
 import { lg } from 'src/theme/variables'
 import SafeAppsGrid from 'src/components/Dashboard/SafeApps/Grid'
 import Row from 'src/components/layout/Row'
+import { FeaturedApps } from 'src/components/Dashboard/FeaturedApps/FeaturedApps'
 
 const Card = styled.div`
   background: #fff;
@@ -36,7 +37,8 @@ function Home(): ReactElement {
 
       <Row>
         <Card>
-          <h2>Owned Safes</h2>
+          <h2>Safe Apps</h2>
+          <FeaturedApps />
         </Card>
 
         <Card>

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -126,3 +126,7 @@ export const generatePrefixedAddressRoutes = (params: SafeRouteParams): typeof S
     {} as typeof STANDARD_SAFE_ROUTES,
   )
 }
+
+export const getSafeAppUrl = (appUrl: string, routesSlug: SafeRouteParams): string => {
+  return generateSafeRoute(SAFE_ROUTES.APPS, routesSlug) + `?appUrl=${appUrl}`
+}

--- a/src/routes/safe/components/Apps/components/AppsList.test.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.test.tsx
@@ -39,6 +39,7 @@ beforeEach(() => {
       accessControl: {
         type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.NoRestrictions,
       },
+      tags: [],
     }),
   )
 
@@ -55,6 +56,7 @@ beforeEach(() => {
         accessControl: {
           type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.NoRestrictions,
         },
+        tags: [],
       },
       {
         id: 3,
@@ -69,6 +71,7 @@ beforeEach(() => {
           type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.DomainAllowlist,
           value: ['https://gnosis-safe.io'],
         },
+        tags: [],
       },
       {
         id: 14,
@@ -81,6 +84,7 @@ beforeEach(() => {
         accessControl: {
           type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.NoRestrictions,
         },
+        tags: [],
       },
       {
         id: 24,
@@ -94,6 +98,7 @@ beforeEach(() => {
           type: safeAppsGatewaySDK.SafeAppAccessPolicyTypes.DomainAllowlist,
           value: ['https://gnosis-safe.io'],
         },
+        tags: [],
       },
     ]),
   )

--- a/src/routes/safe/components/Apps/utils.ts
+++ b/src/routes/safe/components/Apps/utils.ts
@@ -62,6 +62,7 @@ export const getEmptySafeApp = (url = ''): SafeApp => {
     accessControl: {
       type: SafeAppAccessPolicyTypes.NoRestrictions,
     },
+    tags: [],
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1887,10 +1887,10 @@
   dependencies:
     cross-fetch "^3.1.5"
 
-"@gnosis.pm/safe-react-gateway-sdk@^2.10.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.10.2.tgz#25d01ea5c947bc2701535c6cdf059b380276e0f5"
-  integrity sha512-9o0JiA3zS5s1fVQa61DB1gBdFgyqA9QxW3y8lTYzX/lWNbfpm2psonyLjBJkETp7RoMFSp30pM4wgPXXT9bjzQ==
+"@gnosis.pm/safe-react-gateway-sdk@^2.10.3":
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.10.3.tgz#4537442a78eb0508c483aabcac19296335a77ac3"
+  integrity sha512-ukaLACozdJQb2YGSAZgBUkF4CT9iKVjpnKFCKUnGGghXqp+Yyn9jpdcfFK0VYQJ6ZSwAm40tHtQaN3K9817Bcg==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
## What it solves
Part of #3693 

## How this PR fixes it
Adds a widget to display featured apps in the dashboard. Layout will be done in a separate PR.

## How to test it
1. Open the Safe app
2. Select a Safe
3. Observe a widget that displays Transaction Builder and WalletConnect apps in the dashboard
