### PR TITLE
fix: default gas estimation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.24.0",
+  "version": "3.23.2",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/logic/hooks/useEstimateSafeCreationGas.tsx
+++ b/src/logic/hooks/useEstimateSafeCreationGas.tsx
@@ -59,7 +59,7 @@ export const useEstimateSafeCreationGas = ({
 }: EstimateSafeCreationGasProps): SafeCreationEstimationResult => {
   const [gasEstimation, setGasEstimation] = useState<SafeCreationEstimationResult>({
     gasEstimation: 0,
-    gasCostFormatted: '< 0.001',
+    gasCostFormatted: '> 0.001',
     gasLimit: 0,
     gasPrice: '0',
     gasMaxPrioFee: 0,

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -72,7 +72,7 @@ export const getDefaultGasEstimation = ({
   return {
     txEstimationExecutionStatus,
     gasCost: '0',
-    gasCostFormatted: '< 0.001',
+    gasCostFormatted: '> 0.001',
     gasPrice,
     gasPriceFormatted,
     gasMaxPrioFee,


### PR DESCRIPTION
## What it solves
Resolves #3483

## How this PR fixes it
The default `gasCostFormatted` has now been set to `> 0.001`.

I've verified that all instances of estimation are indeed passed through [`formatAmount`](https://github.com/gnosis/safe-react/blob/dev/src/logic/tokens/utils/formatAmount.ts) and are therefore correct when estimation occurs.

## How to test it
Go through the Safe creation funnel and before the final step, throttle the internet. Go to the next step and observe the default estimation be '> 0.001' before estimation succeeds.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/164022180-3ab6cec8-357e-49fc-a286-cad7402fd986.png)