### PR TITLE
fix: set empty names as shortened address

### DIFF
--- a/src/logic/addressBook/hooks/useAddressBookSync.ts
+++ b/src/logic/addressBook/hooks/useAddressBookSync.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { Dispatch } from 'src/logic/safe/store/actions/types.d'
-import { addressBookSync } from 'src/logic/addressBook/store/actions'
+import { addressBookFixEmptyNames, addressBookSync } from 'src/logic/addressBook/store/actions'
 import { ADDRESS_BOOK_REDUCER_ID } from 'src/logic/addressBook/store/reducer'
 import { AddressBookState } from 'src/logic/addressBook/model/addressBook'
 
@@ -26,6 +26,11 @@ const useAddressBookSync = (): void => {
     return () => {
       window.removeEventListener('storage', onStorageUpdate)
     }
+  }, [dispatch])
+
+  // Temporary fix that should be removed after a sufficient amount of time
+  useEffect(() => {
+    dispatch(addressBookFixEmptyNames())
   }, [dispatch])
 }
 

--- a/src/logic/addressBook/store/__tests__/addressBookReducer.test.ts
+++ b/src/logic/addressBook/store/__tests__/addressBookReducer.test.ts
@@ -3,114 +3,149 @@ import { addressBookFixEmptyNames } from '../actions'
 import addressBookReducer, { batchLoadEntries } from '../reducer'
 
 describe('Test AddressBook BatchLoadEntries Reducer', () => {
-  it('returns an addressbook array', () => {
-    const addressBookEntries = [
-      {
-        address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-        name: 'Entry 1',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-      {
-        address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-        name: 'Entry 2',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-    ]
-    const currentState = []
-    const action = {
-      type: 'addressBook/import',
-      payload: addressBookEntries,
-    }
-    const newState = batchLoadEntries(currentState, action)
-    expect(newState).toStrictEqual(addressBookEntries)
-  })
+  describe('batchLoadEntries', () => {
+    it('returns an addressbook array', () => {
+      const addressBookEntries = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'Entry 1',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: 'Entry 2',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+      const currentState = []
+      const action = {
+        type: 'addressBook/import',
+        payload: addressBookEntries,
+      }
+      const newState = batchLoadEntries(currentState, action)
+      expect(newState).toStrictEqual(addressBookEntries)
+    })
 
-  it('merges entries from different chains', () => {
-    const addressBookEntries = [
-      {
-        address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-        name: 'Entry 1',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-      {
-        address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-        name: 'Entry 2',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-    ]
-    const initialState = [
-      {
-        address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-        name: 'Entry 1',
-        chainId: CHAIN_ID.VOLTA,
-      },
-      {
-        address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-        name: 'Entry 2',
-        chainId: CHAIN_ID.VOLTA,
-      },
-    ]
-    const action = {
-      type: 'addressBook/import',
-      payload: addressBookEntries,
-    }
-    const newState = batchLoadEntries(initialState, action)
-    expect(newState).toStrictEqual(initialState.concat(addressBookEntries))
-  })
+    it('merges entries from different chains', () => {
+      const addressBookEntries = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'Entry 1',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: 'Entry 2',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+      const initialState = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'Entry 1',
+          chainId: CHAIN_ID.VOLTA,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: 'Entry 2',
+          chainId: CHAIN_ID.VOLTA,
+        },
+      ]
+      const action = {
+        type: 'addressBook/import',
+        payload: addressBookEntries,
+      }
+      const newState = batchLoadEntries(initialState, action)
+      expect(newState).toStrictEqual(initialState.concat(addressBookEntries))
+    })
 
-  it('skips entries with wrong name format', () => {
-    const addressBookEntries = [
-      {
-        address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-        name: 'OWNER # 1',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-      {
-        address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-        name: 'OWNER # 2',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-    ]
-    const initialState = []
-    const action = {
-      type: 'addressBook/import',
-      payload: addressBookEntries,
-    }
-    const newState = batchLoadEntries(initialState, action)
-    expect(newState).toStrictEqual(initialState)
-  })
+    it('skips entries with wrong name format', () => {
+      const addressBookEntries = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'OWNER # 1',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: 'OWNER # 2',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+      const initialState = []
+      const action = {
+        type: 'addressBook/import',
+        payload: addressBookEntries,
+      }
+      const newState = batchLoadEntries(initialState, action)
+      expect(newState).toStrictEqual(initialState)
+    })
 
-  it('replaces name when entries share address and chain', () => {
-    const addressBookEntries = [
-      {
-        address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-        name: 'NewEntry 1',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-      {
-        address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-        name: 'New Entry 2',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-    ]
-    const initialState = [
-      {
-        address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-        name: 'Entry 1',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-      {
-        address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-        name: 'Entry 2',
-        chainId: CHAIN_ID.RINKEBY,
-      },
-    ]
-    const action = {
-      type: 'addressBook/import',
-      payload: addressBookEntries,
-    }
-    const newState = batchLoadEntries(initialState, action)
-    expect(newState).toStrictEqual(addressBookEntries)
+    it('replaces name when entries share address and chain', () => {
+      const addressBookEntries = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'NewEntry 1',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: 'New Entry 2',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+      const initialState = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'Entry 1',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: 'Entry 2',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+      const action = {
+        type: 'addressBook/import',
+        payload: addressBookEntries,
+      }
+      const newState = batchLoadEntries(initialState, action)
+      expect(newState).toStrictEqual(addressBookEntries)
+    })
+
+    it('fixes empty names upon import', () => {
+      const addressBookEntries = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: '0x44625279...6AAD7aBcb2',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: '0x918925e5...7e5FF9d96F',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+      const initialState = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: '',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: '',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+      const action = {
+        type: 'addressBook/import',
+        payload: addressBookEntries,
+      }
+      const newState = batchLoadEntries(initialState, action)
+      expect(newState).toStrictEqual(addressBookEntries)
+    })
   })
 
   describe('addressBookFixEmptyNames', () => {

--- a/src/logic/addressBook/store/__tests__/addressBookReducer.test.ts
+++ b/src/logic/addressBook/store/__tests__/addressBookReducer.test.ts
@@ -118,12 +118,12 @@ describe('Test AddressBook BatchLoadEntries Reducer', () => {
       const addressBookEntries = [
         {
           address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-          name: '0x44625279...6AAD7aBcb2',
+          name: '0x4462...Bcb2',
           chainId: CHAIN_ID.RINKEBY,
         },
         {
           address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-          name: '0x918925e5...7e5FF9d96F',
+          name: '0x9189...d96F',
           chainId: CHAIN_ID.RINKEBY,
         },
       ]
@@ -166,12 +166,12 @@ describe('Test AddressBook BatchLoadEntries Reducer', () => {
       expect(addressBookReducer(prevState, addressBookFixEmptyNames())).toEqual([
         {
           address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
-          name: '0x44625279...6AAD7aBcb2',
+          name: '0x4462...Bcb2',
           chainId: CHAIN_ID.RINKEBY,
         },
         {
           address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-          name: '0x918925e5...7e5FF9d96F',
+          name: '0x9189...d96F',
           chainId: CHAIN_ID.RINKEBY,
         },
       ])
@@ -199,7 +199,7 @@ describe('Test AddressBook BatchLoadEntries Reducer', () => {
         },
         {
           address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
-          name: '0x918925e5...7e5FF9d96F',
+          name: '0x9189...d96F',
           chainId: CHAIN_ID.RINKEBY,
         },
       ])

--- a/src/logic/addressBook/store/__tests__/addressBookReducer.test.ts
+++ b/src/logic/addressBook/store/__tests__/addressBookReducer.test.ts
@@ -1,5 +1,6 @@
 import { CHAIN_ID } from 'src/config/chain.d'
-import { batchLoadEntries } from '../reducer'
+import { addressBookFixEmptyNames } from '../actions'
+import addressBookReducer, { batchLoadEntries } from '../reducer'
 
 describe('Test AddressBook BatchLoadEntries Reducer', () => {
   it('returns an addressbook array', () => {
@@ -110,5 +111,63 @@ describe('Test AddressBook BatchLoadEntries Reducer', () => {
     }
     const newState = batchLoadEntries(initialState, action)
     expect(newState).toStrictEqual(addressBookEntries)
+  })
+
+  describe('addressBookFixEmptyNames', () => {
+    it('fixes empty names', () => {
+      const prevState = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: '',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: '',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+
+      expect(addressBookReducer(prevState, addressBookFixEmptyNames())).toEqual([
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: '0x44625279...6AAD7aBcb2',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: '0x918925e5...7e5FF9d96F',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ])
+    })
+
+    it("doesn't 'fix' named contacts", () => {
+      const prevState = [
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'test',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: '',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ]
+
+      expect(addressBookReducer(prevState, addressBookFixEmptyNames())).toEqual([
+        {
+          address: '0x4462527986c3fD47f498eF25B4D01e6AAD7aBcb2',
+          name: 'test',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+        {
+          address: '0x918925e548C7208713a965A8cdA0287e5FF9d96F',
+          name: '0x918925e5...7e5FF9d96F',
+          chainId: CHAIN_ID.RINKEBY,
+        },
+      ])
+    })
   })
 })

--- a/src/logic/addressBook/store/actions/index.ts
+++ b/src/logic/addressBook/store/actions/index.ts
@@ -10,6 +10,7 @@ export enum ADDRESS_BOOK_ACTIONS {
   IMPORT = 'addressBook/import',
   SAFE_LOAD = 'addressBook/safeLoad',
   SYNC = 'addressBook/sync',
+  FIX_EMPTY_NAMES = 'addressBook/fixEmptyNames',
 }
 
 export const addressBookAddOrUpdate = createAction<AddressBookEntry>(ADDRESS_BOOK_ACTIONS.ADD_OR_UPDATE)
@@ -17,3 +18,4 @@ export const addressBookRemove = createAction<AddressBookEntry>(ADDRESS_BOOK_ACT
 export const addressBookSafeLoad = createAction<AddressBookState>(ADDRESS_BOOK_ACTIONS.SAFE_LOAD)
 export const addressBookImport = createAction<AddressBookState>(ADDRESS_BOOK_ACTIONS.IMPORT)
 export const addressBookSync = createAction<AddressBookState>(ADDRESS_BOOK_ACTIONS.SYNC)
+export const addressBookFixEmptyNames = createAction(ADDRESS_BOOK_ACTIONS.FIX_EMPTY_NAMES)

--- a/src/logic/addressBook/store/reducer/index.ts
+++ b/src/logic/addressBook/store/reducer/index.ts
@@ -4,12 +4,15 @@ import uniqWith from 'lodash/uniqWith'
 import { AddressBookEntry, AddressBookState } from 'src/logic/addressBook/model/addressBook'
 import { ADDRESS_BOOK_ACTIONS } from 'src/logic/addressBook/store/actions'
 import { getEntryIndex, hasSameAddressAndChainId, isValidAddressBookName } from 'src/logic/addressBook/utils'
+import { textShortener } from 'src/utils/strings'
 
 export const ADDRESS_BOOK_REDUCER_ID = 'addressBook'
 
 export const initialAddressBookState: AddressBookState = []
 
 type Payloads = AddressBookEntry | AddressBookState
+
+const getFallbackName = (address: string) => textShortener()(address)
 
 export const batchLoadEntries = (state: AddressBookState, action: Action<AddressBookState>): AddressBookState => {
   const newState = [...state]
@@ -22,7 +25,7 @@ export const batchLoadEntries = (state: AddressBookState, action: Action<Address
       // TODO: Remove after a sufficient period of time
       // If an entry is an empty name is loaded, set the name as the address
       if (!addressBookEntry.name) {
-        addressBookEntry.name = addressBookEntry.address
+        addressBookEntry.name = getFallbackName(addressBookEntry.address)
       }
 
       const entryIndex = getEntryIndex(newState, addressBookEntry)
@@ -48,7 +51,7 @@ const addressBookReducer = handleActions<AddressBookState, Payloads>(
       const { address, name } = action.payload
 
       const newState = [...state]
-      const addressBookEntry = { ...action.payload, name: name.trim() || address }
+      const addressBookEntry = { ...action.payload, name: name.trim() || getFallbackName(address) }
       const entryIndex = getEntryIndex(newState, addressBookEntry)
 
       // update

--- a/src/logic/addressBook/store/reducer/index.ts
+++ b/src/logic/addressBook/store/reducer/index.ts
@@ -12,7 +12,7 @@ export const initialAddressBookState: AddressBookState = []
 
 type Payloads = AddressBookEntry | AddressBookState
 
-export const getAddressBookFallbackName = (address: string) => textShortener()(address)
+export const getAddressBookFallbackName = (address: string) => textShortener({ charsStart: 6, charsEnd: 4 })(address)
 
 export const batchLoadEntries = (state: AddressBookState, action: Action<AddressBookState>): AddressBookState => {
   const newState = [...state]

--- a/src/logic/addressBook/store/reducer/index.ts
+++ b/src/logic/addressBook/store/reducer/index.ts
@@ -12,7 +12,8 @@ export const initialAddressBookState: AddressBookState = []
 
 type Payloads = AddressBookEntry | AddressBookState
 
-export const getAddressBookFallbackName = (address: string) => textShortener({ charsStart: 6, charsEnd: 4 })(address)
+export const getAddressBookFallbackName = (address: string): string =>
+  textShortener({ charsStart: 6, charsEnd: 4 })(address)
 
 export const batchLoadEntries = (state: AddressBookState, action: Action<AddressBookState>): AddressBookState => {
   const newState = [...state]

--- a/src/logic/addressBook/store/reducer/index.ts
+++ b/src/logic/addressBook/store/reducer/index.ts
@@ -19,6 +19,12 @@ export const batchLoadEntries = (state: AddressBookState, action: Action<Address
     // exclude those entries with invalid name
     .filter(({ name }) => isValidAddressBookName(name))
     .forEach((addressBookEntry) => {
+      // TODO: Remove after a sufficient period of time
+      // If an entry is an empty name is loaded, set the name as the address
+      if (!addressBookEntry.name) {
+        addressBookEntry.name = addressBookEntry.address
+      }
+
       const entryIndex = getEntryIndex(newState, addressBookEntry)
 
       if (entryIndex >= 0) {
@@ -39,8 +45,10 @@ const addressBookReducer = handleActions<AddressBookState, Payloads>(
     [ADDRESS_BOOK_ACTIONS.ADD_OR_UPDATE]: (state, action: Action<AddressBookEntry>) => {
       if (!action.payload.address) return state
 
+      const { address, name } = action.payload
+
       const newState = [...state]
-      const addressBookEntry = { ...action.payload, name: action.payload.name.trim() }
+      const addressBookEntry = { ...action.payload, name: name.trim() || address }
       const entryIndex = getEntryIndex(newState, addressBookEntry)
 
       // update

--- a/src/routes/safe/components/AddressBook/index.tsx
+++ b/src/routes/safe/components/AddressBook/index.tsx
@@ -27,12 +27,7 @@ import Col from 'src/components/layout/Col'
 import Row from 'src/components/layout/Row'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { AddressBookEntry, makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
-import {
-  addressBookAddOrUpdate,
-  addressBookFixEmptyNames,
-  addressBookImport,
-  addressBookRemove,
-} from 'src/logic/addressBook/store/actions'
+import { addressBookAddOrUpdate, addressBookImport, addressBookRemove } from 'src/logic/addressBook/store/actions'
 import { currentNetworkAddressBook } from 'src/logic/addressBook/store/selectors'
 import { isUserAnOwnerOfAnySafe, sameAddress } from 'src/logic/wallets/ethAddresses'
 import { CreateEditEntryModal } from 'src/routes/safe/components/AddressBook/CreateEditEntryModal'
@@ -101,11 +96,6 @@ const AddressBookTable = (): ReactElement => {
   const history = useHistory()
   const queryParams = Object.fromEntries(new URLSearchParams(history.location.search))
   const entryAddressToEditOrCreateNew = queryParams?.entryAddress
-
-  // Temporary fix that should be removed after a sufficient amount of time
-  useEffect(() => {
-    dispatch(addressBookFixEmptyNames())
-  }, [])
 
   useEffect(() => {
     if (entryAddressToEditOrCreateNew) {

--- a/src/routes/safe/components/AddressBook/index.tsx
+++ b/src/routes/safe/components/AddressBook/index.tsx
@@ -27,7 +27,12 @@ import Col from 'src/components/layout/Col'
 import Row from 'src/components/layout/Row'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { AddressBookEntry, makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
-import { addressBookAddOrUpdate, addressBookImport, addressBookRemove } from 'src/logic/addressBook/store/actions'
+import {
+  addressBookAddOrUpdate,
+  addressBookFixEmptyNames,
+  addressBookImport,
+  addressBookRemove,
+} from 'src/logic/addressBook/store/actions'
 import { currentNetworkAddressBook } from 'src/logic/addressBook/store/selectors'
 import { isUserAnOwnerOfAnySafe, sameAddress } from 'src/logic/wallets/ethAddresses'
 import { CreateEditEntryModal } from 'src/routes/safe/components/AddressBook/CreateEditEntryModal'
@@ -96,6 +101,11 @@ const AddressBookTable = (): ReactElement => {
   const history = useHistory()
   const queryParams = Object.fromEntries(new URLSearchParams(history.location.search))
   const entryAddressToEditOrCreateNew = queryParams?.entryAddress
+
+  // Temporary fix that should be removed after a sufficient amount of time
+  useEffect(() => {
+    dispatch(addressBookFixEmptyNames())
+  }, [])
 
   useEffect(() => {
     if (entryAddressToEditOrCreateNew) {


### PR DESCRIPTION
## What it solves
Resolves #3526

## How this PR fixes it
If an empty name makes it's way to the address book reducer (be it by adding or importing), it is set to a shortened version of the given address.

A temporary dispatch sets any existing empty-named address book entries to be the same as the above.

## How to test it
Remove the name name of a contact in the locally stored address book. Refresh/navigate to the address book and observe the shortened address be in place of the name.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/164036838-2bdc689a-9932-4ef5-b753-1dd2b1502072.png)