### PR TITLE
Fix: wallet connection min width

### DIFF
--- a/src/components/AppLayout/Header/components/NetworkSelector.tsx
+++ b/src/components/AppLayout/Header/components/NetworkSelector.tsx
@@ -31,7 +31,6 @@ const styles = {
     height: '100%',
 
     [`@media (min-width: ${screenSm}px)`]: {
-      flexBasis: '180px',
       marginRight: '20px',
     },
   },

--- a/src/components/AppLayout/Header/components/Provider.tsx
+++ b/src/components/AppLayout/Header/components/Provider.tsx
@@ -15,7 +15,7 @@ const styles = () => ({
     height: '100%',
 
     [`@media (min-width: ${screenSm}px)`]: {
-      flexBasis: '284px',
+      flexBasis: '210px',
     },
   },
   provider: {


### PR DESCRIPTION
The min width of the wallet connection widget was needlessly big.

Before:
<img width="369" alt="Screenshot 2022-04-20 at 12 20 24" src="https://user-images.githubusercontent.com/381895/164208144-b013f9dd-17d8-4dff-aac8-19f432bbda02.png">
<img width="410" alt="Screenshot 2022-04-20 at 12 20 19" src="https://user-images.githubusercontent.com/381895/164208258-2505591b-e9b4-4d58-876a-93c17683a1ea.png">

After:
<img width="366" alt="Screenshot 2022-04-20 at 12 20 11" src="https://user-images.githubusercontent.com/381895/164208356-a3626deb-1c25-4298-b9e6-f1c1ece00f58.png">
<img width="410" alt="Screenshot 2022-04-20 at 12 20 04" src="https://user-images.githubusercontent.com/381895/164208491-8d143c5d-7d20-43dd-afa6-d7b085163158.png">


