### PR TITLE
fix: improve chain selector specificity

### DIFF
--- a/cypress/integration/smoke/load_safe.spec.js
+++ b/cypress/integration/smoke/load_safe.spec.js
@@ -22,7 +22,7 @@ describe('Load Safe', () => {
     // Network selection
     cy.findByTestId('select-network-step').find('button').click()
     cy.get('[aria-labelledby="select-network"]').should('exist')
-    cy.findByText('Ethereum').click()
+    cy.get('[aria-labelledby="select-network"]').findByText('Ethereum').click()
     cy.get('nav').findByText('Ethereum').should('exist')
     cy.findByTestId('select-network-step').findByText('Ethereum').should('exist')
     cy.findByTestId('select-network-step').find('button').click()


### PR DESCRIPTION
## What it solves
Fixes a failing E2E test

## How this PR fixes it
Improves the specificity of a selector that was finding multiple instances of a string

## How to test it
run `yarn cypress:open prod` run `load_safe.spec.js` test
